### PR TITLE
shearing sheet: particle pulled away to avoid aggregation

### DIFF
--- a/examples/shearing_sheet/problem.c
+++ b/examples/shearing_sheet/problem.c
@@ -58,18 +58,18 @@ void problem_init(int argc, char* argv[]){
 	softening 			= 0.1;			// m
 	dt 				= 1e-3*2.*M_PI/OMEGA;	// s
 #ifdef OPENGL
-	display_rotate_z		= 20;			// Rotate the box by 20 around the z axis, then 
-	display_rotate_x		= 60;			// rotate the box by 60 degrees around the x axis	
+	display_rotate_z		= 0.;			// Rotate the box by 20 around the z axis, then 
+	display_rotate_x		= 0.;			// rotate the box by 60 degrees around the x axis	
 #ifdef LIBPNG
 	system("mkdir png");
 #endif // LIBPNG
 #endif // OPENGL
 	root_nx = 2; root_ny = 2; root_nz = 1;
 	nghostx = 2; nghosty = 2; nghostz = 0; 			// Use two ghost rings
-	double surfacedensity 		= 400; 			// kg/m^2
-	double particle_density		= 400;			// kg/m^3
-	double particle_radius_min 	= 1;			// m
-	double particle_radius_max 	= 4;			// m
+	double surfacedensity 		= 840; 			// kg/m^2
+	double particle_density		= 900;			// kg/m^3
+	double particle_radius_min 	= 1.;			// m
+	double particle_radius_max 	= 1.;			// m
 	double particle_radius_slope 	= -3;	
 	boxsize 			= 100;			// m
 	if (argc>1){						// Try to read boxsize from command line
@@ -118,8 +118,9 @@ void problem_inloop(){
 }
 
 void problem_output(){
+
 #ifdef LIBPNG
-	if (output_check(1e-3*2.*M_PI/OMEGA)){
+	if (output_check(2.*1e-2*2.*M_PI/OMEGA)){
 		output_png("png/");
 	}
 #endif //LIBPNG

--- a/src/Makefile
+++ b/src/Makefile
@@ -60,6 +60,7 @@ else
 	OPT+= -Wno-unknown-pragmas
 endif
 
+OPT += -Wno-deprecated
 
 # Create precompiler definitions from links
 PREDEF+= -D$(shell basename `readlink gravity.c` '.c' | tr '[a-z]' '[A-Z]')

--- a/src/collision_resolve.c
+++ b/src/collision_resolve.c
@@ -42,9 +42,139 @@ double collisions_constant_coefficient_of_restitution_for_velocity(double v);
 double (*coefficient_of_restitution_for_velocity) (double) = collisions_constant_coefficient_of_restitution_for_velocity;
 double 	collisions_plog =0;	/**< Keep track of momentum exchange (used to calculate collisional viscosity in ring systems. */
 long	collisions_Nlog =0;	/**< Keep track of Number of collisions. */
-void (*collision_resolve) (struct collision) = collision_resolve_hardsphere;
 
-void collision_resolve_hardsphere(struct collision c){
+/* void (*collision_resolve) (struct collision) = collision_resolve_hardsphere_original; */
+void (*collision_resolve) (struct collision) = collision_resolve_hardsphere_pullaway;
+
+void collision_resolve_hardsphere_pullaway(struct collision c){
+
+#ifndef COLLISIONS_NONE
+  struct particle p1 = particles[c.p1];
+  struct particle p2;
+#ifdef MPI
+  int isloc = communication_mpi_rootbox_is_local(c.ri);
+  if (isloc==1){
+#endif // MPI
+    p2 = particles[c.p2];
+#ifdef MPI
+  }else{
+    int root_n_per_node = root_n/mpi_num;
+    int proc_id = c.ri/root_n_per_node;
+    p2 = particles_recv[proc_id][c.p2];
+  }
+#endif // MPI
+  //	if (p1.lastcollision==t || p2.lastcollision==t) return;
+  struct ghostbox gb = c.gb;
+  double x21  = p1.x + gb.shiftx  - p2.x; 
+  double y21  = p1.y + gb.shifty  - p2.y; 
+  double z21  = p1.z + gb.shiftz  - p2.z; 
+  double r = sqrt(x21*x21 + y21*y21 + z21*z21);
+  /* double r21 = sqrt(x21*x21 + y21*y21 + z21*z21); */
+  double rp   = p1.r+p2.r;
+  double oldvyouter;
+
+  if (x21>0){
+    oldvyouter = p1.vy;
+  }else{
+    oldvyouter = p2.vy;
+  }
+
+  if (rp*rp < x21*x21 + y21*y21 + z21*z21) return;
+
+  double vx21 = p1.vx + gb.shiftvx - p2.vx; 
+  double vy21 = p1.vy + gb.shiftvy - p2.vy; 
+  double vz21 = p1.vz + gb.shiftvz - p2.vz; 
+
+  if (vx21*x21 + vy21*y21 + vz21*z21 >0) return; // not approaching
+
+  // Bring the to balls in the xy plane.
+  // NOTE: this could probabely be an atan (which is faster than atan2) 
+  double theta = atan2(z21,y21);
+  double stheta = sin(theta);
+  double ctheta = cos(theta);
+  double vy21n = ctheta * vy21 + stheta * vz21;
+  double y21n = ctheta * y21 + stheta * z21;
+
+  // Bring the two balls onto the positive x axis.
+  double phi = atan2(y21n,x21);
+  double cphi = cos(phi);
+  double sphi = sin(phi);
+  double vx21nn = cphi * vx21  + sphi * vy21n;
+  double vy21nn = -sphi* vx21  + cphi * vy21n;
+
+  // Coefficient of restitution
+  double eps= coefficient_of_restitution_for_velocity(vx21nn);
+  double dvx2 = -(1.0+eps)*vx21nn;
+  double dvy2 = (r/rp-1.)*vy21nn;
+
+  double minr = (p1.r>p2.r)?p2.r:p1.r;
+  double maxr = (p1.r<p2.r)?p2.r:p1.r;
+  double mindv= minr*minimum_collision_velocity;
+  mindv *= 1.-(r - maxr)/minr;
+  if (mindv>maxr*minimum_collision_velocity)mindv = maxr*minimum_collision_velocity;
+  if (dvx2<mindv) dvx2 = mindv;
+
+  // added
+  double dxx2 = rp-r;
+  double dxx2n = cphi * dxx2;
+  double dxy2n = sphi * dxx2;
+  double dxy2nn = ctheta * dxy2n;
+  double dxz2nn = stheta * dxy2n;
+
+  // Now we are rotating backwards
+  /* double dvx2n = cphi * dvx2;	 */
+  /* double dvy2n = sphi * dvx2; */
+
+  // updated
+  double dvx2n = cphi * dvx2 - sphi * dvy2;
+  double dvy2n = sphi * dvx2 + cphi * dvy2;
+
+  double dvy2nn = ctheta * dvy2n;
+  double dvz2nn = stheta * dvy2n;
+
+  // Applying the changes to the particles.
+#ifdef MPI
+  if (isloc==1){
+#endif // MPI
+
+    const double p1pf = p1.m/(p1.m+p2.m);
+    const double p2pf = p2.m/(p1.m+p2.m);
+    particles[c.p2].vx -=	p1pf*dvx2n;
+    particles[c.p2].vy -=	p1pf*dvy2nn;
+    particles[c.p2].vz -=	p1pf*dvz2nn;
+    particles[c.p2].lastcollision = t;
+
+    // added
+    particles[c.p2].x -=	p1pf*dxx2n;
+    particles[c.p2].y -=	p1pf*dxy2nn;
+    particles[c.p2].z -=	p1pf*dxz2nn;
+#ifdef MPI
+  }
+#endif // MPI
+  particles[c.p1].vx +=	p2pf*dvx2n;
+  particles[c.p1].vy +=	p2pf*dvy2nn;
+  particles[c.p1].vz +=	p2pf*dvz2nn;
+
+  // added
+  particles[c.p1].x +=	p2pf*dxx2n; 
+  particles[c.p1].y +=	p2pf*dxy2nn; 
+  particles[c.p1].z +=	p2pf*dxz2nn; 
+
+  particles[c.p1].lastcollision = t;
+
+  // Return y-momentum change
+  if (x21>0){
+    collisions_plog += -fabs(x21)*(oldvyouter-particles[c.p1].vy) * p1.m;
+    collisions_Nlog ++;
+  }else{
+    collisions_plog += -fabs(x21)*(oldvyouter-particles[c.p2].vy) * p2.m;
+    collisions_Nlog ++;
+  }
+
+#endif // COLLISIONS_NONE
+}
+
+void collision_resolve_hardsphere_original(struct collision c){
 #ifndef COLLISIONS_NONE
 	struct particle p1 = particles[c.p1];
 	struct particle p2;

--- a/src/collision_resolve.h
+++ b/src/collision_resolve.h
@@ -59,7 +59,13 @@ extern double (*coefficient_of_restitution_for_velocity) (double); /**< Function
  * Resolve a single collision assuming a hardsphere collision model (no super-particle).
  * @param c Collision to resolve.
  */
-void collision_resolve_hardsphere(struct collision c);	
+void collision_resolve_hardsphere_original(struct collision c);	
+
+/**
+ * Resolve a single collision assuming a hardsphere collision model (no super-particle).
+ * @param c Collision to resolve.
+ */
+void collision_resolve_hardsphere_pullaway(struct collision c);	
 
 /**
  * Function pointer to collision resolve function. 


### PR DESCRIPTION
In the original implementation of collision resolving, particles may be submerged into themselves due to self-gravity. One solution is to pull the contacting particles away artificially.
See the movie for example, with surfacedensity= 840kg/m2 and particledensity=900kg/m3, 
original: https://www.youtube.com/watch?v=lWkNq1kLjtk
revised: https://www.youtube.com/watch?v=SfLj8-MWGTE
There should be several ways to do this, such as conserving total momentum or conserving angular momentum. 
