### PR TITLE
Mean longitude error(?)

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -230,7 +230,7 @@ struct orbit tools_p2orbit(struct particle p, struct particle star){
 		o.f=2.*M_PI-o.f;	
 		ea =2.*M_PI-ea;
 	}
-	o.l = ea -o.e*sin(ea)+o.omega;			// mean longitude
+	o.l = ea -o.e*sin(ea)+o.omega+o.Omega;		// mean longitude = M+omega+Omega
 	if (o.e<=1.e-10){ 				//circular orbit
 		o.omega=0.;
 		o.f=0.; 				// f has no meaning


### PR DESCRIPTION
Problem(?) with this algorithm:
- I found that sometimes the result of omega and/or mean longitude is "nan" and I'm not sure why [maybe in hyperbolic case or when the arbitrary case which one of the e0, e1, or e2 give a "nan" value]
- if the orbit is circular (in this case e<=1.e-10) it should be that Omega=0, omega=0 and true anomaly or mean anomaly = mean longitude, but in this algorithm it will give all 0.0 for Omega, omega, l, and f (?)
