### PR TITLE
changed prints and xranges to python 3.x version. Still works in python ...

### DIFF
--- a/python_examples/dragforce/problem.py
+++ b/python_examples/dragforce/problem.py
@@ -33,4 +33,4 @@ rebound.integrate(100.)
 
 # Output something at the end (the planet will be at ~0.1 AU)
 for i in range(N):
-    print particles[i].x, particles[i].y, particles[i].z
+    print(particles[i].x, particles[i].y, particles[i].z)

--- a/python_examples/megno/problem.py
+++ b/python_examples/megno/problem.py
@@ -32,7 +32,7 @@ def setup_planet(com, mass, period, M, omega, eccentricity):
     if eccentricity>0.8:
         E = math.pi
     F = E - eccentricity*math.sin(M) - M
-    for i in xrange(100):
+    for i in range(100):
         E = E - F/(1.0-eccentricity*math.cos(E))
         F = E - eccentricity*math.sin(E) - M
         if math.fabs(F)<1e-16:

--- a/python_examples/orbital_elements/problem.py
+++ b/python_examples/orbital_elements/problem.py
@@ -20,8 +20,8 @@ rebound.move_to_center_of_momentum()
 
 # Print the resulting cartesian coordinates.
 p = rebound.particles_get()
-for i in xrange(rebound.get_N()):
-    print p[i].m, p[i].x, p[i].y, p[i].z, p[i].vx, p[i].vy, p[i].vz
+for i in range(rebound.get_N()):
+    print(p[i].m, p[i].x, p[i].y, p[i].z, p[i].vx, p[i].vy, p[i].vz)
 
 # Integrate for 100 time units
 rebound.integrate(100.)

--- a/python_examples/outersolarsystem/problem.py
+++ b/python_examples/outersolarsystem/problem.py
@@ -32,5 +32,5 @@ while rebound.get_t()<1e6:
     if steps%100==0:
         for i in range(rebound.get_N()):
             #     time             particle id   x               y               z 
-            print rebound.get_t(), i,            particles[i].x, particles[i].y, particles[i].z
+            print(rebound.get_t(), i,            particles[i].x, particles[i].y, particles[i].z)
 

--- a/python_examples/rebound.py
+++ b/python_examples/rebound.py
@@ -2,9 +2,9 @@ from ctypes import *
 import math
 
 try:
-    xrange          # If there's a name error we're using python 3.x
+    range = xrange          # this means python 2.x
 except NameError:
-    xrange = range  # xrange = range in python 3.x
+    pass                    # this means python 3.x
 
 # Try to load libias15 from the obvioud places it could be in.
 try:
@@ -165,7 +165,7 @@ def particle_get(i):
 def particles_get_array():
     N = get_N() 
     particles = []
-    for i in xrange(0,N):
+    for i in range(0,N):
         particles.append(particle_get(i))
     return particles
 
@@ -214,7 +214,7 @@ def eccentricAnomaly(e,M):
     E = M if e<0.8 else math.pi
     
     F = E - e*math.sin(M) - M
-    for i in xrange(100):
+    for i in range(100):
         E = E - F/(1.0-e*math.cos(E))
         F = E - e*math.sin(E) - M
         if math.fabs(F)<1e-16:
@@ -232,7 +232,7 @@ def get_center_of_momentum():
     vy = 0.
     vz = 0.
     ps = particles_get()    # particle pointer
-    for i in xrange(get_N()):
+    for i in range(get_N()):
     	m  += ps[i].m
     	x  += ps[i].x*ps[i].m
     	y  += ps[i].y*ps[i].m

--- a/python_examples/simple/problem.py
+++ b/python_examples/simple/problem.py
@@ -34,4 +34,4 @@ rebound.integrate(200.)
 # particles exactly where they started out from (note that we moved to the
 # center of momentum frame)
 for i in range(rebound.get_N()):
-    print particles[i].x, particles[i].y, particles[i].z
+    print(particles[i].x, particles[i].y, particles[i].z)


### PR DESCRIPTION
...2.x

OK, changed things as Dave suggested.  For consistency, we should from now on always use range (instead of xrange) and if rebound.py detects python 2.x it will change all the ranges to xranges, and we should write all print statements in parentheses, e.g. print(x) not print x.  The former works in both 2.x and 3.x, the latter doesn't work in 3.x.