### PR TITLE
made rebound.py python 3 compatible and added get_N_megno()

### DIFF
--- a/python_examples/biastest/problem.py
+++ b/python_examples/biastest/problem.py
@@ -99,7 +99,7 @@ plt.yscale('log', nonposy='clip')
 
 
 for i in xrange(len(res)):
-    print res[i]
+    print(res[i])
     im1 = axarr.plot(masses,res[i], label=integrators[i])
 
 plt.legend(loc='upper left')

--- a/python_examples/rebound.py
+++ b/python_examples/rebound.py
@@ -5,9 +5,11 @@ TINY=1.e-308
 MIN_REL_ERROR = 1.e-12
 
 try:
-    range = xrange          # this means python 2.x
-except NameError:
-    pass                    # this means python 3.x
+    import builtins      # if this succeeds it's python 3.x
+    builtins.xrange = range
+    builtins.basestring = (str,bytes)
+except ImportError:
+    pass                 # python 2.x
 
 # Try to load librebound from the obvioud places it could be in.
 try:
@@ -368,6 +370,9 @@ def get_lyapunov():
 
 def get_N():
     return c_int.in_dll(librebound,"N").value 
+
+def get_N_megno():
+    return c_int.in_dll(librebound,"N_megno").value 
 
 def get_iter():
     return c_int.in_dll(librebound,"iter").value 


### PR DESCRIPTION
I realized the previous edits for python3 compatibility did not take care of cases where example programs had instances of functions that are deprecated in python 3.  I now test to see whether we're using python 3, and if so, use builtins to redefine calls that don't exist in python 3 (i.e., xrange and basestring) to the python3 equivalent.  

Also, before we were renaming range to xrange when using python 2, when it seems like there could be situations where someone using python 2 did mean to use range instead of xrange.  I also added a helper function get_N_megno().