### PR TITLE
edited whfast tutorial

### DIFF
--- a/WHFast_tutorial.ipynb
+++ b/WHFast_tutorial.ipynb
@@ -16,7 +16,7 @@
     "###Installing REBOUND\n",
     "You first need to make sure you have an up-to-date version of REBOUND installed. REBOUND is a software package that includes the WHFast integrator among other. Installing REBOUND is very easy.\n",
     "\n",
-    "Optionally, you can create a virtual environment to keep your python installation clean. This is recommended, but you need to have virtualenv installed.\n",
+    "Optionally, you can create a virtual environment to keep your python installation clean. This is recommended, but you need to have virtualenv installed (also, if you use the Anaconda python distribution, you'll need to instead create a conda environment--see the README file).\n",
     "\n",
     "Simply open a terminal window, go to the folder where you want REBOUND to be installed and enter:\n",
     "\n",
@@ -62,7 +62,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, let's add some particle. We'll work in units in which $G=1$ (see below on how to set $G$ to another value). The first particle we add is the central object. We place it at rest at the origin and use the convention of setting the mass of the central object $M_*$ to 1:"
+    "Next, let's add some particles. We'll work in units in which $G=1$ (see below on how to set $G$ to another value). The first particle we add is the central object. We place it at rest at the origin and use the convention of setting the mass of the central object $M_*$ to 1:"
    ]
   },
   {
@@ -111,7 +111,7 @@
    "source": [
     "The output tells us that the mass of the particle is 1 and all coordinates are zero. \n",
     "\n",
-    "The next partile we're adding is a planet. We'll use Cartesian coordinates to initialize it. Any coordinate that we do not specify in the `rebound.add()` command is assumed to be 0. We place our planet on a circular orbit at $a=1$ and give it a mass of $10^{-3}$ times that of the central star."
+    "The next particle we're adding is a planet. We'll use Cartesian coordinates to initialize it. Any coordinate that we do not specify in the `rebound.add()` command is assumed to be 0. We place our planet on a circular orbit at $a=1$ and give it a mass of $10^{-3}$ times that of the central star."
    ]
   },
   {
@@ -182,8 +182,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, let's tell REBOUND which integrator (WHFast, of course!) and timestep we want to use. In our system of units, an orbit at $a=1$ has the orbital period of $T_{\\rm orb} =2\\pi \\sqrt{\\frac{GM}{a}}= 1$. \n",
-    "So a reasonable timestep to start with would be $dt=10^{-3} T_{\\rm orb}$."
+    "Next, let's tell REBOUND which integrator (WHFast, of course!) and timestep we want to use. In our system of units, an orbit at $a=1$ has the orbital period of $T_{\\rm orb} =2\\pi \\sqrt{\\frac{GM}{a}}= 2\\pi$. \n",
+    "So a reasonable timestep to start with would be $dt=10^{-3}$."
    ]
   },
   {
@@ -257,7 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see the time has advanced to $t=2\\pi$ and the positions and velocities of *all* particles has changed. If you want to post-process the particle data, you can access it the following way:"
+    "As you can see the time has advanced to $t=2\\pi$ and the positions and velocities of *all* particles have changed. If you want to post-process the particle data, you can access it in the following way:"
    ]
   },
   {
@@ -297,7 +297,7 @@
     "## Visualization with matplotlib\n",
     "Instead of just printing boring numbers at the end of the simulation, let's visualize the orbit using matplotlib (you'll need to install numpy and matplotlib to run this example, see above).\n",
     "\n",
-    "We'll use the same particles as above. As the particles are already in memory, so we don't need to add them again. Let us plot the position of the inner planet at 100 steps during its orbit. First, we'll import numpy and create an array of times for which we want to have an output (here, from $T_{\\rm orb}$ to $2 T_{\\rm orb}$ (we have already advanced the simulation time to $t=2\\pi$)."
+    "We'll use the same particles as above. As the particles are already in memory, we don't need to add them again. Let us plot the position of the inner planet at 100 steps during its orbit. First, we'll import numpy and create an array of times for which we want to have an output (here, from $T_{\\rm orb}$ to $2 T_{\\rm orb}$ (we have already advanced the simulation time to $t=2\\pi$)."
    ]
   },
   {
@@ -320,7 +320,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we'll step through the simulation. Rebound will integrate up to `time`. Depending on the timestep, it might overshoot slightly. If you want to have the outputs at exactly time time you specify you can set the `exactTime=1` flag in the `integrate` function. However, note that changing the timestep in a symplectic integrator could have negative impacts on its properties."
+    "Next, we'll step through the simulation. Rebound will integrate up to `time`. Depending on the timestep, it might overshoot slightly. If you want to have the outputs at exactly the time you specify you can set the `exactTime=1` flag in the `integrate` function. However, note that changing the timestep in a symplectic integrator could have negative impacts on its properties."
    ]
   },
   {
@@ -376,7 +376,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hurray! It worked. The orbit looks like it should, it's an almost perfect circle. There are small perturbation thought, induced by the outer planet. Let's integrate a bit longer to see them. "
+    "Hurray! It worked. The orbit looks like it should, it's an almost perfect circle. There are small perturbations though, induced by the outer planet. Let's integrate a bit longer to see them. "
    ]
   },
   {
@@ -418,7 +418,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ups! This doesn't look like what we expected to see (small perturbations to an almost circluar orbit). What you see here is the barycenter movement. WHFast does work in any inertial frame, i.e. it is not restricted to the heliocentric frame as you might expect form some other integrator packages. As you can see we are also not in the barycentric frame (also called center of momentum or center of mass frame), which makes sense if you recall how we added the particles, the Sun was at the origin and at rest, then we added the planets. There are multiple ways we can get the plot we want to.\n",
+    "Oops! This doesn't look like what we expected to see (small perturbations to an almost circluar orbit). What you see here is the barycenter slowly drifting. Some integration packages require that the simulation be carried out in a particular frame, but WHFast provides extra flexibility by working in any inertial frame.  If you recall how we added the particles, the Sun was at the origin and at rest, and then we added the planets.  This means that the center of mass, or barycenter, will have a small velocity, which results in the observed drift.  There are multiple ways we can get the plot we want to.\n",
     "1. We can calculate only relative positions.\n",
     "2. We can add the particles in the barycentric frame.\n",
     "3. We can make REBOUND do the work and let it transform the particle coordinates to the bayrcentric frame.\n",
@@ -527,7 +527,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The semimajor axis seems to almost stay constant, whereas the eccentricity undergoes an oscillation. Thus, one might conclude the planets interact only secular, i.e. there are no large resonant terms."
+    "The semimajor axis seems to almost stay constant, whereas the eccentricity undergoes an oscillation. Thus, one might conclude the planets interact only secularly, i.e. there are no large resonant terms."
    ]
   }
  ],


### PR DESCRIPTION
Hi Hanno,

This is fantastic!  I made some of my typical minor neurotic changes, but had a couple questions:

1)  Would it make sense to make rebound.integrate() take an optional flag, e.g., movetocom=true, so that you move to center_of_momentum by default (but can manually override it?).  I have somewhat mixed feelings.  It seems like it would avoid potential confusion for someone just getting started, but then again we put in considerable effort into integrating that extra degree of freedom, only to later hide it!  

2)  What do you think of me adding a small section to the tutorial that takes an FFT of the time series and plots it?  I think it would highlight a really nice feature of the python wrapper, i.e., that within python you have access through scipy etc. to pretty high-level tools for analyzing the rebound output.  If you think that's a good idea I'll add it.