### PR TITLE
modified installation tutorial

### DIFF
--- a/python_tutorials/Installation.ipynb
+++ b/python_tutorials/Installation.ipynb
@@ -8,7 +8,9 @@
    "source": [
     "# Installing REBOUND\n",
     "\n",
-    "Installing REBOUND is very easy. Rebound does not depend on any libraries. However, you need to have python (version 2 or 3) and a C compiler installed. Most likely, you already have those on your system.\n",
+    "Installing REBOUND is very easy. Rebound does not depend on any libraries. However, you need to have python (version 2 or 3) and a C compiler installed. Most likely, you already have those on your system.  \n",
+    "\n",
+    "If you don't, and aren't sure how to go about getting them, it is probably easiest to install either the Enthought or Anaconda python distributions (which are free and come with typically used libraries and an easy-to-use installer).  For the C compiler on Mac, it's probably easiest to install Xcode from the App store.\n",
     "\n",
     "## Create a virtual environment\n",
     "\n",
@@ -22,23 +24,28 @@
     "\n",
     "    source venv/bin/activate\n",
     "\n",
-    "If you log out of your terminal or open a new one, you'll need to reactivate the virtual environment with the above command.\n",
+    "If you log out of your terminal or open a new one, you'll need to reactivate the virtual environment with the above command (if the environment is active you'll see its name in parentheses before the command prompt).\n",
     "\n",
-    "If you use the Anaconda distribution, the above likely will not work. To create a conda environment run the follog command:\n",
+    "If you use the Anaconda distribution, the above likely will not work. To create a conda environment run the following command:\n",
     "\n",
-    "    conda create -n venv pip && source activate venv\n",
-    "    pip install rebound\n",
+    "    conda create -n venv pip\n",
+    "    source activate venv\n",
     "\n",
     "\n",
     "## Standard python installation using pip\n",
     "\n",
-    "Now you can install REBOUND using pip. All you have to do is type the following into a terminal window:\n",
+    "Now you can install REBOUND using pip. All you have to do is type the following into a terminal window (if you created a virtual environment above you should first run the appropriate activate command depending on whether you used virtualenv or conda):\n",
     "\n",
     "    pip install rebound\n",
     "\n",
-    "The setup script will download the latest version of REBOUND from [PyPI](https://pypi.python.org/pypi) (the Python Package Index), compile the C code in the background and place all the files in their correct location. No other libraries are needed to start working with WHFast and REBOUND, but you might want to install numpy and matplotlib to be able to post-process your data and make plots. Installing those libraries is also very easy (but may need a few minutes):\n",
+    "The setup script will download the latest version of REBOUND from [PyPI](https://pypi.python.org/pypi) (the Python Package Index), compile the C code in the background and place all the files in their correct location. No other libraries are needed to start working with WHFast and REBOUND, but you might want to install numpy and matplotlib to be able to post-process your data and make plots. For analysis tools (and to run FourierSpectrum.ipynb) you might also want scipy.  Installing those libraries is also very easy (but may need a few minutes).  Depending on whether you use virtualenv or conda, use\n",
     "\n",
-    "    pip install numpy matplotlib\n",
+    "    pip install numpy matplotlib scipy\n",
+    "    \n",
+    "or\n",
+    "    \n",
+    "    conda install numpy matplotlib scipy\n",
+    "    \n",
     "\n",
     "That's all there is to do!\n",
     "\n",
@@ -63,27 +70,52 @@
     "\n",
     "You can modify the python module files in the directory `rebound/` and you'll see the changed the next time you run a python script (no need to reinstall the REBOUND package every time).\n",
     "\n",
-    "If you install REBOUND directly from github, you can also run it without python. Have a look at the README file in the main directory and at the examples in the `examples/` directory for examples in C. These are much more diverse than the python examples (e.g. allow you to use a tree code for gravity calculations, use other boundary conditions, etc)."
+    "If you install REBOUND directly from github, you can also run it without python. Have a look at the README file in the main directory and at the examples in the `examples/` directory for examples in C. These are much more diverse than the python examples (e.g. allow you to use a tree code for gravity calculations, use other boundary conditions, etc).\n",
+    "\n",
+    "## iPython Notebook\n",
+    "\n",
+    "The tutorials in python_tutorials were written using iPython notebook.  To install it use (make sure to activate the virtual environment first if you created one)\n",
+    "\n",
+    "    pip install \"ipython[notebook]\"\n",
+    "\n",
+    "or\n",
+    "\n",
+    "    conda install ipython-notebook\n",
+    "    \n",
+    "You can then open a blank notebook by typing\n",
+    "\n",
+    "    ipython notebook\n",
+    "    \n",
+    "and selecting python notebook from the dropdown menu on the top right that says 'New'.  Now you can interactively follow the commands in the tutorials or run your own!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I think I mentioned that I had problems before getting rebound to work from within jupyter before.  Now that I'm reinstalling everything, I tried to be careful about it, and realized I got things moved around and confused.  Anyway, I changed the tutorial to be more explicit on the anaconda side of things.  I also added a short paragraph at the top about getting python and C.  I figured the people that wouldn't have these installed would probably need the most help, so there are a couple pointers.  I also added a section at the bottom of how to get ipython notebook running to reproduce the tutorials.  Feel free to use only whatever pieces you think are worthwhile.