### PR TITLE
fixed horizons to take a date and cache UTC time, and wrote Horizons.…

### DIFF
--- a/python_tutorials/Horizons.ipynb
+++ b/python_tutorials/Horizons.ipynb
@@ -1,0 +1,240 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Horizons\n",
+    "\n",
+    "REBOUND can add particles to simulations by obtaining ephemerides from NASA's powerful HORIZONS database.  HORIZONS supports many different options, and we will certainly not try to cover everything here.  This is meant to serve as an introduction to the basics, beyond what's in [Churyumov-Gerasimenko.ipynb](Churyumov-Gerasimenko.ipynb).  If you catch any errors, or would either like to expand on this documentation or improve REBOUND's HORIZONS interface (`rebound/horizons.py`), please do fork the repository and send us a pull request.\n",
+    "\n",
+    "## Adding particles\n",
+    "When we add particles by passing a string, REBOUND queries the HORIZONS database and takes the first dataset HORIZONS offers.  For the Sun, moons, and small bodies, this will typically return the body itself.  For planets, it will return the barycenter of the system (for moonless planets like Venus it will say barycenter but there is no distinction).  In all cases, REBOUND will print out the name of the HORIZONS entry it's using.\n",
+    "\n",
+    "You can also add bodies using their integer NAIF IDs:  [NAIF IDs](http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/MATLAB/req/naif_ids.html).  Note that because of the number of small bodies (asteroids etc.) we have discovered, this convention only works for large objetcts.  For small bodies, instead use \"NAME=name\" (see the SMALL BODIES section in the [HORIZONS Documentation](http://ssd.jpl.nasa.gov/?horizons_doc)):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Searching NASA Horizons for 'Sun'... Found: Sun (10).\n",
+      "Searching NASA Horizons for 'Venus'... Found: Venus Barycenter (299).\n",
+      "Searching NASA Horizons for '399'... Found: Earth (399).\n",
+      "Searching NASA Horizons for 'Europa'... Found: Europa (502).\n",
+      "Searching NASA Horizons for 'NAME=Ida'... Found: 243 Ida.\n",
+      "Warning: Mass cannot be retrieved from NASA HORIZONS. Set to 0.\n",
+      "---------------------------------\n",
+      "Rebound version:     \t1.2.0\n",
+      "Build on:            \tb'Jul  9 2015 21:55:55'\n",
+      "Number of particles: \t5\n",
+      "Simulation time:     \t0.000000\n",
+      "---------------------------------\n",
+      "<rebound.Particle object, ID=-1 m=1.0 x=0.0 y=0.0 z=0.0 vx=0.0 vy=0.0 vz=0.0>\n",
+      "<rebound.Particle object, ID=-1 m=2.4478382877847715e-06 x=0.08129005731050014 y=-0.7226251087335751 z=-0.014595593309124655 vx=1.160535336195962 vy=0.1272994031220507 vz=-0.06522786651696702>\n",
+      "<rebound.Particle object, ID=-1 m=3.0034896149157645e-06 x=0.4230127608701656 y=-0.9241655729624345 z=3.160457029615395e-05 vx=0.8934381645961075 vy=0.4127626410813716 vz=-3.870454429083151e-05>\n",
+      "<rebound.Particle object, ID=-1 m=2.413292057557507e-08 x=-4.6534879479330895 y=2.686509173341105 z=0.09312411353266535 vx=-0.1984045466560473 vy=0.1050402723418354 vz=0.02743843339323101>\n",
+      "<rebound.Particle object, ID=-1 m=0.0 x=2.313631109750353 y=1.5237199599031466 z=0.05122787768102368 vx=-0.3490497595251338 vy=0.500505002874108 vz=0.003951861759178601>\n",
+      "---------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "import rebound\n",
+    "rebound.add(\"Sun\")\n",
+    "rebound.add(\"Venus\")\n",
+    "rebound.add(\"399\")\n",
+    "rebound.add(\"Europa\")\n",
+    "rebound.add(\"NAME=Ida\")\n",
+    "rebound.status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Currently, HORIZONS does not have any mass information for solar system bodies.  `rebound/horizons.py` has a hard-coded list provided by Jon Giorgini (10 May 2015) that includes the planets, their barycenters (total mass of planet plus moons), and the largest moons.  If REBOUND doesn't find the corresponding mass for an object from this list (like for the asteroid Ida above), it will print a warning message.  If you need the body's mass for your simulation, you can set it manually, e.g. (see [Units.ipynb](Units.ipynb) for an overview of using different units):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "rebound.particles[4] = 2.1e-14 # mass of Ida in Solar masses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time\n",
+    "\n",
+    "By default, REBOUND queries HORIZONS for objects' current positions.  Specifically, it caches the current time the first time you call `rebound.add`, and gets the corresponding ephemeris.  All subsequent calls to `rebound.add` will then use that initial cached time to make sure you get a synchronized set of ephemerides.\n",
+    "\n",
+    "You can also explicitly pass REBOUND the time at which you would like the particles ephemerides:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Searching NASA Horizons for 'Venus'... Found: Venus Barycenter (299).\n",
+      "Searching NASA Horizons for 'Venus'... Found: Venus Barycenter (299).\n",
+      "---------------------------------\n",
+      "Rebound version:     \t1.2.0\n",
+      "Build on:            \tb'Jul  9 2015 21:55:55'\n",
+      "Number of particles: \t2\n",
+      "Simulation time:     \t0.000000\n",
+      "---------------------------------\n",
+      "<rebound.Particle object, ID=-1 m=2.4478382877847715e-06 x=0.08129005731050014 y=-0.7226251087335751 z=-0.014595593309124655 vx=1.160535336195962 vy=0.1272994031220507 vz=-0.06522786651696702>\n",
+      "<rebound.Particle object, ID=-1 m=2.4478382877847715e-06 x=-0.6654844749991903 y=0.26871758853641614 z=0.04208694540059936 vx=-0.4456006539134351 vy=-1.0957969134253158 vz=0.010728112604452313>\n",
+      "---------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "rebound.reset()\n",
+    "date = \"2005-06-30 15:24\"\n",
+    "rebound.add(\"Venus\")\n",
+    "rebound.add(\"Venus\", date=date)\n",
+    "rebound.status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the two Venus positions are different.  The first call cached the current time, but since the second call specified a date, it overrode the default.  Any time you pass a date, it will overwrite the default cached time, so: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Searching NASA Horizons for 'Venus'... Found: Venus Barycenter (299).\n",
+      "Searching NASA Horizons for 'Earth'... Found: Earth-Moon Barycenter (3).\n",
+      "Searching NASA Horizons for 'Mercury'... Found: Mercury Barycenter (199).\n",
+      "---------------------------------\n",
+      "Rebound version:     \t1.2.0\n",
+      "Build on:            \tb'Jul  9 2015 21:55:55'\n",
+      "Number of particles: \t3\n",
+      "Simulation time:     \t0.000000\n",
+      "---------------------------------\n",
+      "<rebound.Particle object, ID=-1 m=2.4478382877847715e-06 x=-0.6654844749991903 y=0.26871758853641614 z=0.04208694540059936 vx=-0.4456006539134351 vy=-1.0957969134253158 vz=0.010728112604452313>\n",
+      "<rebound.Particle object, ID=-1 m=3.0404326480226416e-06 x=0.4229904937623144 y=-0.9241422147058279 z=2.943598767201012e-05 vx=0.8931352015101482 vy=0.4124958732824667 vz=-1.658696026529267e-05>\n",
+      "<rebound.Particle object, ID=-1 m=1.6601141530543485e-07 x=0.03706660845756681 y=0.30476808403726025 z=0.021501811851843564 vx=-1.951592561898317 vy=0.25761953640682184 vz=0.2000985125634695>\n",
+      "---------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "rebound.reset()\n",
+    "date = \"2005-06-30 15:24\"\n",
+    "rebound.add(\"Venus\", date=date)\n",
+    "rebound.add(\"Earth\")\n",
+    "rebound.add(\"Mercury\")\n",
+    "rebound.status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "would set up a simulation with Mercury, Venus and Earth, all synchronized to 2005-06-30 15:24.  All dates should be passed in the format Year-Month-Day Hour:Minute.  \n",
+    "\n",
+    "REBOUND takes these absolute times to the nearest minute, since at the level of seconds you have to worry about exactly what time system you're using, and small additional perturbations probably start to matter.  For reference HORIZONS interprets all times for ephemerides as [Coordinate (or Barycentric Dynamical) Time](https://en.wikipedia.org/wiki/Barycentric_Dynamical_Time)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reference Frame\n",
+    "\n",
+    "REBOUND queries for particles' positions and velocities relative to the Sun:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Searching NASA Horizons for 'Sun'... Found: Sun (10).\n",
+      "---------------------------------\n",
+      "Rebound version:     \t1.2.0\n",
+      "Build on:            \tb'Jul  9 2015 21:55:55'\n",
+      "Number of particles: \t1\n",
+      "Simulation time:     \t0.000000\n",
+      "---------------------------------\n",
+      "<rebound.Particle object, ID=-1 m=1.0 x=0.0 y=0.0 z=0.0 vx=0.0 vy=0.0 vz=0.0>\n",
+      "---------------------------------\n"
+     ]
+    }
+   ],
+   "source": [
+    "rebound.reset()\n",
+    "rebound.add(\"Sun\")\n",
+    "rebound.status()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The reference plane is the ecliptic (Earth's orbital plane) of J2000 (Jan. 1st 2000 12:00 GMT), with the x axis along the ascending node of the ecliptic and the Earth's mean equator (also at J2000).  "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
…ipynb

These are the updates for horizons.py that allow you to pass a particular date, and caches the current time in utc.  I also wrote Horizons.ipynb, which goes through all of this and what coordinate systems we're querying horizons in (a somewhat painful process to figure out!).

I know you're in the midst of the no globals transition, but this only affects horizons.py, and adds a new tutorial, so hopefully it's not a problem.