### PR TITLE
no longer set p.ap to null when adding particle to simulation

### DIFF
--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -32,10 +32,12 @@ class Particle(Structure):
         Particle radius
     lastcollision : float       
         Last time the particle had a physical collision (if checking for collisions)
-    c           : float       
+    c           : c_void_p (C void pointer) 
         Pointer to the cell the particle is currently in (if using tree code)
     id          : int         
         Particle ID (arbitrary, specified by the user)
+    ap          : c_void_p (C void pointer)
+        Pointer to additional parameters one might want to add to particles
     _sim        : POINTER(rebound.Simulation)
         Internal pointer to the parent simulation (used in C version of REBOUND)
     """
@@ -117,10 +119,16 @@ class Particle(Structure):
             raise ValueError("Cannot initialize particle from other particles.")
         cart = [x,y,z,vx,vy,vz]
         orbi = [primary,a,e,inc,Omega,omega,pomega,f,M,l,theta]
-        
+       
+        self.ax = 0.
+        self.ay = 0.
+        self.az = 0.
         self.m = 0. if m is None else m
-        self.id = -1 if id is None else id
         self.r  =  0. if r is None else r
+        self.lastcollision = 0.
+        self.c = None
+        self.id = -1 if id is None else id
+        self.ap = None
         
         if notNone(cart) and notNone(orbi):
                 raise ValueError("You cannot pass cartesian coordinates and orbital elements (and/or primary) at the same time.")

--- a/src/particle.c
+++ b/src/particle.c
@@ -54,7 +54,6 @@ static void reb_add_local(struct reb_simulation* const r, struct reb_particle pt
 	}
 
 	r->particles[r->N] = pt;
-	r->particles[r->N].ap = NULL;
 	r->particles[r->N].sim = r;
 	if (r->gravity==REB_GRAVITY_TREE || r->collision==REB_COLLISION_TREE){
 		reb_tree_add_particle_to_tree(r, r->N);


### PR DESCRIPTION
REBOUNDx at some points need to check whether p.ap is set, so I had added a line in reb_add_local to set p.ap = NULL when adding a particle so I could check for NULL.

The problem is that one can't then copy particles and add them to the simulation (with REBOUNDx), since any p.ap will get reset to NULL.

p.ap = NULL would be perfect for a constructor (which wouldn't get call during a copy), but in C I decided that the burden should be on the user to properly initialize structures, just like with the other fields.  If they use the standard reb_particle p = {0} syntax, everything's fine.  

In Python I did put p.ap = None (NULL) in the constructor, and thought it made sense to also zero / None out all the other fields.  This makes sure everything's intialized, and works fine if you do p = sim.particles[1], sim.add(p), since p doesn't pass through the constructor.  

I left p.sim = r in particle.c, because I thought it made sense to strictly enforce that the particle you add with a simulation be added to that simulation, and we don't (I don't think) want to require that the user have to set p.sim = r when initializing a reb_particle structure in C to then add to the simulation.  If you think they should, feel free to add that initialization statement to particle.py __init__ too.