### PR TITLE
changed id default to 0 and updated ipynbs to match

### DIFF
--- a/ipython_examples/EscapingParticles.ipynb
+++ b/ipython_examples/EscapingParticles.ipynb
@@ -266,21 +266,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/ipython_examples/ParticleIDsAndRemoval.ipynb
+++ b/ipython_examples/ParticleIDsAndRemoval.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "For some applications, it is useful to keep track of which particle is which, and this can get jumbled up when particles are added or removed from the simulation.  It can thefore be useful for particles to have unique IDs associated with them.\n",
     "\n",
-    "Let's set up a simple simulation with 10 bodies, and give them IDs in the order we add the particles:"
+    "Let's set up a simple simulation with 10 bodies, and give them IDs in the order we add the particles (if you don't set them explicitly, all particle IDs default to 0):"
    ]
   },
   {
@@ -222,21 +222,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -92,7 +92,7 @@ class Particle(Structure):
             True longitude              (Default: 0)
         r           : float       
             Particle radius (only used for collisional simulations)
-        id          : int         
+        id          : int               (Default: 0)
             Particle ID (arbitrary, specified by the user)
         date        : string      
             For consistency with adding particles through horizons.  Not used here.
@@ -119,7 +119,7 @@ class Particle(Structure):
         orbi = [primary,a,e,inc,Omega,omega,pomega,f,M,l,theta]
         
         self.m = 0. if m is None else m
-        self.id = -1 if id is None else id
+        self.id = 0 if id is None else id
         self.r  =  0. if r is None else r
         
         if notNone(cart) and notNone(orbi):


### PR DESCRIPTION
I thought it made sense to change the default particle ID to 0 (was -1), since in C when you do reb_particle p = {0}, everything defaults to 0, including the ID, so it would be nice to be consistent with both.  I updated particle.py, the documentation and relevant ipynbs (didn't overlap with the ones I modified for exact_finish_time so hopefully shouldn't be a problem for merge).