### PR TITLE
set sim pointer to particles when loading sim from binary

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -114,6 +114,9 @@ struct reb_simulation* reb_create_simulation_from_binary(char* filename){
 		printf("Can not open file '%s'\n.",filename);
 		return NULL;
 	}
+    for(int i=0; i<r->N; i++){
+		r->particles[i].sim = r;
+	}
 	return r;
 }
 


### PR DESCRIPTION
When you loaded a simulation from a binary, the particle pointers to the simulation were not set, so since all the calculate_orbit routines rely on these, none of these worked, which also messed up OrbitPlot etc.