### PR TITLE
added _extras_ref to simulation

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -186,7 +186,6 @@ class Simulation(Structure):
     """
     def __init__(self):
         clibrebound.reb_init_simulation(byref(self))
-        self.ref = byref(self)
 
     @classmethod
     def from_file(cls, filename):
@@ -215,9 +214,10 @@ class Simulation(Structure):
     _corfp = None # coefficient of restitution function pointer
     _ptmp = None # post timestep modifications pointer 
     _units = {'length':None, 'time':None, 'mass':None}
+    _extras_ref = None # for additional REBOUND libraries to set and keep a reference alive for the lifetime of the simulation
 
     def __del__(self):
-        if self._b_needsfree_ == 1:
+        if self._b_needsfree_ == 1: # to avoid, e.g., sim.particles[1]._sim.contents.G creating a Simulation instance to get G, and then freeing the C simulation when it immediately goes out of scope
             clibrebound.reb_free_pointers(byref(self))
 
 # Status functions


### PR DESCRIPTION
I ran tests and confirmed that we did in fact have a memory leak with the self.ref line in __init__, and now with the extras_ref, writing a create_sim function that only returns sim keeps reboundx alive