### PR TITLE
fixed badge links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,24 @@ REBOUND - An open-source multi-purpose N-body code
 ==================================================
 
 .. image:: http://img.shields.io/badge/rebound-v2.11.0-green.svg?style=flat
-.. image:: http://img.shields.io/badge/license-GPL-green.svg?style=flat :target: https://github.com/hannorein/rebound/blob/master/LICENSE
-.. image:: http://img.shields.io/travis/hannorein/rebound/master.svg?style=flat :target: https://travis-ci.org/hannorein/rebound/
-.. image:: https://coveralls.io/repos/hannorein/rebound/badge.svg?branch=master&service=github :target: https://coveralls.io/github/hannorein/rebound?branch=master
-.. image:: http://img.shields.io/badge/arXiv-1110.4876-green.svg?style=flat :target: http://arxiv.org/abs/1110.4876
-.. image:: http://img.shields.io/badge/arXiv-1409.4779-green.svg?style=flat :target: http://arxiv.org/abs/1409.4779
-.. image:: http://img.shields.io/badge/arXiv-1506.01084-green.svg?style=flat :target: http://arxiv.org/abs/1506.01084
+    :target: http://rebound.readthedocs.org
+.. image:: https://badge.fury.io/py/rebound.svg
+    :target: https://badge.fury.io/py/rebound
+.. image:: http://img.shields.io/badge/license-GPL-green.svg?style=flat 
+    :target: https://github.com/hannorein/rebound/blob/master/LICENSE
+.. image:: http://img.shields.io/travis/hannorein/rebound/master.svg?style=flat 
+    :target: https://travis-ci.org/hannorein/rebound/
+.. image:: https://coveralls.io/repos/hannorein/rebound/badge.svg?branch=master&service=github 
+    :target: https://coveralls.io/github/hannorein/rebound?branch=master
+.. image:: http://img.shields.io/badge/arXiv-1110.4876-green.svg?style=flat 
+    :target: http://arxiv.org/abs/1110.4876
+.. image:: http://img.shields.io/badge/arXiv-1409.4779-green.svg?style=flat 
+    :target: http://arxiv.org/abs/1409.4779
+.. image:: http://img.shields.io/badge/arXiv-1506.01084-green.svg?style=flat 
+    :target: http://arxiv.org/abs/1506.01084
+.. image:: https://readthedocs.org/projects/pip/badge/?version=latest
+    :target: http://rebound.readthedocs.org/
+
 
 FEATURES
 --------


### PR DESCRIPTION
I just added some badges for REBOUNDx, and noticed that the links in the REBOUND badges weren't working because of an indentation problem.  I've fixed those, and added two more you're free to delete.  One auto-updates to give the current version on PyPI that I thought might be helpful to make sure we keep things in sync, and the other is a docs badge to rebound.readthedocs.org