### PR TITLE
added dummy function for raising external exceptions

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -806,7 +806,17 @@ class Simulation(Structure):
     @integrator_whfast_recalculate_jacobi_this_timestep.setter
     def integrator_whfast_recalculate_jacobi_this_timestep(self, value):
         self.ri_whfast.recalculate_jacobi_this_timestep = c_uint(value)
-    
+
+    def raise_external_exceptions(self, ret_value):
+        """
+        Dummy function that can be monkey patched by external libraries to check a simulation's
+        status field to raise custom exceptions, e.g.
+
+        if ret_value == 999:
+            raise CustomError("This or that kind of error occurred.")
+        """
+        pass
+
 # Integration
     def step(self):
         """
@@ -854,6 +864,7 @@ class Simulation(Structure):
                 raise Encounter("Two particles had a close encounter (d<exit_min_distance).")
             if ret_value == 4:
                 raise Escape("A particle escaped (r>exit_max_distance).")
+            self.raise_external_exceptions(ret_value)
         else:
             debug.integrate_other_package(tmax,exact_finish_time)
 


### PR DESCRIPTION
I wanted to have a way for reboundx to raise exceptions when something goes wrong, so that you're not left wondering what happened with a Kernel died message in ipython.  After reb_integrate checks error codes, I have it call a dummy function that an external library can monkey patch.  Let me know if you think there's a better way to do this.  The corresponding reboundx branch that uses this is called 'effects' if you want to take a look