### PR TITLE
added __version__ and __build__ to rebound module

### DIFF
--- a/rebound/__init__.py
+++ b/rebound/__init__.py
@@ -20,19 +20,21 @@ pymodulepath = os.path.dirname(__file__)
 from ctypes import cdll, c_char_p
 clibrebound = cdll.LoadLibrary(pymodulepath+"/../librebound"+suffix)
 
+# Version
+__version__ = c_char_p.in_dll(clibrebound, "reb_version_str").value.decode('ascii')
+
+# Build
+__build__ = c_char_p.in_dll(clibrebound, "reb_build_str").value.decode('ascii')
 # Check for version
+
 try:
     moduleversion = pkg_resources.require("rebound")[0].version
-    libreboundversion = c_char_p.in_dll(clibrebound, "reb_version_str").value.decode("ascii") 
+    libreboundversion = __version__
     if moduleversion != libreboundversion:
         print("WARNING: python module and librebound have different version numbers: '%s' vs '%s'.\n" %(moduleversion, libreboundversion))
 except:
     # Might fails on python3 versions, but not important
     pass
-
-# Built str
-def build_str():
-    return c_char_p.in_dll(clibrebound, "reb_build_str").value.decode('ascii')
 
 
 # Exceptions    
@@ -63,4 +65,4 @@ from .particle import Particle
 from .plotting import OrbitPlot
 from .interruptible_pool import InterruptiblePool
 
-__all__ = ["Simulation", "Orbit", "OrbitPlot", "Particle", "SimulationError", "Encounter", "Escape", "NoParticles", "InterruptiblePool"]
+__all__ = ["__version__", "__build__", "Simulation", "Orbit", "OrbitPlot", "Particle", "SimulationError", "Encounter", "Escape", "NoParticles", "InterruptiblePool"]

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -220,10 +220,11 @@ class Simulation(Structure):
         Prints a summary of the current status 
         of the simulation.
         """
+        from rebound import __version__, __build__
         s= ""
         s += "---------------------------------\n"
-        s += "REBOUND version:     \t%s\n" %c_char_p.in_dll(clibrebound, "reb_version_str").value.decode('ascii')
-        s += "REBOUND built on:    \t%s\n" %c_char_p.in_dll(clibrebound, "reb_build_str").value.decode('ascii')
+        s += "REBOUND version:     \t%s\n" %__version__
+        s += "REBOUND built on:    \t%s\n" %__build__
         s += "Number of particles: \t%d\n" %self.N       
         s += "Selected integrator: \t" + self.integrator + "\n"       
         s += "Simulation time:     \t%f\n" %self.t


### PR DESCRIPTION
I realized that for REBOUNDx I need the rebound version in setup.py, so I added a __version__ and __build__ to the rebound module, which is maybe nice so you can import rebound; rebound.__version__, rather than create a simulation and sim.status() to see the version.

I also modified the places that get these things from the shared library directly to use the module's attribute.

One potentially confusing thing is that __version__ stores the librebound.so version, and we separately put in a rebound version in setup.py.  Of course the two are tied through update_version.py so I don't think this is an issue, but I thought the librebound.so version was the important one.