### PR TITLE
Add exit cond

### DIFF
--- a/add_exit_cond.py
+++ b/add_exit_cond.py
@@ -23,7 +23,7 @@ with open("src/rebound.h", "w") as f:
         if "struct reb_simulation {" in rebh[i]:
             f.write("    {0} {1};\n".format(param_type_c, param_name))
         if "enum REB_STATUS {" in rebh[i]:
-            f.write("REB_{0} = {1},\n".format(param_name.upper(), param_enum_code))
+            f.write("    REB_{0} = {1},\n".format(param_name.upper(), param_enum_code))
 
 with open("src/rebound.c") as f:
     rebc = f.readlines()
@@ -37,18 +37,21 @@ with open("src/rebound.c", "w") as f:
             f.write("        if (fill_in_here){\n")
             f.write("            r->status = REB_{0};\n".format(param_name.upper()))
             f.write("        }\n")
-            f.write("    }")
+            f.write("    }\n")
+        if "void reb_init_simulation(" in rebc[i]:
+            f.write("    r->{0} = 0;\n".format(param_name))
 
 with open("rebound/simulation.py") as f:
     sim = f.readlines()
 
 with open("rebound/simulation.py", "w") as f:
     for i in range(len(sim)):
-        f.write(sim[i])
+        if "from . import clibrebound" in sim[i]:
+            f.write(sim[i].rstrip()+", {0}\n".format(exception))
+        else:
+            f.write(sim[i])
         if "Simulation._fields_ = " in sim[i]:
             f.write('\t\t\t\t("{0}", {1}),\n'.format(param_name, param_ctype))
-        if "from . import clibrebound" in sim[i]:
-            f.write(sim[i]+", {0}\n".format(exception))
         if "ret_value = clibrebound.reb_integrate" in sim[i]:
             f.write("\t\t\tif ret_value == {0}:\n".format(param_enum_code))
             f.write('\t\t\t\traise {0}("{1}")\n'.format(exception, description))
@@ -58,9 +61,11 @@ with open("rebound/__init__.py") as f:
 
 with open("rebound/__init__.py", "w") as f:
     for i in range(len(init)):
-        f.write(init[i])
+        if "__all__ = " in init[i]:
+            init[i] = init[i].rstrip()
+            f.write(init[i][:-1] + ', "{0}"]\n'.format(exception))
+        else:
+            f.write(init[i])
         if "# Exceptions" in init[i]:
             f.write("class {0}(Exception):\n".format(exception))
             f.write("\tpass\n")
-        if "__all__ = " in init[i]:
-            f.write(init[i][:-1] + ', "{0}"]\n'.format(exception))

--- a/add_exit_cond.py
+++ b/add_exit_cond.py
@@ -1,0 +1,66 @@
+#!/usr/local/bin/python
+
+import sys
+
+if len(sys.argv) is not 6:
+    print('Error\n*****\nMust pass (in order) name of parameter, name of type in c (e.g. "struct reb_particle*"), the ctype type (e.g., "POINTER(Particle)"), the number code for the enum (shouldnt conflict with codes at the top of src/rebound.h in REB_STATUS, e.g., 736), and a description to be shown in python when error occurs (e.g. "a particle got too close to particle blah")')
+    sys.exit()
+
+param_name = str(sys.argv[1])
+param_type_c = str(sys.argv[2])
+param_ctype = str(sys.argv[3])
+param_enum_code = str(sys.argv[4])
+description = str(sys.argv[5])
+
+exception = param_name.capitalize()
+
+with open("src/rebound.h") as f:
+    rebh = f.readlines()
+
+with open("src/rebound.h", "w") as f:
+    for i in range(len(rebh)):
+        f.write(rebh[i])
+        if "struct reb_simulation {" in rebh[i]:
+            f.write("    {0} {1};\n".format(param_type_c, param_name))
+        if "enum REB_STATUS {" in rebh[i]:
+            f.write("REB_{0} = {1},\n".format(param_name.upper(), param_enum_code))
+
+with open("src/rebound.c") as f:
+    rebc = f.readlines()
+
+with open("src/rebound.c", "w") as f:
+    for i in range(len(rebc)):
+        f.write(rebc[i])
+        if "if (r->heartbeat){ r->heartbeat(r); }" in rebc[i]:
+            f.write("    if (r->{0}){{\n".format(param_name))
+            f.write("        // Check for custom condition\n")
+            f.write("        if (fill_in_here){\n")
+            f.write("            r->status = REB_{0};\n".format(param_name.upper()))
+            f.write("        }\n")
+            f.write("    }")
+
+with open("rebound/simulation.py") as f:
+    sim = f.readlines()
+
+with open("rebound/simulation.py", "w") as f:
+    for i in range(len(sim)):
+        f.write(sim[i])
+        if "Simulation._fields_ = " in sim[i]:
+            f.write('\t\t\t\t("{0}", {1}),\n'.format(param_name, param_ctype))
+        if "from . import clibrebound" in sim[i]:
+            f.write(sim[i]+", {0}\n".format(exception))
+        if "ret_value = clibrebound.reb_integrate" in sim[i]:
+            f.write("\t\t\tif ret_value == {0}:\n".format(param_enum_code))
+            f.write('\t\t\t\traise {0}("{1}")\n'.format(exception, description))
+
+with open("rebound/__init__.py") as f:
+    init = f.readlines()
+
+with open("rebound/__init__.py", "w") as f:
+    for i in range(len(init)):
+        f.write(init[i])
+        if "# Exceptions" in init[i]:
+            f.write("class {0}(Exception):\n".format(exception))
+            f.write("\tpass\n")
+        if "__all__ = " in init[i]:
+            f.write(init[i][:-1] + ', "{0}"]\n'.format(exception))

--- a/add_exit_cond.py
+++ b/add_exit_cond.py
@@ -14,6 +14,8 @@ description = str(sys.argv[5])
 
 exception = param_name.capitalize()
 
+tab = "    " # 4 space tab
+
 with open("src/rebound.h") as f:
     rebh = f.readlines()
 
@@ -21,9 +23,9 @@ with open("src/rebound.h", "w") as f:
     for i in range(len(rebh)):
         f.write(rebh[i])
         if "struct reb_simulation {" in rebh[i]:
-            f.write("    {0} {1};\n".format(param_type_c, param_name))
+            f.write(tab+"{0} {1};\n".format(param_type_c, param_name))
         if "enum REB_STATUS {" in rebh[i]:
-            f.write("    REB_{0} = {1},\n".format(param_name.upper(), param_enum_code))
+            f.write(tab+"REB_{0} = {1},\n".format(param_name.upper(), param_enum_code))
 
 with open("src/rebound.c") as f:
     rebc = f.readlines()
@@ -32,12 +34,12 @@ with open("src/rebound.c", "w") as f:
     for i in range(len(rebc)):
         f.write(rebc[i])
         if "if (r->heartbeat){ r->heartbeat(r); }" in rebc[i]:
-            f.write("    if (r->{0}){{\n".format(param_name))
-            f.write("        // Check for custom condition\n")
-            f.write("        if (fill_in_here){\n")
-            f.write("            r->status = REB_{0};\n".format(param_name.upper()))
-            f.write("        }\n")
-            f.write("    }\n")
+            f.write(tab+"if (r->{0}){{\n".format(param_name))
+            f.write(tab+tab+"// Check for custom condition\n")
+            f.write(tab+tab+"if (fill_in_here){\n")
+            f.write(tab+tab+tab+"r->status = REB_{0};\n".format(param_name.upper()))
+            f.write(tab+tab+"}\n")
+            f.write(tab+"}\n")
         if "void reb_init_simulation(" in rebc[i]:
             f.write("    r->{0} = 0;\n".format(param_name))
 
@@ -51,10 +53,10 @@ with open("rebound/simulation.py", "w") as f:
         else:
             f.write(sim[i])
         if "Simulation._fields_ = " in sim[i]:
-            f.write('\t\t\t\t("{0}", {1}),\n'.format(param_name, param_ctype))
+            f.write(tab+tab+tab+tab+'("{0}", {1}),\n'.format(param_name, param_ctype))
         if "ret_value = clibrebound.reb_integrate" in sim[i]:
-            f.write("\t\t\tif ret_value == {0}:\n".format(param_enum_code))
-            f.write('\t\t\t\traise {0}("{1}")\n'.format(exception, description))
+            f.write(tab+tab+tab+"if ret_value == {0}:\n".format(param_enum_code))
+            f.write(tab+tab+tab+tab+'raise {0}("{1}")\n'.format(exception, description))
 
 with open("rebound/__init__.py") as f:
     init = f.readlines()
@@ -68,4 +70,4 @@ with open("rebound/__init__.py", "w") as f:
             f.write(init[i])
         if "# Exceptions" in init[i]:
             f.write("class {0}(Exception):\n".format(exception))
-            f.write("\tpass\n")
+            f.write(tab+"pass\n")

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -869,7 +869,8 @@ class Simulation(Structure):
 
 
 # Setting up fields after class definition (because of self-reference)
-Simulation._fields_ = [("t", c_double),
+Simulation._fields_ = [
+                ("t", c_double),
                 ("G", c_double),
                 ("softening", c_double),
                 ("dt", c_double),

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -47,7 +47,7 @@ enum REB_STATUS {
 	REB_EXIT_ERROR = 1,		///< A generic error occured and the integration was not successfull.
 	REB_EXIT_NOPARTICLES = 2,	///< The integration ends early because no particles are left in the simulation.
 	REB_EXIT_ENCOUNTER = 3,		///< The integration ends early because two particles had a close encounter (see exit_min_distance)
-	REB_EXIT_ESCAPE = 4,		///< The integration ends early because a particle escaped (see exit_min_distance)  
+	REB_EXIT_ESCAPE = 4,		///< The integration ends early because a particle escaped (see exit_max_distance)  
 	REB_EXIT_USER = 5,		///< User caused exit, simulation did not finish successfully.
 };
 


### PR DESCRIPTION
So a couple times now people have asked me to have a custom field in reb_simulation so that they can check for their own thing in heartbeat, like we do with exit_min_distance etc.  Many of these are probably not general enough to include in the master branch.  For Chris project, we'd like to keep track of distance from the star, and save a checkpoint if ever particles get close enough that tides might matter.  He's already using exit_min_distance for close encounters between planets, so we need an extra parameter like exit_min_peri.

Instead of just coding it in, I've created a script add_exit_cond.py that can do this generically.  The usage for this case is

python add_exit_cond.py "exit_min_peri" "double" "c_double" "101" "A particle got too close to the central body."

This will:
add a field in the reb_simulation struct with name "exit_min_peri"
add a field in the REB_STATUS enum REB_EXIT_MIN_PERI = 101 
add a placeholder in rebound.c's run_heartbeat if(r->exit_min_peri){ for you to fill in how you want to determine the exit condition.

add the corresponding _field_ in simulation.py
add an exception class "Exit_min_peri"
add a check for ret_value == 101 when calling reb_integrate from python that raises the new exception

I'm not sure whether you would find this useful, but thought I'd share in case.  If you don't, would you mind merging the typo I fixed in rebound.h and the line break in simulation.py (which my script needs to put in the new field?).