### PR TITLE
added consts to tools_energy

### DIFF
--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1182,7 +1182,7 @@ struct reb_particle reb_tools_orbit_to_particle_df_dm(double G, struct reb_parti
  * @param r The rebound simulation to be considered
  * @return Total energy. 
  */
-double reb_tools_energy(struct reb_simulation* r);
+double reb_tools_energy(const struct reb_simulation* const r);
 
 /**
  * @brief Add and initialize a set of first order variational particles

--- a/src/tools.c
+++ b/src/tools.c
@@ -68,7 +68,7 @@ double reb_random_rayleigh(double sigma){
 }
 
 /// Other helper routines
-double reb_tools_energy(struct reb_simulation* r){
+double reb_tools_energy(const struct reb_simulation* const r){
 	const int N = r->N;
 	const struct reb_particle* restrict const particles = r->particles;
 	const int N_var = r->N_var;


### PR DESCRIPTION
Just a trivial change to get rid of warnings in REBOUNDx in functions calculating energy and passing a const sim.