### PR TITLE
Angmom

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -899,10 +899,9 @@ class Simulation(Structure):
         """
         Returns a list of the three (x,y,z) components of the total angular momentum of all particles in the simulation.
         """
-        clibrebound.reb_tools_Lx.restype = c_double
-        clibrebound.reb_tools_Ly.restype = c_double
-        clibrebound.reb_tools_Lz.restype = c_double
-        return [clibrebound.reb_tools_Lx(byref(self)), clibrebound.reb_tools_Ly(byref(self)), clibrebound.reb_tools_Lz(byref(self))]
+        clibrebound.reb_tools_angular_momentum.restype = reb_vec3d
+        L = clibrebound.reb_tools_angular_momentum(byref(self))
+        return [L.x, L.y, L.z]
 
     def configure_box(self, boxsize, root_nx=1, root_ny=1, root_nz=1):
         """

--- a/rebound/tests/test_simulation.py
+++ b/rebound/tests/test_simulation.py
@@ -102,6 +102,16 @@ class TestSimulation(unittest.TestCase):
         energy = self.sim.calculate_energy()
         self.assertAlmostEqual(energy, -0.5e-3, delta=1e-14)
 
+    def test_calculate_angular_momentum(self):
+        sim = rebound.Simulation()
+        sim.add(m=1.)
+        sim.add(m=1.e-3, a=1., inc=0.3, Omega=0.5)
+        sim.add(m=1.e-3, a=3., inc=0.2, Omega = -0.8)
+        L0 = sim.calculate_angular_momentum()
+        sim.integrate(1.)
+        Lf = sim.calculate_angular_momentum()
+        for i in range(3):
+            self.assertAlmostEqual(abs((Lf[i]-L0[i])/L0[i]), 0., delta=1e-15)
 
     def test_additional_forces(self):
         def af(sim):

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1198,23 +1198,11 @@ struct reb_particle reb_tools_orbit_to_particle_df_dm(double G, struct reb_parti
 double reb_tools_energy(const struct reb_simulation* const r);
 
 /**
- * @brief Calculate the x component of the system's angular momentum.
+ * @brief Calculate the system's angular momentum.
  * @param r The rebound simulation to be considered.
- * @return x component of the angular momentum.
+ * @return The angular momentum vector as a reb_vec3d struct.
  */
-double reb_tools_Lx(const struct reb_simulation* const r);
-/**
- * @brief Calculate the y component of the system's angular momentum.
- * @param r The rebound simulation to be considered.
- * @return y component of the angular momentum.
- */
-double reb_tools_Ly(const struct reb_simulation* const r);
-/**
- * @brief Calculate the z component of the system's angular momentum.
- * @param r The rebound simulation to be considered.
- * @return z component of the angular momentum.
- */
-double reb_tools_Lz(const struct reb_simulation* const r);
+struct reb_vec3d reb_tools_angular_momentum(const struct reb_simulation* const r);
 
 /**
  * @brief Add and initialize a set of first order variational particles

--- a/src/tools.c
+++ b/src/tools.c
@@ -89,40 +89,18 @@ double reb_tools_energy(const struct reb_simulation* const r){
 	return e_kin +e_pot;
 }
 
-double reb_tools_Lx(const struct reb_simulation* const r){
+struct reb_vec3d reb_tools_angular_momentum(const struct reb_simulation* const r){
 	const int N = r->N;
 	const struct reb_particle* restrict const particles = r->particles;
 	const int N_var = r->N_var;
-	double Lx = 0.;
+    struct reb_vec3d L = {0};
     for (int i=0;i<N-N_var;i++){
 		struct reb_particle pi = particles[i];
-        Lx += pi.m*(pi.y*pi.vz - pi.z*pi.vy);
+        L.x += pi.m*(pi.y*pi.vz - pi.z*pi.vy);
+        L.y += pi.m*(pi.z*pi.vx - pi.x*pi.vz);
+        L.z += pi.m*(pi.x*pi.vy - pi.y*pi.vx);
 	}
-	return Lx;
-}
-
-double reb_tools_Ly(const struct reb_simulation* const r){
-	const int N = r->N;
-	const struct reb_particle* restrict const particles = r->particles;
-	const int N_var = r->N_var;
-	double Ly = 0.;
-    for (int i=0;i<N-N_var;i++){
-		struct reb_particle pi = particles[i];
-        Ly += pi.m*(pi.z*pi.vx - pi.x*pi.vz);
-	}
-	return Ly;
-}
-
-double reb_tools_Lz(const struct reb_simulation* const r){
-	const int N = r->N;
-	const struct reb_particle* restrict const particles = r->particles;
-	const int N_var = r->N_var;
-	double Lz = 0.;
-    for (int i=0;i<N-N_var;i++){
-		struct reb_particle pi = particles[i];
-        Lz += pi.m*(pi.x*pi.vy - pi.y*pi.vx);
-	}
-	return Lz;
+	return L;
 }
 
 void reb_move_to_com(struct reb_simulation* const r){


### PR DESCRIPTION
Changed to returning vec3d.  Kept python as returning a list since it seems simpler, but maybe having an object where you can check L.x, L.y, L.z is more specific.  Any preference?

Added a unit test that makes sure L is conserved in a very short integration.