### PR TITLE
added sphinx flag to document __init__

### DIFF
--- a/doc/python_api.rst
+++ b/doc/python_api.rst
@@ -3,4 +3,5 @@ API documentation (Python)
 
 .. automodule:: rebound
    :members:
+   :special-members: __init__
 


### PR DESCRIPTION
Note this will add documentation for all documented __init__ methods (which I think is what we want).  Currently Particle is the only class with documentation.  Doc now looks like this

![screen shot 2016-06-17 at 8 52 26 am](https://cloud.githubusercontent.com/assets/3408023/16151316/5bd7355c-346a-11e6-80b9-254346f9f0a8.png)
