### PR TITLE
reset extras and particles pointer in binary read

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -139,6 +139,7 @@ struct reb_simulation* reb_create_simulation_from_binary(char* filename){
         // Read particles
         r->particles = malloc(sizeof(struct reb_particle)*r->N);
         objects += fread(r->particles,sizeof(struct reb_particle),r->N,inf);
+        reb_reset_particle_pointers(r);
         for (int l=0;l<r->N;l++){
             r->particles[l].sim = r;
         }

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -213,12 +213,21 @@ void reb_free_pointers(struct reb_simulation* const r){
     free(r->particle_lookup_table);
 }
 
+void reb_reset_particle_pointers(struct reb_simulation* const r){
+    for(int i=0;i<r->N;i++){
+        r->particles[i].c = NULL;
+        r->particles[i].ap = NULL;
+        r->particles[i].sim = NULL;
+    }
+}
+
 void reb_reset_temporary_pointers(struct reb_simulation* const r){
     // Note: this will not clear the particle array.
     r->gravity_cs_allocatedN    = 0;
     r->gravity_cs           = NULL;
     r->collisions_allocatedN    = 0;
     r->collisions           = NULL;
+    r->extras               = NULL;
     // ********** WHFAST
     r->ri_whfast.allocated_N    = 0;
     r->ri_whfast.eta        = NULL;

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -692,6 +692,11 @@ void reb_mpi_finalize(struct reb_simulation* const r);
 /**
  * @cond PRIVATE
  */
+
+/**
+ * @brief Function used for binary input.
+ */
+void reb_reset_particle_pointers(struct reb_simulation* const r);
 /**
  * @brief Function used to allow binary input.
  */


### PR DESCRIPTION
I also added a reset_particle_pointers function that only gets called in reading an input binary to make sure that p->ap is NULL when you reload binary file and you don't try to access memory freed by reboundx.