### PR TITLE
reset lookup table parameters and pointers during binary read

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -136,10 +136,6 @@ struct reb_simulation* reb_create_simulation_from_binary(char* filename){
         r->allocatedN = r->N;
         r->tree_root = NULL;
 
-        // Reset lookup table
-        r->N_lookup = 0;
-        r->allocatedN_lookup = 0;
-
         // Read particles
         r->particles = malloc(sizeof(struct reb_particle)*r->N);
         objects += fread(r->particles,sizeof(struct reb_particle),r->N,inf);

--- a/src/input.c
+++ b/src/input.c
@@ -136,6 +136,10 @@ struct reb_simulation* reb_create_simulation_from_binary(char* filename){
         r->allocatedN = r->N;
         r->tree_root = NULL;
 
+        // Reset lookup table
+        r->N_lookup = 0;
+        r->allocatedN_lookup = 0;
+
         // Read particles
         r->particles = malloc(sizeof(struct reb_particle)*r->N);
         objects += fread(r->particles,sizeof(struct reb_particle),r->N,inf);

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -219,8 +219,11 @@ void reb_reset_temporary_pointers(struct reb_simulation* const r){
     r->gravity_cs           = NULL;
     r->collisions_allocatedN    = 0;
     r->collisions           = NULL;
-    r->particle_lookup_table = NULL;
     r->extras               = NULL;
+    // ********** Lookup Table
+    r->particle_lookup_table = NULL;
+    r->N_lookup = 0;
+    r->allocatedN_lookup = 0;
     // ********** WHFAST
     r->ri_whfast.allocated_N    = 0;
     r->ri_whfast.eta        = NULL;

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -219,6 +219,7 @@ void reb_reset_temporary_pointers(struct reb_simulation* const r){
     r->gravity_cs           = NULL;
     r->collisions_allocatedN    = 0;
     r->collisions           = NULL;
+    r->particle_lookup_table = NULL;
     r->extras               = NULL;
     // ********** WHFAST
     r->ri_whfast.allocated_N    = 0;


### PR DESCRIPTION
We don't write the lookup table to the binary file, so I think the right thing is to 0 / NULL out everything, and then the lookup table just gets remade the first time someone tries to get_by_hash