### PR TITLE
Reorder

### DIFF
--- a/examples/variational_equations/problem.c
+++ b/examples/variational_equations/problem.c
@@ -13,7 +13,7 @@
 struct reb_simulation* create_sim(){
 	struct reb_simulation* r = reb_create_simulation();
     // r->integrator = REB_INTEGRATOR_WHFAST;  Only first order variational equations supported in WHFast.
-    struct reb_particle star = {0.};
+    struct reb_particle star = {0};
     star.m = 1;
     reb_add(r, star);
     struct reb_particle planet = reb_tools_orbit_to_particle(1.,star,1e-3,1.,0.,0.,0.,0.,0.);

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1414,7 +1414,8 @@ Simulation._fields_ = [
                 ("extras", c_void_p),
                  ]
 
-Particle._fields_ = [("x", c_double),
+Particle._fields_ = [("_sim", POINTER(Simulation)),
+                ("x", c_double),
                 ("y", c_double),
                 ("z", c_double),
                 ("vx", c_double),
@@ -1428,8 +1429,7 @@ Particle._fields_ = [("x", c_double),
                 ("lastcollision", c_double),
                 ("c", c_void_p),
                 ("_hash", c_uint32),
-                ("ap", c_void_p),
-                ("_sim", POINTER(Simulation))]
+                ("ap", c_void_p)]
 
 POINTER_REB_SIM = POINTER(Simulation) 
 AFF = CFUNCTYPE(None,POINTER_REB_SIM)

--- a/src/derivatives.c
+++ b/src/derivatives.c
@@ -38,7 +38,7 @@ struct reb_particle reb_derivatives_lambda(double G, struct reb_particle primary
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -78,7 +78,7 @@ struct reb_particle reb_derivatives_h(double G, struct reb_particle primary, str
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -120,7 +120,7 @@ struct reb_particle reb_derivatives_k(double G, struct reb_particle primary, str
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -162,7 +162,7 @@ struct reb_particle reb_derivatives_k_k(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -216,7 +216,7 @@ struct reb_particle reb_derivatives_h_h(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -271,7 +271,7 @@ struct reb_particle reb_derivatives_lambda_lambda(double G, struct reb_particle 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -318,7 +318,7 @@ struct reb_particle reb_derivatives_k_lambda(double G, struct reb_particle prima
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -373,7 +373,7 @@ struct reb_particle reb_derivatives_h_lambda(double G, struct reb_particle prima
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -427,7 +427,7 @@ struct reb_particle reb_derivatives_k_h(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -487,7 +487,7 @@ struct reb_particle reb_derivatives_a(double G, struct reb_particle primary, str
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -522,7 +522,7 @@ struct reb_particle reb_derivatives_a_a(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -557,7 +557,7 @@ struct reb_particle reb_derivatives_ix(double G, struct reb_particle primary, st
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -594,7 +594,7 @@ struct reb_particle reb_derivatives_ix_ix(double G, struct reb_particle primary,
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -634,7 +634,7 @@ struct reb_particle reb_derivatives_iy(double G, struct reb_particle primary, st
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -671,7 +671,7 @@ struct reb_particle reb_derivatives_iy_iy(double G, struct reb_particle primary,
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -711,7 +711,7 @@ struct reb_particle reb_derivatives_k_ix(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -756,7 +756,7 @@ struct reb_particle reb_derivatives_h_ix(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -801,7 +801,7 @@ struct reb_particle reb_derivatives_lambda_ix(double G, struct reb_particle prim
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -844,7 +844,7 @@ struct reb_particle reb_derivatives_lambda_iy(double G, struct reb_particle prim
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -886,7 +886,7 @@ struct reb_particle reb_derivatives_h_iy(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -929,7 +929,7 @@ struct reb_particle reb_derivatives_k_iy(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -972,7 +972,7 @@ struct reb_particle reb_derivatives_ix_iy(double G, struct reb_particle primary,
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1014,7 +1014,7 @@ struct reb_particle reb_derivatives_a_ix(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1050,7 +1050,7 @@ struct reb_particle reb_derivatives_a_iy(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1087,7 +1087,7 @@ struct reb_particle reb_derivatives_a_lambda(double G, struct reb_particle prima
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
 
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -1127,7 +1127,7 @@ struct reb_particle reb_derivatives_a_h(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1169,7 +1169,7 @@ struct reb_particle reb_derivatives_a_k(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1211,7 +1211,7 @@ struct reb_particle reb_derivatives_m(double G, struct reb_particle primary, str
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     np.m = 1.;
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
@@ -1241,7 +1241,7 @@ struct reb_particle reb_derivatives_m_a(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 
@@ -1270,7 +1270,7 @@ struct reb_particle reb_derivatives_m_lambda(double G, struct reb_particle prima
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
     double dq_dlambda = -p/(1.-q);
@@ -1304,7 +1304,7 @@ struct reb_particle reb_derivatives_m_h(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
     double slp = sin(lambda+p);
@@ -1340,7 +1340,7 @@ struct reb_particle reb_derivatives_m_k(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
     double slp = sin(lambda+p);
@@ -1376,7 +1376,7 @@ struct reb_particle reb_derivatives_m_ix(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
     double slp = sin(lambda+p);
@@ -1407,7 +1407,7 @@ struct reb_particle reb_derivatives_m_iy(double G, struct reb_particle primary, 
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
     double slp = sin(lambda+p);
@@ -1438,7 +1438,7 @@ struct reb_particle reb_derivatives_m_m(double G, struct reb_particle primary, s
     double a, lambda, k, h, ix, iy;
     reb_tools_particle_to_pal(G, po, primary, &a, &lambda, &k, &h, &ix, &iy);
 
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     double p=0.,q=0.;
     reb_tools_solve_kepler_pal(h, k, lambda, &p, &q);
 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -96,6 +96,7 @@ struct reb_ghostbox{
  * for MPI in communications_mpi.c.
  */
 struct reb_particle {
+    struct reb_simulation* sim; ///< Pointer to the parent simulation.
     double x;           ///< x-position of the particle. 
     double y;           ///< y-position of the particle. 
     double z;           ///< z-position of the particle. 
@@ -111,7 +112,6 @@ struct reb_particle {
     struct reb_treecell* c;     ///< Pointer to the cell the particle is currently in.
     uint32_t hash;      ///< hash to identify particle.
     void* ap;           ///< Functionality for externally adding additional properties to particles.
-    struct reb_simulation* sim; ///< Pointer to the parent simulation.
 };
 
 

--- a/src/tools.c
+++ b/src/tools.c
@@ -754,7 +754,7 @@ void reb_tools_particle_to_pal(double G, struct reb_particle p, struct reb_parti
 }
 
 struct reb_particle reb_tools_pal_to_particle(double G, struct reb_particle primary, double m, double a, double lambda, double k, double h, double ix, double iy){
-    struct reb_particle np = {0.};
+    struct reb_particle np = {0};
     np.m = m;
 
     double p=0.,q=0.;


### PR DESCRIPTION
This will only make sense after reading the e-mail I sent you a couple hours ago.  Moving the object_type member of rebx_effect did not help, because the whole structure is smaller than the first 9 elements of reb_particle (positions, velocities, and accelerations).  So since all these 9 quantities are changing every timestep, there's a good chance that in 10^10 timesteps you will match a given hash in all 10 places.  So I've moved the simulation pointer to the beginning of reb_particle.  This pointer won't change lots of times, so the chance of collision is negligible.  It meant that I had to also update the code and examples to initialize with {0} rather than {0.} since the first element is now a pointer.  I don't see any downside to this, but maybe you do.  I guess the alternative in REBOUNDx is another rewriting (?), or duplication of all the getter/setters for different types...I don't really like the latter since you might want to start adding parameters to other structures too in the future, and it will be a pain to have separate functions for each type, and for each variable type...