### PR TITLE
fixed safe_mode typo

### DIFF
--- a/ipython_examples/AdvWHFast.ipynb
+++ b/ipython_examples/AdvWHFast.ipynb
@@ -15,7 +15,7 @@
     "1. you don't add, remove or otherwise modify particles between timesteps\n",
     "2. you get your outputs by passing a list of output times ahead of time and access the particles pointer between calls to `sim.integrate()` (see, e.g., the Visualization section of [WHFast.ipynb](WHFast.ipynb))\n",
     "\n",
-    "you can set `sim.ri_whfast.safemode = 0` to get a substantial performance boost.  Under the same stipulations, you can set `sim.ri_whfast.corrector = 11` to get much higher accuracy, at a nearly negligible loss of performance (as long as there are many timesteps between outputs).\n",
+    "you can set `sim.ri_whfast.safe_mode = 0` to get a substantial performance boost.  Under the same stipulations, you can set `sim.ri_whfast.corrector = 11` to get much higher accuracy, at a nearly negligible loss of performance (as long as there are many timesteps between outputs).\n",
     "\n",
     "If you want to modify particles, or if the code breaks with these advanced settings, read below for details, and check out the Common mistake with WHFast section at the bottom of [WHFast.ipynb](WHFast.ipynb)."
    ]
@@ -334,21 +334,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
While going through it again, I noticed there was a typo on one of the ri_whfast.safe_mode instances in the notebook (didn't have a hyphen).  Horrible typo since python doesn't let you know if you set a field that doesn't exist!