### PR TITLE
added decimals to time in status and updated archive ipynbs

### DIFF
--- a/ipython_examples/SimulationArchive.ipynb
+++ b/ipython_examples/SimulationArchive.ipynb
@@ -267,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -290,6 +290,36 @@
    "metadata": {},
    "source": [
     "Note that in the above example, we use an initializer function so that each thread has its own Simulation Archive."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "collapsed": true
+   },
+   "source": [
+    "# Note\n",
+    "\n",
+    "For efficiency reasons, indexing the `SimulationArchive` always updates an internal pointer to a `Simulation` and returns it. This can sometimes lead to surprising behavior. For example, if one tried to rerun a simulation from the first snapshot to the final time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "sim = sa[0]\n",
+    "sim.integrate(sa[-1].t)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This code executes immediately because it's not doing the integration! When `sa[-1].t` is evaluated to get the final time, `sim` is automatically updated to reflect a simulation initialized at the final snapshot, which is already at the final time."
    ]
   },
   {
@@ -319,10 +349,6 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.5.1"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.0.0"
   }
  },
  "nbformat": 4,

--- a/ipython_examples/SimulationArchiveRestart.ipynb
+++ b/ipython_examples/SimulationArchiveRestart.ipynb
@@ -165,7 +165,8 @@
    "source": [
     "A few things to note when restarting a simulation from a SA: \n",
     "- If you used any additional forces or post-timestep modifications in the original simulation, then those need to be restored after loading a simulation from a SA.\n",
-    "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsychronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that."
+    "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsychronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that.\n",
+    "- For reproducibility, the SimulationArchive does not output snapshots at the *exact* intervals specified, but rather at the timestep in the integration directly following each interval. This means that if you load from a SimulationArchive and want to reproduce the state in a snapshot later on, you have to pass `exact_finish_time=0` in a call to `sim.integrate`."
    ]
   },
   {
@@ -180,25 +181,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.10"
-  },
-  "widgets": {
-   "state": {},
-   "version": "1.0.0"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -537,7 +537,7 @@ class Simulation(Structure):
         s += "REBOUND built on:    \t%s\n" %__build__
         s += "Number of particles: \t%d\n" %self.N       
         s += "Selected integrator: \t" + self.integrator + "\n"       
-        s += "Simulation time:     \t%f\n" %self.t
+        s += "Simulation time:     \t%.16e\n" %self.t
         s += "Current timestep:    \t%f\n" %self.dt
         if self.N>0:
             s += "---------------------------------\n"


### PR DESCRIPTION
I added some quick notes to the simulation archive ipynbs based on some snags I ran into, and updates sim.status() to output the simulation time to 16 digits to help diagnose reproducibility issues.