### PR TITLE
Update Makefile.defs

### DIFF
--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -1,4 +1,4 @@
-OPT+= -std=c99 -Wpointer-arith -D_GNU_SOURCE -O3 -march=native
+OPT+= -std=c99 -Wpointer-arith -D_GNU_SOURCE -O3 -mtune=native
 ifndef OS
 	OS=$(shell uname)
 endif


### PR DESCRIPTION
On my MacBookPro10,1 (OSX Sierra, Macports GCC 5.4), Rebound fails to compile with "-march=native". "-mtune=native" builds Rebound successfully. 