### PR TITLE
whfasthelio jump step now O(N)

### DIFF
--- a/src/integrator_whfasthelio.c
+++ b/src/integrator_whfasthelio.c
@@ -50,15 +50,19 @@
 static void reb_whfasthelio_jump_step(const struct reb_simulation* const r, double _dt){
     const int N_real = r->N-r->N_var;
     struct reb_particle* const p_h = r->ri_whfasthelio.p_h;
-    const double m0 = r->particles[0].m;   
+    const double m0 = r->particles[0].m;
+    double px=0, py=0, pz=0;
     for(int i=1;i<N_real;i++){
-    for(int j=1;j<N_real;j++){
-        if(i==j) continue;
-        const double m = r->particles[j].m;   
-        p_h[i].x += _dt * m * p_h[j].vx / (m0+m);
-        p_h[i].y += _dt * m * p_h[j].vy / (m0+m);
-        p_h[i].z += _dt * m * p_h[j].vz / (m0+m);
+        const double m = r->particles[i].m;
+        px += _dt * m * p_h[i].vx / m0;
+        py += _dt * m * p_h[i].vy / m0;
+        pz += _dt * m * p_h[i].vz / m0;
     }
+    for(int i=1;i<N_real;i++){
+        const double m = r->particles[i].m;
+        p_h[i].x += px - (_dt * m * p_h[i].vx / m0);
+        p_h[i].y += py - (_dt * m * p_h[i].vy / m0);
+        p_h[i].z += pz - (_dt * m * p_h[i].vz / m0);
     }
 }
 

--- a/src/integrator_whfasthelio.c
+++ b/src/integrator_whfasthelio.c
@@ -54,15 +54,15 @@ static void reb_whfasthelio_jump_step(const struct reb_simulation* const r, doub
     double px=0, py=0, pz=0;
     for(int i=1;i<N_real;i++){
         const double m = r->particles[i].m;
-        px += _dt * m * p_h[i].vx / m0;
-        py += _dt * m * p_h[i].vy / m0;
-        pz += _dt * m * p_h[i].vz / m0;
+        px += _dt * m * p_h[i].vx / (m0+m);
+        py += _dt * m * p_h[i].vy / (m0+m);
+        pz += _dt * m * p_h[i].vz / (m0+m);
     }
     for(int i=1;i<N_real;i++){
         const double m = r->particles[i].m;
-        p_h[i].x += px - (_dt * m * p_h[i].vx / m0);
-        p_h[i].y += py - (_dt * m * p_h[i].vy / m0);
-        p_h[i].z += pz - (_dt * m * p_h[i].vz / m0);
+        p_h[i].x += px - (_dt * m * p_h[i].vx / (m0+m));
+        p_h[i].y += py - (_dt * m * p_h[i].vy / (m0+m));
+        p_h[i].z += pz - (_dt * m * p_h[i].vz / (m0+m));
     }
 }
 


### PR DESCRIPTION
Hanno, 
Here is the code for the O(N) jump step. Looking at the Hernandez paper, it looks like the divisor of m[i]*p_h[i].v should be just m0, not (m0 + m[i]). This is reflected in the pull request. Maybe you can double check yourself and confirm. I'm not sure how (m0 + m[i]) snuck in there...