### PR TITLE
added plotparticles and color lists to orbitplot

### DIFF
--- a/rebound/plotting.py
+++ b/rebound/plotting.py
@@ -3,7 +3,7 @@ import math
 from .particle import Particle
 from itertools import cycle
 
-def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, color=False, periastron=False, trails=True, lw=1., slices=False):
+def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, color=False, periastron=False, trails=True, lw=1., slices=False, plotparticles=[]):
     """
     Convenience function for plotting instantaneous orbits.
 
@@ -19,14 +19,16 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
         Limit for z axis, only used if slices=True (default: None = automatically determined)
     unitlabel       : str, optional          
         String describing the units, shown on axis labels (default: None)
-    color           : bool, optional            
-        Enable color (default: False)
+    color           : bool, str or list, optional            
+        By default plots in black. If set to True, plots using REBOUND color cycle. If a string or list of strings, e.g. ['red', 'cyan'], will cycle between passed colors.
     periastron  : bool, optional            
         Draw a marker at periastron (default: False)
     trails          : bool, optional            
         Draw trails instead of solid lines (default: False)
     lw              : float, optional           
         Linewidth (default: 1.)
+    plotparticles   : list, optional
+        List of particles to plot. Can be a list of any valid keys for accessing sim.particles, i.e., integer indices or hashes (default: plot all particles)
 
     Returns
     -------
@@ -60,9 +62,9 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
             figsize = (8,8)
         fig, ax = plt.subplots(2, 2, figsize=figsize)
         gs = gridspec.GridSpec(2, 2, width_ratios=[3., 2.], height_ratios=[2.,3.],wspace=0., hspace=0.) 
-        OrbitPlotOneSlice(sim, plt.subplot(gs[2]), lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xy")
-        OrbitPlotOneSlice(sim, plt.subplot(gs[3]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="zy")
-        OrbitPlotOneSlice(sim, plt.subplot(gs[0]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xz")
+        OrbitPlotOneSlice(sim, plt.subplot(gs[2]), lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xy", plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, plt.subplot(gs[3]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="zy", plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, plt.subplot(gs[0]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xz", plotparticles=plotparticles)
         plt.subplot(gs[2]).set_xlabel("x"+unitlabel)
         plt.subplot(gs[2]).set_ylabel("y"+unitlabel)
       
@@ -77,15 +79,35 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
         fig, ax = plt.subplots(1, 1, figsize=figsize)
         ax.set_xlabel("x"+unitlabel)
         ax.set_ylabel("y"+unitlabel)
-        OrbitPlotOneSlice(sim, ax, lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw)
+        OrbitPlotOneSlice(sim, ax, lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, plotparticles=plotparticles)
     return fig
 
-def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, periastron=False, trails=False, lw=1., axes="xy"):
+def getcolor(color):
+    import matplotlib.colors as mplcolors
+    try:
+        hexcolor = mplcolors.cnames[color]
+    except KeyError:
+        raise AttributeError("Color passed to OrbitPlot not recognized in matplotlib.")
+
+    hexcolor = hexcolor.lstrip('#')
+    lv = len(hexcolor)
+    return tuple(int(hexcolor[i:i + lv // 3], 16)/255. for i in range(0, lv, lv // 3)) # tuple of rgb values
+
+def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, periastron=False, trails=False, lw=1., axes="xy", plotparticles=[]):
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection
     from matplotlib.colors import LinearSegmentedColormap
     import numpy as np
-    orbits = sim.calculate_orbits()
+    if not plotparticles: # default. No plotparticles list passed, so plot all obits
+        orbits = sim.calculate_orbits()
+    else: 
+        orbits = []
+        for p in plotparticles:
+            try:
+                orbits.append(sim.particles[p].orbit)
+            except ParticleNotFound:
+                raise AttributeError("Particle in plotparticles list passed to OrbitPlot not found in the simulation.")
+
     particles = sim.particles
     if lim is None:
         lim = 0.
@@ -116,10 +138,18 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
         ax.set_ylim([-lim,lim])
 
     if color:
-        coloriterator = cycle([(1.,0.,0.),(0.,0.75,0.75),(0.75,0.,0.75),(0.75, 0.75, 0,),(0., 0., 0.),(0., 0., 1.),(0., 0.5, 0.)])
+        if color == True:
+            colors = [(1.,0.,0.),(0.,0.75,0.75),(0.75,0.,0.75),(0.75, 0.75, 0,),(0., 0., 0.),(0., 0., 1.),(0., 0.5, 0.)]
+        if isinstance(color, str):
+            colors = [getcolor(color)]
+        if isinstance(color, list):
+            colors = []
+            for c in color:
+                colors.append(getcolor(c))
     else:
-        coloriterator = cycle([(0.,0.,0.)])
-
+        colors = [(0.,0.,0.)]
+    
+    coloriterator = cycle(colors)
 
     ax.scatter(getattr(particles[0],axes[0]),getattr(particles[0],axes[1]), marker="*", s=35*lw, facecolor="black", edgecolor=None, zorder=3)
     for i, o in enumerate(orbits):


### PR DESCRIPTION
You can now pass a color or list of colors to define the color cycle. You can also pass a plotparticles list to specify which particles get plotted (using any quantity that can be used to access the sim.particles mapping, i.e. integer indices, string hashes or c_uints). See screenshots for examples.

![screen shot 2017-04-12 at 5 45 29 pm](https://cloud.githubusercontent.com/assets/3408023/24981683/c8aeb8d0-1fab-11e7-8087-87405988fc51.png)
![screen shot 2017-04-12 at 6 07 54 pm](https://cloud.githubusercontent.com/assets/3408023/24981693/d3a46e06-1fab-11e7-8c8d-2348a123761e.png)
