### PR TITLE
Simulation.add drops kwargs when particle is list

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1010,7 +1010,7 @@ class Simulation(Structure):
                 clibrebound.reb_add(byref(self), particle)
             elif isinstance(particle, list):
                 for p in particle:
-                    self.add(p)
+                    self.add(p, **kwargs)
             elif isinstance(particle,str):
                 if None in self.units.values():
                     self.units = ('AU', 'yr2pi', 'Msun')


### PR DESCRIPTION
I ran across this while trying to simulate future planetary orbits from JPL Horizons.

`sim.add(['Sun', 'Earth', 'Jupiter'], date='2176-10-01 12:00')`

works on the current date rather than the one specified