### PR TITLE
Update OrbitPlot to allow for not plotting orbit lines/trails

### DIFF
--- a/rebound/plotting.py
+++ b/rebound/plotting.py
@@ -3,7 +3,7 @@ import math
 from .particle import Particle
 from itertools import cycle
 
-def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, color=False, periastron=False, trails=True, lw=1., slices=False, plotparticles=[]):
+def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, color=False, periastron=False, trails=True, phases=True, lw=1., slices=False, plotparticles=[]):
     """
     Convenience function for plotting instantaneous orbits.
 
@@ -25,6 +25,8 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
         Draw a marker at periastron (default: False)
     trails          : bool, optional            
         Draw trails instead of solid lines (default: False)
+    phases          : bool, optional
+        Draw orbit trails/lines (default: True)
     lw              : float, optional           
         Linewidth (default: 1.)
     plotparticles   : list, optional
@@ -62,9 +64,9 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
             figsize = (8,8)
         fig, ax = plt.subplots(2, 2, figsize=figsize)
         gs = gridspec.GridSpec(2, 2, width_ratios=[3., 2.], height_ratios=[2.,3.],wspace=0., hspace=0.) 
-        OrbitPlotOneSlice(sim, plt.subplot(gs[2]), lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xy", plotparticles=plotparticles)
-        OrbitPlotOneSlice(sim, plt.subplot(gs[3]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="zy", plotparticles=plotparticles)
-        OrbitPlotOneSlice(sim, plt.subplot(gs[0]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, axes="xz", plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, plt.subplot(gs[2]), lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, phases=phases, lw=lw, axes="xy", plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, plt.subplot(gs[3]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, phases=phases, lw=lw, axes="zy", plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, plt.subplot(gs[0]), lim=lim, limz=limz, Narc=Narc, color=color, periastron=periastron, trails=trails, phases=phases, lw=lw, axes="xz", plotparticles=plotparticles)
         plt.subplot(gs[2]).set_xlabel("x"+unitlabel)
         plt.subplot(gs[2]).set_ylabel("y"+unitlabel)
       
@@ -79,7 +81,7 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
         fig, ax = plt.subplots(1, 1, figsize=figsize)
         ax.set_xlabel("x"+unitlabel)
         ax.set_ylabel("y"+unitlabel)
-        OrbitPlotOneSlice(sim, ax, lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, lw=lw, plotparticles=plotparticles)
+        OrbitPlotOneSlice(sim, ax, lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, phases=phases, lw=lw, plotparticles=plotparticles)
     return fig
 
 def getcolor(color):
@@ -93,7 +95,7 @@ def getcolor(color):
     lv = len(hexcolor)
     return tuple(int(hexcolor[i:i + lv // 3], 16)/255. for i in range(0, lv, lv // 3)) # tuple of rgb values
 
-def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, periastron=False, trails=False, lw=1., axes="xy", plotparticles=[]):
+def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, periastron=False, trails=False, phases=True, lw=1., axes="xy", plotparticles=[]):
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection
     from matplotlib.colors import LinearSegmentedColormap
@@ -159,12 +161,13 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
         ax.scatter(getattr(pp,axes[0]), getattr(pp,axes[1]), s=25*lw, facecolor="black", edgecolor=None, zorder=3)
         if o.a>0.: # bound orbit
             segments = np.zeros((Narc,2,2))
-            phase = np.linspace(0,2.*np.pi,Narc)
-            for j,ph in enumerate(phase):
-                newp = Particle(a=o.a, f=o.f+ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                segments[j][1]=xy
-                segments[(j+1)%Narc][0]=xy
+            if phases:
+                phase = np.linspace(0,2.*np.pi,Narc)
+                for j,ph in enumerate(phase):
+                    newp = Particle(a=o.a, f=o.f+ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
+                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
+                    segments[j][1]=xy
+                    segments[(j+1)%Narc][0]=xy
             cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
                      'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
                      'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
@@ -172,22 +175,24 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
                 cdict['alpha'] = ((0.,0.,0.),(1.,1.,1.))
             individual_cm = LinearSegmentedColormap('indv1', cdict)
             lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            lc.set_array(phase)
+            if phases:
+                lc.set_array(phase)
             ax.add_collection(lc)
         else:     # unbound orbit.  Step in M rather than f, since for hyperbolic orbits f stays near lim, and jumps to -f at peri
             t_cross = 4.*o.d/o.v # rough time to cross display box
             
             lim_phase = abs(o.n)*t_cross # M = nt, n is negative
             segments = np.zeros((Narc,2,2))
-            phase = np.linspace(-lim_phase+o.M,o.M,Narc)
-            for j,ph in enumerate(phase):
-                newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                segments[j][1]=xy
-                if j+1<Narc:
-                   segments[j+1][0]=xy
-                if j==0:
-                   segments[j][0]=xy
+            if phases:
+                phase = np.linspace(-lim_phase+o.M,o.M,Narc)
+                for j,ph in enumerate(phase):
+                    newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
+                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
+                    segments[j][1]=xy
+                    if j+1<Narc:
+                       segments[j+1][0]=xy
+                    if j==0:
+                       segments[j][0]=xy
             cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
                      'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
                      'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
@@ -195,19 +200,21 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
                 cdict['alpha'] = ((0.,0.,0.),(1.,1.,1.))
             individual_cm = LinearSegmentedColormap('indv1', cdict)
             lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            lc.set_array(phase)
+            if phases:
+                lc.set_array(phase)
             ax.add_collection(lc)
             
             segments = np.zeros((Narc,2,2))
-            phase = np.linspace(o.M,o.M+lim_phase,Narc)
-            for j,ph in enumerate(phase):
-                newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                segments[j][1]=xy
-                if j+1<Narc:
-                   segments[j+1][0]=xy
-                if j==0:
-                   segments[j][0]=xy
+            if phases:
+                phase = np.linspace(o.M,o.M+lim_phase,Narc)
+                for j,ph in enumerate(phase):
+                    newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
+                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
+                    segments[j][1]=xy
+                    if j+1<Narc:
+                       segments[j+1][0]=xy
+                    if j==0:
+                       segments[j][0]=xy
             cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
                      'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
                      'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
@@ -215,7 +222,8 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
                 cdict['alpha'] = ((0.,0.2,0.2),(1.,0.2,0.2))
             individual_cm = LinearSegmentedColormap('indv1', cdict)
             lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            lc.set_array(phase)
+            if phases:
+                lc.set_array(phase)
             ax.add_collection(lc)
         
         


### PR DESCRIPTION
This is a PR per the discussion in #269.

I added a new argument to `OrbitPlot` called `phases` that when `False` does not plot the orbit lines/trails.

The argument name was based on the internal name (`phase`) for plotting the orbits like that, but I'm sure there can be something better for it.

I was aiming to reduce the work done if `phases` was `False`, but I might have been too aggressive over what is behind the `if`; there was a bit of trial-and-error on my part for figuring out what did what.