### PR TITLE
added calc_jacobi_masses to transformations.c

### DIFF
--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1622,7 +1622,7 @@ long reb_simulationarchive_estimate_size(struct reb_simulation* const r, double 
  * particles in ps, p_mass should be the corresponding array of real particles.
  * @param N number of particles in the array.
  */
-
+void reb_transformations_calculate_jacobi_masses(const struct reb_particle* const ps, double* const m_j, const int N);
 void reb_transformations_inertial_to_jacobi_posvel(const struct reb_particle* const particles, struct reb_particle* const p_j, const struct reb_particle* const p_mass, const int N);
 void reb_transformations_inertial_to_jacobi_posvelacc(const struct reb_particle* const particles, struct reb_particle* const p_j, const struct reb_particle* const p_mass, const int N);
 void reb_transformations_inertial_to_jacobi_acc(const struct reb_particle* const particles, struct reb_particle* const p_j,const struct reb_particle* const p_mass, const int N);

--- a/src/transformations.c
+++ b/src/transformations.c
@@ -25,11 +25,23 @@
  *
  */
 
+#include <stdlib.h>
 #include "transformations.h"
 #include "rebound.h"
 
 /******************************
  * Jacobi */
+
+void reb_transformations_calculate_jacobi_masses(const struct reb_particle* const ps, double* const m_j, const int N){
+    double* const eta = malloc(N*sizeof(*eta));
+    eta[0] = ps[0].m;
+    for (unsigned int i=1;i<N;i++){
+        eta[i] = eta[i-1] + ps[i].m;
+        m_j[i] = ps[i].m*eta[i-1]/eta[i];
+    }
+    m_j[0] = eta[N-1];
+    free(eta);
+}
 
 void reb_transformations_inertial_to_jacobi_posvel(const struct reb_particle* const particles, struct reb_particle* const p_j, const struct reb_particle* const p_mass, const int N){
     double eta = p_mass[0].m;


### PR DESCRIPTION
readded calc_jacobi_masses to work with REBOUNDx. Seems cleaner to have all the jacobi transformations in REBOUND even if it currently does not use this one. Could you let me know when you push to PyPI so that I can anchor the REBOUNDx setup.py to that version of REBOUND?