### PR TITLE
refactored plotting

### DIFF
--- a/python_examples/simple_orbit/problem.py
+++ b/python_examples/simple_orbit/problem.py
@@ -12,7 +12,7 @@ sim.add( a=1.4, e=0.1 )       # Massless test particle
 for o in sim.calculate_orbits(): print(o)
 
 # Output orbits in Heliocentric coordinates
-for o in sim.calculate_orbits(heliocentric=True): print(o)
+for o in sim.calculate_orbits(primary=sim.particles[0]): print(o)
 
 # Output cartesian coordinates
 for p in sim.particles: 

--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -435,6 +435,53 @@ class Particle(Structure):
 
         return o
     
+    def sample_orbit(self, Npts=100, primary=None, trailing=True, timespan=None, useTrueAnomaly=True):
+        """
+        Returns a nested list of xyz positions along the osculating orbit of the particle. 
+        If primary is not passed, returns xyz positions along the Jacobi osculating orbit.
+
+        Parameters
+        ----------
+        Npts    : int, optional  
+            Number of points along the orbit to return  (default: 100)
+        primary : rebound.Particle, optional
+            Primary to use for the osculating orbit (default: Jacobi center of mass)
+        trailing: bool, optional
+            Whether to return points stepping backwards in time (True) or forwards (False). (default: True)
+        timespan: float, optional    
+            Return points (for the osculating orbit) from the current position to timespan (forwards or backwards in time depending on trailing keyword). 
+            Defaults to the orbital period for bound orbits, and to the rough time it takes the orbit to move by the current distance from the primary for a hyperbolic orbit. Implementation currently only supports this option if useTrueAnomaly=False.
+        useTrueAnomaly: bool, optional
+            Will sample equally spaced points in true anomaly if True, otherwise in mean anomaly.
+            Latter might be better for hyperbolic orbits, where true anomaly can stay near the limiting value for a long time, and then switch abruptly at pericenter. (Default: True)
+        """
+        pts = []
+        if primary is None:
+            primary = self.jacobi_com
+        o = self.calculate_orbit(primary=primary)
+
+        if timespan is None:
+            if o.a < 0.: # hyperbolic orbit
+                timespan = 2*math.pi*o.d/o.v # rough time to cross display box
+            else:
+                timespan = o.P
+        
+        lim_phase = abs(o.n)*timespan # n is negative for hyperbolic orbits
+
+        if trailing is True:
+            lim_phase *= -1 # sample phase backwards from current value
+        phase = [lim_phase*i/(Npts-1) for i in range(Npts)]
+
+        for i,ph in enumerate(phase):
+            if useTrueAnomaly is True:
+                newp = Particle(a=o.a, f=o.f+ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=self.m, primary=primary, simulation=self._sim.contents)
+            else: 
+                newp = Particle(a=o.a, M=o.M+ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=self.m, primary=primary, simulation=self._sim.contents)
+
+            pts.append(newp.xyz)
+        
+        return pts
+
     # Simple operators for particles.
 
     def __sub__(self, other):
@@ -469,49 +516,6 @@ class Particle(Structure):
             clibrebound.reb_particle_divide.restype = Particle
             return clibrebound.reb_particle_divide(self, c_double(other))
         return NotImplemented 
-
-    def sample_orbit(self, Npts=100, trailing=True, timespan=None, useTrueAnomaly=True):
-        """
-        Returns a nested list of xyz positions along the orbit of the particle. 
-        Points are equally spaced in true anomaly for bound orbits, and equally spaced in time for hyperbolic orbits.
-        
-        Parameters
-        ----------
-        Npts    : int, optional  
-            Number of points along the orbit to return  (default: 100)
-        trailing: bool, optional
-            Whether to return points stepping backwards in time (True) or forwards (False). (default: True)
-        timespan: float, optional    
-            Return points (for the osculating orbit) from the current position to timespan (forwards or backwards in time depending on trailing keyword). 
-            Defaults to the orbital period for bound orbits, and to the rough time it taks the orbit to move by the current distance from the primary for a hyperbolic orbit.
-        useTrueAnomaly: bool, optional
-            Will sample equally spaced points in true anomaly if True, otherwise in mean anomaly.
-            Latter might be better for hyperbolic orbits, where true anomaly can stay near the limiting value for a long time, and then switch abruptly at pericenter. (Default: True)
-        """
-        p = self
-        o = []
-
-        if timespan is None:
-            if self.a < 0.: # hyperbolic orbit
-                timespan = 2*math.pi*p.d/p.v # rough time to cross display box
-            else:
-                timespan = self.P
-        
-        lim_phase = abs(p.n)*timespan # n is negative for hyperbolic orbits
-
-        if trailing is True:
-            lim_phase *= -1 # sample phase backwards from current value
-        phase = [lim_phase*i/(Npts-1) for i in range(Npts)]
-
-        for i,ph in enumerate(phase):
-            if useTrueAnomaly is True:
-                newp = Particle(a=p.a, f=p.f+ph, inc=p.inc, omega=p.omega, Omega=p.Omega, e=p.e, m=p.m, simulation=p._sim.contents)
-            else: 
-                newp = Particle(a=p.a, M=p.M+ph, inc=p.inc, omega=p.omega, Omega=p.Omega, e=p.e, m=p.m, simulation=p._sim.contents)
-
-            o.append(newp.xyz)
-        
-        return o 
 
     @property
     def index(self):

--- a/rebound/plotting.py
+++ b/rebound/plotting.py
@@ -84,16 +84,76 @@ def OrbitPlot(sim, figsize=None, lim=None, limz=None, Narc=100, unitlabel=None, 
         OrbitPlotOneSlice(sim, ax, lim=lim, Narc=Narc, color=color, periastron=periastron, trails=trails, show_orbit=show_orbit, lw=lw, plotparticles=plotparticles)
     return fig
 
-def getcolor(color):
-    import matplotlib.colors as mplcolors
+def get_color(color):
+    """
+    Takes a string for a color name defined in matplotlib and returns of a 3-tuple of RGB values.
+    Will simply return passed value if it's a tuple of length three.
+
+    Parameters
+    ----------
+    color   : str
+        Name of matplotlib color to calculate RGB values for.
+    """
+
+    if isinstance(color, tuple) and len(color) == 3: # already a tuple of RGB values
+        return color
+
+    try:
+        import matplotlib.colors as mplcolors
+    except:
+        raise ImportError("Error importing matplotlib. If running from within a jupyter notebook, try calling '%matplotlib inline' beforehand.")
+   
     try:
         hexcolor = mplcolors.cnames[color]
     except KeyError:
-        raise AttributeError("Color passed to OrbitPlot not recognized in matplotlib.")
+        raise AttributeError("Color not recognized in matplotlib.")
 
     hexcolor = hexcolor.lstrip('#')
     lv = len(hexcolor)
     return tuple(int(hexcolor[i:i + lv // 3], 16)/255. for i in range(0, lv, lv // 3)) # tuple of rgb values
+
+def fading_line(x, y, color='black', alpha_initial=1., alpha_final=0., **kwargs):
+    """
+    Returns a matplotlib LineCollection connecting the points in the x and y lists, with a single color and alpha varying from alpha_initial to alpha_final along the line.
+    Can pass any kwargs you can pass to LineCollection, like linewidgth.
+
+    Parameters
+    ----------
+    x       : list or array of floats for the positions on the (plot's) x axis
+    y       : list or array of floats for the positions on the (plot's) y axis
+    color   : matplotlib color for the line. Can also pass a 3-tuple of RGB values (default: 'black')
+    alpha_initial:  Limiting value of alpha to use at the beginning of the arrays.
+    alpha_final:    Limiting value of alpha to use at the end of the arrays.
+    """
+    try:
+        from matplotlib.collections import LineCollection
+        from matplotlib.colors import LinearSegmentedColormap
+        import numpy as np
+    except:
+        raise ImportError("Error importing matplotlib and/or numpy. Plotting functions not available. If running from within a jupyter notebook, try calling '%matplotlib inline' beforehand.")
+
+    color = get_color(color)
+    cdict = {'red': ((0.,color[0],color[0]),(1.,color[0],color[0])),
+             'green': ((0.,color[1],color[1]),(1.,color[1],color[1])),
+             'blue': ((0.,color[2],color[2]),(1.,color[2],color[2])),
+             'alpha': ((0.,alpha_initial, alpha_initial), (1., alpha_final, alpha_final))}
+    
+    Npts = len(x)
+    if len(y) != Npts:
+        raise AttributeError("x and y must have same dimension.")
+   
+    segments = np.zeros((Npts-1,2,2))
+    segments[0][0] = [x[0], y[0]]
+    for i in range(1,Npts-1):
+        pt = [x[i], y[i]]
+        segments[i-1][1] = pt
+        segments[i][0] = pt 
+    segments[-1][1] = [x[-1], y[-1]]
+
+    individual_cm = LinearSegmentedColormap('indv1', cdict)
+    lc = LineCollection(segments, cmap=individual_cm, **kwargs)
+    lc.set_array(np.linspace(0.,1.,len(segments)))
+    return lc
 
 def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, periastron=False, trails=False, show_orbit=True, lw=1., axes="xy", plotparticles=[]):
     import matplotlib.pyplot as plt
@@ -101,34 +161,30 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
     from matplotlib.colors import LinearSegmentedColormap
     import numpy as np
     if not plotparticles: # default. No plotparticles list passed, so plot all obits
-        orbits = sim.calculate_orbits()
+        ps = sim.particles[1:]
     else: 
-        orbits = []
-        for p in plotparticles:
-            try:
-                orbits.append(sim.particles[p].orbit)
-            except ParticleNotFound:
-                raise AttributeError("Particle in plotparticles list passed to OrbitPlot not found in the simulation.")
+        try:
+            ps = [sim.particles[i] for i in plotparticles]
+        except ParticleNotFound:
+            raise AttributeError("Particle in plotparticles list passed to OrbitPlot not found in the simulation.")
 
-    particles = sim.particles
     if lim is None:
         lim = 0.
-        for o in orbits:
-            if o.a>0.:
-                r = (1.+o.e)*o.a
+        for p in ps:
+            if p.a>0.:
+                r = (1.+p.e)*p.a
             else:
-                r = o.d
+                r = p.d
             if r>lim:
                 lim = r
         lim *= 1.15
     if limz is None:
-        z = [p.z for p in particles]
+        z = [p.z for p in ps]
         limz = 2.0*max(z)
         if limz > lim:
             limz = lim
         if limz <= 0.:
             limz = lim
-
 
     if axes[0]=="z":
         ax.set_xlim([-limz,limz])
@@ -143,92 +199,51 @@ def OrbitPlotOneSlice(sim, ax, lim=None, limz=None, Narc=100, color=False, peria
         if color == True:
             colors = [(1.,0.,0.),(0.,0.75,0.75),(0.75,0.,0.75),(0.75, 0.75, 0,),(0., 0., 0.),(0., 0., 1.),(0., 0.5, 0.)]
         if isinstance(color, str):
-            colors = [getcolor(color)]
+            colors = [get_color(color)]
         if isinstance(color, list):
             colors = []
             for c in color:
-                colors.append(getcolor(c))
+                colors.append(get_color(c))
     else:
-        colors = [(0.,0.,0.)]
-    
+        colors = ['black']
     coloriterator = cycle(colors)
 
-    ax.scatter(getattr(particles[0],axes[0]),getattr(particles[0],axes[1]), marker="*", s=35*lw, facecolor="black", edgecolor=None, zorder=3)
-    for i, o in enumerate(orbits):
+    coords = {'x':0, 'y':1, 'z':2}
+    axis0 = coords[axes[0]]
+    axis1 = coords[axes[1]]
+    
+    ax.scatter(getattr(sim.particles[0],axes[0]),getattr(sim.particles[0],axes[1]), marker="*", s=35*lw, facecolor="black", edgecolor=None, zorder=3)
+    
+    proj = {}
+    for p in ps:
+        ax.scatter(getattr(p,axes[0]), getattr(p,axes[1]), s=25*lw, facecolor="black", edgecolor=None, zorder=3)
         colori = next(coloriterator)
-        primary = sim.calculate_com(last=i)
-        pp = Particle(a=o.a, f=o.f, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-        ax.scatter(getattr(pp,axes[0]), getattr(pp,axes[1]), s=25*lw, facecolor="black", edgecolor=None, zorder=3)
-        if o.a>0.: # bound orbit
-            segments = np.zeros((Narc,2,2))
-            if show_orbit:
-                phase = np.linspace(0,2.*np.pi,Narc)
-                for j,ph in enumerate(phase):
-                    newp = Particle(a=o.a, f=o.f+ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                    segments[j][1]=xy
-                    segments[(j+1)%Narc][0]=xy
-            cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
-                     'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
-                     'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
-            if trails:
-                cdict['alpha'] = ((0.,0.,0.),(1.,1.,1.))
-            individual_cm = LinearSegmentedColormap('indv1', cdict)
-            lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            if show_orbit:
-                lc.set_array(phase)
-            ax.add_collection(lc)
-        else:     # unbound orbit.  Step in M rather than f, since for hyperbolic orbits f stays near lim, and jumps to -f at peri
-            t_cross = 4.*o.d/o.v # rough time to cross display box
-            
-            lim_phase = abs(o.n)*t_cross # M = nt, n is negative
-            segments = np.zeros((Narc,2,2))
-            if show_orbit:
-                phase = np.linspace(-lim_phase+o.M,o.M,Narc)
-                for j,ph in enumerate(phase):
-                    newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                    segments[j][1]=xy
-                    if j+1<Narc:
-                       segments[j+1][0]=xy
-                    if j==0:
-                       segments[j][0]=xy
-            cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
-                     'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
-                     'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
-            if trails:
-                cdict['alpha'] = ((0.,0.,0.),(1.,1.,1.))
-            individual_cm = LinearSegmentedColormap('indv1', cdict)
-            lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            if show_orbit:
-                lc.set_array(phase)
-            ax.add_collection(lc)
-            
-            segments = np.zeros((Narc,2,2))
-            if show_orbit:
-                phase = np.linspace(o.M,o.M+lim_phase,Narc)
-                for j,ph in enumerate(phase):
-                    newp = Particle(a=o.a, M=ph, inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
-                    xy = [getattr(newp,axes[0]), getattr(newp,axes[1])]
-                    segments[j][1]=xy
-                    if j+1<Narc:
-                       segments[j+1][0]=xy
-                    if j==0:
-                       segments[j][0]=xy
-            cdict = {'red': ((0.,colori[0],colori[0]),(1.,colori[0],colori[0])),
-                     'green': ((0.,colori[1],colori[1]),(1.,colori[1],colori[1])),
-                     'blue': ((0.,colori[2],colori[2]),(1.,colori[2],colori[2]))}
-            if trails:
-                cdict['alpha'] = ((0.,0.2,0.2),(1.,0.2,0.2))
-            individual_cm = LinearSegmentedColormap('indv1', cdict)
-            lc = LineCollection(segments, cmap=individual_cm, linewidth=lw)
-            if show_orbit:
-                lc.set_array(phase)
-            ax.add_collection(lc)
-        
-        
+       
+        if show_orbit is True:
+            alpha_final = 0. if trails is True else 1. # fade to 0 with trails
+
+            hyperbolic = p.a < 0. # Boolean for whether orbit is hyperbolic
+            if hyperbolic is False:
+                o = np.array(p.sample_orbit())
+                proj['x'],proj['y'],proj['z'] = [o[:,i] for i in range(3)]
+                lc = fading_line(proj[axes[0]], proj[axes[1]], colori, alpha_final=alpha_final, lw=lw)
+                ax.add_collection(lc)
+            else:
+                o = np.array(p.sample_orbit(useTrueAnomaly=False))
+                # true anomaly stays close to limiting value and switches quickly at pericenter for hyperbolic orbit, so use mean anomaly
+                proj['x'],proj['y'],proj['z'] = [o[:,i] for i in range(3)]
+                lc = fading_line(proj[axes[0]], proj[axes[1]], colori, alpha_final=alpha_final, lw=lw)
+                ax.add_collection(lc)
+          
+                alpha = 0.2 if trails is True else 1.
+                o = np.array(p.sample_orbit(trailing=False, useTrueAnomaly=False))
+                proj['x'],proj['y'],proj['z'] = [o[:,i] for i in range(3)]
+                lc = fading_line(proj[axes[0]], proj[axes[1]], colori, alpha_initial=alpha, alpha_final=alpha, lw=lw)
+                ax.add_collection(lc)
+
         if periastron:
-            newp = Particle(a=o.a, f=0., inc=o.inc, omega=o.omega, Omega=o.Omega, e=o.e, m=particles[i+1].m, primary=primary, simulation=sim)
+            primary = p.jacobi_com
+            newp = Particle(a=p.a, f=0., inc=p.inc, omega=p.omega, Omega=p.Omega, e=p.e, m=p.m, primary=primary, simulation=sim)
             ax.plot([getattr(primary,axes[0]), getattr(newp,axes[0])], [getattr(primary,axes[1]), getattr(newp,axes[1])], linestyle="dotted", c=colori, zorder=1, lw=lw)
             ax.scatter([getattr(newp,axes[0])],[getattr(newp,axes[1])], marker="o", s=5.*lw, facecolor="none", edgecolor=colori, zorder=1)
 

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1136,6 +1136,8 @@ class Simulation(Structure):
         if primary is None:
             jacobi = True
             primary = _particles_tmp[0]
+        else:
+            jacobi = False
 
         clibrebound.reb_get_com_of_pair.restype = Particle
         for i in range(1,self.N_real):

--- a/rebound/tests/test_simulation.py
+++ b/rebound/tests/test_simulation.py
@@ -97,12 +97,12 @@ class TestSimulation(unittest.TestCase):
         self.assertAlmostEqual(orbits[0].e,0.01,delta=1e-15)
         self.assertAlmostEqual(orbits[0].omega,0.02,delta=1e-12)
         self.assertAlmostEqual(orbits[0].inc,0.1,delta=1e-15)
-        orbits = self.sim.calculate_orbits(heliocentric=True)
+        orbits = self.sim.calculate_orbits(primary=self.sim.particles[0])
         self.assertAlmostEqual(orbits[0].a,1.,delta=1e-15)
         self.assertAlmostEqual(orbits[0].e,0.01,delta=1e-15)
         self.assertAlmostEqual(orbits[0].omega,0.02,delta=1e-12)
         self.assertAlmostEqual(orbits[0].inc,0.1,delta=1e-15)
-        orbits = self.sim.calculate_orbits(barycentric=True)
+        orbits = self.sim.calculate_orbits(primary=self.sim.calculate_com())
         self.assertAlmostEqual(orbits[0].a,1.,delta=1e-2)
         
     def test_com(self):


### PR DESCRIPTION
After a couple iterations, I think I've broken out the essential functionality. It involved changing some of the logic around, but I've gone through it a couple times, plotted with the various permutations of the flags, and double-checked that OrbitPlot.ipynb renders the same plots as before with the new code. Made two helper functions with various options and put all the logic into OrbitPlot to replicate old behavior and keywords. Might be helpful to see first how these helper functions can be used to make custom plots:

[https://github.com/dtamayo/systemsounds/blob/voiceover/projects/trappistvoiceover.ipynb](https://github.com/dtamayo/systemsounds/blob/voiceover/projects/trappistvoiceover.ipynb)

- Particle class now has a sample_orbit function that gives you back a list of xyz positions along the orbit. You choose Npts, how long to sample (defaults to reasonable values), and whether to sample in true or mean anomaly (OrbitPlot chooses for you based on whether hyperbolic like before)

- made it return a list rather than numpy array to keep particle.py numpy free

- I thought it made sense as a method on the Particle class since it's just giving you back numbers like all the orbital element properties

- fading_line just takes a list (or np array) and gives back a line collection linearly varying alpha

- made it accept **kwargs so it can take anything you want to pass that you could pass line collection