### PR TITLE
Realloc changes

### DIFF
--- a/src/collision.c
+++ b/src/collision.c
@@ -98,7 +98,7 @@ void reb_collision_search(struct reb_simulation* const r){
 						// Add particles to collision array.
 						if (r->collisions_allocatedN<=collisions_N){
 							// Allocate memory if there is no space in array.
-							// Doing it in chunks of 32 to avoid having to do it too often.
+							// Init to 32 if no space has been allocated yet, otherwise double it.
 							r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
 							r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
 						}
@@ -143,7 +143,7 @@ void reb_collision_search(struct reb_simulation* const r){
                         // Add particles to collision array.
                         if (r->collisions_allocatedN<=collisions_N){
                             // Allocate memory if there is no space in array.
-                            // Doing it in chunks of 32 to avoid having to do it too often.
+                            // Init to 32 if no space has been allocated yet, otherwise double it.
                             r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
                             r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
                         }
@@ -211,7 +211,7 @@ void reb_collision_search(struct reb_simulation* const r){
                     // Add particles to collision array.
                     if (r->collisions_allocatedN<=collisions_N){
                         // Allocate memory if there is no space in array.
-                        // Doing it in chunks of 32 to avoid having to do it too often.
+                        // Init to 32 if no space has been allocated yet, otherwise double it.
                         r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
                         r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
                     }
@@ -438,6 +438,7 @@ static void reb_tree_get_nearest_neighbour_in_cell(struct reb_simulation* const 
 #pragma omp critical
 			{
 				if (r->collisions_allocatedN<=(*collisions_N)){
+					// Init to 32 if no space has been allocated yet, otherwise double it.
 					r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
 					r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
 				}

--- a/src/collision.c
+++ b/src/collision.c
@@ -99,7 +99,7 @@ void reb_collision_search(struct reb_simulation* const r){
 						if (r->collisions_allocatedN<=collisions_N){
 							// Allocate memory if there is no space in array.
 							// Doing it in chunks of 32 to avoid having to do it too often.
-							r->collisions_allocatedN += 32;
+							r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
 							r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
 						}
 						r->collisions[collisions_N].p1 = i;
@@ -144,7 +144,7 @@ void reb_collision_search(struct reb_simulation* const r){
                         if (r->collisions_allocatedN<=collisions_N){
                             // Allocate memory if there is no space in array.
                             // Doing it in chunks of 32 to avoid having to do it too often.
-                            r->collisions_allocatedN += 32;
+                            r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
                             r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
                         }
                         r->collisions[collisions_N].p1 = i;
@@ -212,7 +212,7 @@ void reb_collision_search(struct reb_simulation* const r){
                     if (r->collisions_allocatedN<=collisions_N){
                         // Allocate memory if there is no space in array.
                         // Doing it in chunks of 32 to avoid having to do it too often.
-                        r->collisions_allocatedN += 32;
+                        r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
                         r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
                     }
                     r->collisions[collisions_N].p1 = 0;
@@ -438,7 +438,7 @@ static void reb_tree_get_nearest_neighbour_in_cell(struct reb_simulation* const 
 #pragma omp critical
 			{
 				if (r->collisions_allocatedN<=(*collisions_N)){
-					r->collisions_allocatedN += 32;
+					r->collisions_allocatedN = r->collisions_allocatedN ? r->collisions_allocatedN * 2 : 32;
 					r->collisions = realloc(r->collisions,sizeof(struct reb_collision)*r->collisions_allocatedN);
 				}
 				r->collisions[(*collisions_N)] = *collision_nearest;

--- a/src/particle.c
+++ b/src/particle.c
@@ -51,7 +51,7 @@ static void reb_add_local(struct reb_simulation* const r, struct reb_particle pt
 		return;
 	}
 	while (r->allocatedN<=r->N){
-		r->allocatedN += 128;
+		r->allocatedN = r->allocatedN ? r->allocatedN * 2 : 128;
 		r->particles = realloc(r->particles,sizeof(struct reb_particle)*r->allocatedN);
 	}
 
@@ -157,7 +157,7 @@ static void reb_update_particle_lookup_table(struct reb_simulation* const r){
     int zerohash = -1;
     for(int i=0; i<r->N; i++){
         if(N_hash >= r->allocatedN_lookup){
-            r->allocatedN_lookup += 128;
+            r->allocatedN_lookup = r->allocatedN_lookup ? r->allocatedN_lookup * 2 : 128;
             r->particle_lookup_table = realloc(r->particle_lookup_table, sizeof(struct reb_hash_pointer_pair)*r->allocatedN_lookup);
         }
         if(particles[i].hash == 0){ // default hash (0) special case


### PR DESCRIPTION
I noticed that simulations with lots of collisions tend to slow down over time. It seems it might be due to the fact that certain arrays related to collisions, when full, are reallocated to a size which is larger than the old size by a constant amount. Thus, as the number of total collisions increases, the reallocation becomes increasingly more expensive.

This PR changes the use of ``realloc()`` in two files so that reallocations double the original size. This results in a noticeable performance improvement on simulations with many collisions.