### PR TITLE
Raise

### DIFF
--- a/examples/bouncing_balls/problem.c
+++ b/examples/bouncing_balls/problem.c
@@ -11,33 +11,33 @@
 #include "rebound.h"
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->gravity	= REB_GRAVITY_BASIC;
-	r->collision	= REB_COLLISION_DIRECT;
-	r->collision_resolve = reb_collision_resolve_hardsphere;
-	r->usleep	= 1000;			// Slow down integration (for visualization only)
-	r->dt = 1e-2;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->gravity    = REB_GRAVITY_BASIC;
+    r->collision    = REB_COLLISION_DIRECT;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
+    r->usleep    = 1000;            // Slow down integration (for visualization only)
+    r->dt = 1e-2;
 
-	reb_configure_box(r, 3.0, 1, 1, 1);
-	
-	// Initial conditions
-	{
-		struct reb_particle p = {0};
-		p.x  = 1; p.y  = 1; p.z  = 1;
-		p.m  = 1;
-		p.r  = 0.1;
-		reb_add(r, p);
-	}
-	{
-		struct reb_particle p = {0};
-		p.x  = -1; p.y  = -1; p.z  = -1;
-		p.m  = 1;
-		p.r  = 0.1;
-		reb_add(r, p);
-	}
+    reb_configure_box(r, 3.0, 1, 1, 1);
+    
+    // Initial conditions
+    {
+        struct reb_particle p = {0};
+        p.x  = 1; p.y  = 1; p.z  = 1;
+        p.m  = 1;
+        p.r  = 0.1;
+        reb_add(r, p);
+    }
+    {
+        struct reb_particle p = {0};
+        p.x  = -1; p.y  = -1; p.z  = -1;
+        p.m  = 1;
+        p.r  = 0.1;
+        reb_add(r, p);
+    }
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }
 

--- a/examples/bouncing_balls/problem.c
+++ b/examples/bouncing_balls/problem.c
@@ -16,6 +16,7 @@ int main(int argc, char* argv[]){
 	r->integrator	= REB_INTEGRATOR_LEAPFROG;
 	r->gravity	= REB_GRAVITY_BASIC;
 	r->collision	= REB_COLLISION_DIRECT;
+	r->collision_resolve = reb_collision_resolve_hardsphere;
 	r->usleep	= 1000;			// Slow down integration (for visualization only)
 	r->dt = 1e-2;
 

--- a/examples/bouncing_balls_corners/problem.c
+++ b/examples/bouncing_balls_corners/problem.c
@@ -18,6 +18,7 @@ int main(int argc, char* argv[]){
 	r->integrator	= REB_INTEGRATOR_LEAPFROG;
 	r->gravity	= REB_GRAVITY_BASIC;
 	r->collision	= REB_COLLISION_TREE;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	r->dt 		= 1e-3;
 	r->boundary	= REB_BOUNDARY_PERIODIC;
 	r->usleep	= 1000;			// Slow down integration (for visualization only)

--- a/examples/bouncing_balls_corners/problem.c
+++ b/examples/bouncing_balls_corners/problem.c
@@ -13,77 +13,77 @@
 
 extern double coefficient_of_restitution; 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->gravity	= REB_GRAVITY_BASIC;
-	r->collision	= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->gravity    = REB_GRAVITY_BASIC;
+    r->collision    = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	r->dt 		= 1e-3;
-	r->boundary	= REB_BOUNDARY_PERIODIC;
-	r->usleep	= 1000;			// Slow down integration (for visualization only)
-	reb_configure_box(r,3.,1,1,1);
-	
-	// Initial conditions
-	int problem_id = 1;
-	if (argc>1){			
-		problem_id = atoi(argv[1]);
-	}
-	struct reb_particle p = {0};
+    r->dt         = 1e-3;
+    r->boundary    = REB_BOUNDARY_PERIODIC;
+    r->usleep    = 1000;            // Slow down integration (for visualization only)
+    reb_configure_box(r,3.,1,1,1);
+    
+    // Initial conditions
+    int problem_id = 1;
+    if (argc>1){            
+        problem_id = atoi(argv[1]);
+    }
+    struct reb_particle p = {0};
 
-	switch (problem_id){
-		case 1: // Multiple instantaneous collisions across boundaries
-			r->nghostx = 1; r->nghosty = 1; r->nghostz = 0;
-			p.x  = 1; p.y  = 1; p.z  = 0;
-			p.m  = 1;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = -1; p.y  = -1; p.z  = 0;
-			p.m  = 1;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = 1; p.y  = -1; p.z  = 0;
-			p.m  = 1;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = -1; p.y  = 1; p.z  = 0;
-			p.m  = 1;
-			p.r  = 0.1;
-			reb_add(r,p);
-			break;
-		case 2: // Multiple instantaneous collisions with different sizes
-			r->nghostx = 0; r->nghosty = 0; r->nghostz = 0;
-			p.x  = 0; p.y  = 0; p.z  = 0;
-			p.m  = 1;
-			p.r  = 0.5;
-			reb_add(r,p);
-			p.x  = 1; p.y  = 1; p.z  = 0;
-			p.m  = 0.008;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = -1; p.y  = -1; p.z  = 0;
-			p.m  = 0.008;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = 1; p.y  = -1; p.z  = 0;
-			p.m  = 0.008;
-			p.r  = 0.3;
-			reb_add(r,p);
-			p.x  = -1; p.y  = 1; p.z  = 0;
-			p.m  = 0.008;
-			p.r  = 0.2;
-			reb_add(r,p);
-			p.x  = 0;  p.y  = 0; p.z  = 1.3;
-			p.m  = 0.008;
-			p.r  = 0.1;
-			reb_add(r,p);
-			p.x  = 0;  p.y  = 0; p.z  =-1.3;
-			p.m  = 0.008;
-			p.r  = 0.05;
-			reb_add(r,p);
-			break;
-	}
+    switch (problem_id){
+        case 1: // Multiple instantaneous collisions across boundaries
+            r->nghostx = 1; r->nghosty = 1; r->nghostz = 0;
+            p.x  = 1; p.y  = 1; p.z  = 0;
+            p.m  = 1;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = -1; p.y  = -1; p.z  = 0;
+            p.m  = 1;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = 1; p.y  = -1; p.z  = 0;
+            p.m  = 1;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = -1; p.y  = 1; p.z  = 0;
+            p.m  = 1;
+            p.r  = 0.1;
+            reb_add(r,p);
+            break;
+        case 2: // Multiple instantaneous collisions with different sizes
+            r->nghostx = 0; r->nghosty = 0; r->nghostz = 0;
+            p.x  = 0; p.y  = 0; p.z  = 0;
+            p.m  = 1;
+            p.r  = 0.5;
+            reb_add(r,p);
+            p.x  = 1; p.y  = 1; p.z  = 0;
+            p.m  = 0.008;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = -1; p.y  = -1; p.z  = 0;
+            p.m  = 0.008;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = 1; p.y  = -1; p.z  = 0;
+            p.m  = 0.008;
+            p.r  = 0.3;
+            reb_add(r,p);
+            p.x  = -1; p.y  = 1; p.z  = 0;
+            p.m  = 0.008;
+            p.r  = 0.2;
+            reb_add(r,p);
+            p.x  = 0;  p.y  = 0; p.z  = 1.3;
+            p.m  = 0.008;
+            p.r  = 0.1;
+            reb_add(r,p);
+            p.x  = 0;  p.y  = 0; p.z  =-1.3;
+            p.m  = 0.008;
+            p.r  = 0.05;
+            reb_add(r,p);
+            break;
+    }
 
-	reb_integrate(r,INFINITY);
+    reb_integrate(r,INFINITY);
 }
 

--- a/examples/bouncing_string/problem.c
+++ b/examples/bouncing_string/problem.c
@@ -18,6 +18,7 @@ int main(int argc, char* argv[]){
 	r->integrator		= REB_INTEGRATOR_LEAPFROG;
 	r->boundary		= REB_BOUNDARY_PERIODIC;
 	r->collision		= REB_COLLISION_DIRECT;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	r->gravity		= REB_GRAVITY_NONE;
 	r->usleep		= 5000;			// Slow down integration (for visualization only)
 	

--- a/examples/bouncing_string/problem.c
+++ b/examples/bouncing_string/problem.c
@@ -12,32 +12,32 @@
 #include "rebound.h"
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* const r = reb_create_simulation();
-	// Setup constants
-	r->dt 			= 1e-3;
-	r->integrator		= REB_INTEGRATOR_LEAPFROG;
-	r->boundary		= REB_BOUNDARY_PERIODIC;
-	r->collision		= REB_COLLISION_DIRECT;
+    struct reb_simulation* const r = reb_create_simulation();
+    // Setup constants
+    r->dt             = 1e-3;
+    r->integrator        = REB_INTEGRATOR_LEAPFROG;
+    r->boundary        = REB_BOUNDARY_PERIODIC;
+    r->collision        = REB_COLLISION_DIRECT;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	r->gravity		= REB_GRAVITY_NONE;
-	r->usleep		= 5000;			// Slow down integration (for visualization only)
-	
-	reb_configure_box(r,10.,3,1,1);  // boxsize 10., three root boxes in x direction, one in y and z
-	r->nghostx = 1; 
-	r->nghosty = 1; 
-	r->nghostz = 0;
+    r->gravity        = REB_GRAVITY_NONE;
+    r->usleep        = 5000;            // Slow down integration (for visualization only)
+    
+    reb_configure_box(r,10.,3,1,1);  // boxsize 10., three root boxes in x direction, one in y and z
+    r->nghostx = 1; 
+    r->nghosty = 1; 
+    r->nghostz = 0;
 
-	// Initial conditions
-	for(int i=0;i<10;i++){
-		struct reb_particle p = {0};
-		p.x  = -r->boxsize.x/2.+r->boxsize.x*(double)i/10.; p.y  = 0; p.z  = 0;
-		p.m  = 1;
-		p.r  = 1;
-		reb_add(r, p);
-	}
+    // Initial conditions
+    for(int i=0;i<10;i++){
+        struct reb_particle p = {0};
+        p.x  = -r->boxsize.x/2.+r->boxsize.x*(double)i/10.; p.y  = 0; p.z  = 0;
+        p.m  = 1;
+        p.r  = 1;
+        reb_add(r, p);
+    }
 
-	// Give one particle a kick
-	r->particles[0].vx = 20;
+    // Give one particle a kick
+    r->particles[0].vx = 20;
 
-	reb_integrate(r,INFINITY);
+    reb_integrate(r,INFINITY);
 }

--- a/examples/circumplanetarydust/problem.c
+++ b/examples/circumplanetarydust/problem.c
@@ -18,109 +18,109 @@
 void force_radiation(struct reb_simulation* r);
 void heartbeat(struct reb_simulation* r);
 
-double betaparticles = 0.01; 	// Beta parameter, defined as the ratio of radiation pressure over gravity.
+double betaparticles = 0.01;     // Beta parameter, defined as the ratio of radiation pressure over gravity.
 double tmax = 1e6;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->integrator		= REB_INTEGRATOR_IAS15;
-	r->dt 			= 1e-4;	// Initial timestep.
-	r->N_active		= 2; 	// Only the star and the planet are massive.
-	r->additional_forces 	= force_radiation;
-	r->heartbeat	 	= heartbeat;
-	r->usleep		= 5000;			// Slow down integration (for visualization only)
-	
-	// Star
-	struct reb_particle star = {0};
-	star.m  = 1.;
-	reb_add(r, star);
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->integrator        = REB_INTEGRATOR_IAS15;
+    r->dt             = 1e-4;    // Initial timestep.
+    r->N_active        = 2;     // Only the star and the planet are massive.
+    r->additional_forces     = force_radiation;
+    r->heartbeat         = heartbeat;
+    r->usleep        = 5000;            // Slow down integration (for visualization only)
+    
+    // Star
+    struct reb_particle star = {0};
+    star.m  = 1.;
+    reb_add(r, star);
 
 
-	// planet 
-	struct reb_particle planet = {0};
-	planet.m  = 1e-3;
-	planet.x  = 1; 
-	planet.vy = sqrt(r->G*(star.m+planet.m)/planet.x);
-	reb_add(r, planet);
-	
-	
+    // planet 
+    struct reb_particle planet = {0};
+    planet.m  = 1e-3;
+    planet.x  = 1; 
+    planet.vy = sqrt(r->G*(star.m+planet.m)/planet.x);
+    reb_add(r, planet);
+    
+    
 
-	// Dust particles
-	while(r->N<3){ 	// Three particles in total (star, planet, dust particle) 
-		struct reb_particle p = {0}; 
-		p.m  = 0;		// massless
-		double _r = 0.001;	// distance from planet planet
-		double v = sqrt(r->G*planet.m/_r);
-		p.x  = _r;
-		p.vy = v;
-		p.x += planet.x; 	p.y += planet.y; 	p.z += planet.z;
-		p.vx += planet.vx; 	p.vy += planet.vy; 	p.vz += planet.vz;
-		reb_add(r, p); 
-	}
-	
-	reb_move_to_com(r);
+    // Dust particles
+    while(r->N<3){     // Three particles in total (star, planet, dust particle) 
+        struct reb_particle p = {0}; 
+        p.m  = 0;        // massless
+        double _r = 0.001;    // distance from planet planet
+        double v = sqrt(r->G*planet.m/_r);
+        p.x  = _r;
+        p.vy = v;
+        p.x += planet.x;     p.y += planet.y;     p.z += planet.z;
+        p.vx += planet.vx;     p.vy += planet.vy;     p.vz += planet.vz;
+        reb_add(r, p); 
+    }
+    
+    reb_move_to_com(r);
 
-	system("rm -v a.txt");	
+    system("rm -v a.txt");    
 
-	reb_integrate(r, tmax);
+    reb_integrate(r, tmax);
 }
 
 void force_radiation(struct reb_simulation* r){
-	struct reb_particle* particles = r->particles;
-	const struct reb_particle star = particles[0];			// cache
-	const int N = r->N;
-	const double G = r->G;
+    struct reb_particle* particles = r->particles;
+    const struct reb_particle star = particles[0];            // cache
+    const int N = r->N;
+    const double G = r->G;
 #pragma omp parallel for
-	for (int i=0;i<N;i++){
-		const struct reb_particle p = particles[i]; 			// cache
-		if (p.m!=0.) continue; 						// Only dust particles feel radiation forces
-		const double prx  = p.x-star.x;
-		const double pry  = p.y-star.y;
-		const double prz  = p.z-star.z;
-		const double pr   = sqrt(prx*prx + pry*pry + prz*prz); 	// distance relative to star
-		const double prvx = p.vx-star.vx;
-		const double prvy = p.vy-star.vy;
-		const double prvz = p.vz-star.vz;
+    for (int i=0;i<N;i++){
+        const struct reb_particle p = particles[i];             // cache
+        if (p.m!=0.) continue;                         // Only dust particles feel radiation forces
+        const double prx  = p.x-star.x;
+        const double pry  = p.y-star.y;
+        const double prz  = p.z-star.z;
+        const double pr   = sqrt(prx*prx + pry*pry + prz*prz);     // distance relative to star
+        const double prvx = p.vx-star.vx;
+        const double prvy = p.vy-star.vy;
+        const double prvz = p.vz-star.vz;
 
-		const double c 		= 1.006491504759635e+04; 		// speed of light.
-		const double rdot 	= (prvx*prx + prvy*pry + prvz*prz)/pr; 	// radial velocity relative to star
-		const double F_r 	= betaparticles*G*star.m/(pr*pr);
+        const double c         = 1.006491504759635e+04;         // speed of light.
+        const double rdot     = (prvx*prx + prvy*pry + prvz*prz)/pr;     // radial velocity relative to star
+        const double F_r     = betaparticles*G*star.m/(pr*pr);
 
-		// Equation (5) of Burns, Lamy, Soter (1979)
-		particles[i].ax += F_r*((1.-rdot/c)*prx/pr - prvx/c);
-		particles[i].ay += F_r*((1.-rdot/c)*pry/pr - prvy/c);
-		particles[i].az += F_r*((1.-rdot/c)*prz/pr - prvz/c);
-	}
+        // Equation (5) of Burns, Lamy, Soter (1979)
+        particles[i].ax += F_r*((1.-rdot/c)*prx/pr - prvx/c);
+        particles[i].ay += F_r*((1.-rdot/c)*pry/pr - prvy/c);
+        particles[i].az += F_r*((1.-rdot/c)*prz/pr - prvz/c);
+    }
 }
 
 void heartbeat(struct reb_simulation* r){
-	if(reb_output_check(r, M_PI*2.)){
-		reb_output_timing(r, tmax);
-	}
-	if(reb_output_check(r, M_PI*2.)){ // output every year
-		FILE* f = fopen("a.txt","a");
-		const struct reb_particle* particles = r->particles;
-		const struct reb_particle planet = particles[1];
-		const double G = r->G;
-		const double t = r->t;
-		const int N = r->N;
-		for (int i=2;i<N;i++){
-			const struct reb_particle p = particles[i]; 
-			const double prx  = p.x-planet.x;
-			const double pry  = p.y-planet.y;
-			const double prz  = p.z-planet.z;
-			const double pr   = sqrt(prx*prx + pry*pry + prz*prz); 	// distance relative to star
-			
-			const double pvx  = p.vx-planet.vx;
-			const double pvy  = p.vy-planet.vy;
-			const double pvz  = p.vz-planet.vz;
-			const double pv   = sqrt(pvx*pvx + pvy*pvy + pvz*pvz); 	// distance relative to star
-			
-			const double a = -G*planet.m/( pv*pv - 2.*G*planet.m/pr );			// semi major axis
-			
-			fprintf(f,"%e\t%e\n",t,a);
-		}
-		fclose(f);
-	}
+    if(reb_output_check(r, M_PI*2.)){
+        reb_output_timing(r, tmax);
+    }
+    if(reb_output_check(r, M_PI*2.)){ // output every year
+        FILE* f = fopen("a.txt","a");
+        const struct reb_particle* particles = r->particles;
+        const struct reb_particle planet = particles[1];
+        const double G = r->G;
+        const double t = r->t;
+        const int N = r->N;
+        for (int i=2;i<N;i++){
+            const struct reb_particle p = particles[i]; 
+            const double prx  = p.x-planet.x;
+            const double pry  = p.y-planet.y;
+            const double prz  = p.z-planet.z;
+            const double pr   = sqrt(prx*prx + pry*pry + prz*prz);     // distance relative to star
+            
+            const double pvx  = p.vx-planet.vx;
+            const double pvy  = p.vy-planet.vy;
+            const double pvz  = p.vz-planet.vz;
+            const double pv   = sqrt(pvx*pvx + pvy*pvy + pvz*pvz);     // distance relative to star
+            
+            const double a = -G*planet.m/( pv*pv - 2.*G*planet.m/pr );            // semi major axis
+            
+            fprintf(f,"%e\t%e\n",t,a);
+        }
+        fclose(f);
+    }
 }

--- a/examples/closeencounter/problem.c
+++ b/examples/closeencounter/problem.c
@@ -17,34 +17,34 @@
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	r->dt 		= 0.01*2.*M_PI;		// initial timestep
-	r->integrator 	= REB_INTEGRATOR_IAS15;
-	r->heartbeat  	= heartbeat;
-	r->usleep	= 10000;		// Slow down integration (for visualization only)
+    struct reb_simulation* r = reb_create_simulation();
+    r->dt         = 0.01*2.*M_PI;        // initial timestep
+    r->integrator     = REB_INTEGRATOR_IAS15;
+    r->heartbeat      = heartbeat;
+    r->usleep    = 10000;        // Slow down integration (for visualization only)
 
-	// Add star
-	struct reb_particle star = {0};
-	star.m = 1;
-	reb_add(r, star);
-	
-	// Add planets
-	int N_planets = 7;
-	for (int i=0;i<N_planets;i++){
-		double a = 1.+(double)i/(double)(N_planets-1);		// semi major axis
-		double v = sqrt(1./a); 					// velocity (circular orbit)
-		struct reb_particle planet = {0};
-		planet.m = 1e-4; 
-		planet.x = a; 
-		planet.vy = v; 
-		reb_add(r, planet); 
-	}
-	reb_move_to_com(r);		// This makes sure the planetary systems stays within the computational domain and doesn't drift.
-	reb_integrate(r, INFINITY);
+    // Add star
+    struct reb_particle star = {0};
+    star.m = 1;
+    reb_add(r, star);
+    
+    // Add planets
+    int N_planets = 7;
+    for (int i=0;i<N_planets;i++){
+        double a = 1.+(double)i/(double)(N_planets-1);        // semi major axis
+        double v = sqrt(1./a);                     // velocity (circular orbit)
+        struct reb_particle planet = {0};
+        planet.m = 1e-4; 
+        planet.x = a; 
+        planet.vy = v; 
+        reb_add(r, planet); 
+    }
+    reb_move_to_com(r);        // This makes sure the planetary systems stays within the computational domain and doesn't drift.
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.*2.*M_PI)){  
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 10.*2.*M_PI)){  
+        reb_output_timing(r, 0);
+    }
 }

--- a/examples/closeencounter_hybrid/problem.c
+++ b/examples/closeencounter_hybrid/problem.c
@@ -16,44 +16,44 @@ void heartbeat(struct reb_simulation* r);
 double e_init; // initial energy
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	r->dt = 0.0012*2.*M_PI;				// initial timestep
-	r->integrator = REB_INTEGRATOR_MERCURIUS;
-	r->heartbeat  = heartbeat;
+    struct reb_simulation* r = reb_create_simulation();
+    r->dt = 0.0012*2.*M_PI;                // initial timestep
+    r->integrator = REB_INTEGRATOR_MERCURIUS;
+    r->heartbeat  = heartbeat;
 
-	struct reb_particle star = {0};
-	star.m = 1;
-	reb_add(r, star);
-	
-	// Add planets
-	int N_planets = 3;
-	for (int i=0;i<N_planets;i++){
-		double a = 1.+.1*(double)i;		// semi major axis
-		double v = sqrt(1./a); 			// velocity (circular orbit)
-		struct reb_particle planet = {0};
-		planet.m = 2e-5; 
-		planet.x = a; 
-		planet.vy = v;
-		reb_add(r, planet); 
-	}
-	reb_move_to_com(r);				// This makes sure the planetary systems stays within the computational domain and doesn't drift.
-	e_init = reb_tools_energy(r);
-	system("rm -rf energy.txt");
+    struct reb_particle star = {0};
+    star.m = 1;
+    reb_add(r, star);
+    
+    // Add planets
+    int N_planets = 3;
+    for (int i=0;i<N_planets;i++){
+        double a = 1.+.1*(double)i;        // semi major axis
+        double v = sqrt(1./a);             // velocity (circular orbit)
+        struct reb_particle planet = {0};
+        planet.m = 2e-5; 
+        planet.x = a; 
+        planet.vy = v;
+        reb_add(r, planet); 
+    }
+    reb_move_to_com(r);                // This makes sure the planetary systems stays within the computational domain and doesn't drift.
+    e_init = reb_tools_energy(r);
+    system("rm -rf energy.txt");
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.*2.*M_PI)){  
-		reb_output_timing(r, 0);
-	}
-	if (reb_output_check(r, 2.*M_PI)){  
+    if (reb_output_check(r, 10.*2.*M_PI)){  
+        reb_output_timing(r, 0);
+    }
+    if (reb_output_check(r, 2.*M_PI)){  
         // Once per year, output the relative energy error to a text file
-		FILE* f = fopen("energy.txt","a");
-		reb_integrator_synchronize(r);
-		double e = reb_tools_energy(r);
-		fprintf(f,"%e %e\n",r->t, fabs((e-e_init)/e_init));
-		fclose(f);
-	}
+        FILE* f = fopen("energy.txt","a");
+        reb_integrator_synchronize(r);
+        double e = reb_tools_energy(r);
+        fprintf(f,"%e %e\n",r->t, fabs((e-e_init)/e_init));
+        fclose(f);
+    }
 }
 

--- a/examples/closeencounter_record/problem.c
+++ b/examples/closeencounter_record/problem.c
@@ -16,65 +16,65 @@
 #include <math.h>
 #include "rebound.h"
 
-// Define our own collision resolve function, which will only record collisions but not change any of the particles.		
+// Define our own collision resolve function, which will only record collisions but not change any of the particles.        
 int collision_record_only(struct reb_simulation* const r, struct reb_collision c){
-	double delta_t = 2.*M_PI; 	
-	struct reb_particle* particles = r->particles;
-	const double t = r->t;
+    double delta_t = 2.*M_PI;     
+    struct reb_particle* particles = r->particles;
+    const double t = r->t;
 
-	// only record a maximum of one collision per year per particle
-	if ( particles[c.p1].lastcollision+delta_t < t  &&  particles[c.p2].lastcollision+delta_t < t ){
-		particles[c.p1].lastcollision = t; 
-		particles[c.p2].lastcollision = t;
-		printf("\nCollision detected.\n");		
-		FILE* of = fopen("collisions.txt","a+");		// open file for collision output
-		fprintf(of, "%e\t", t);					// time
-		fprintf(of, "%e\t", (particles[c.p1].x+particles[c.p2].x)/2.);	// x position
-		fprintf(of, "%e\t", (particles[c.p1].y+particles[c.p2].y)/2.);	// y position
-		fprintf(of, "\n");
-		fclose(of);						// close file
-	}
+    // only record a maximum of one collision per year per particle
+    if ( particles[c.p1].lastcollision+delta_t < t  &&  particles[c.p2].lastcollision+delta_t < t ){
+        particles[c.p1].lastcollision = t; 
+        particles[c.p2].lastcollision = t;
+        printf("\nCollision detected.\n");        
+        FILE* of = fopen("collisions.txt","a+");        // open file for collision output
+        fprintf(of, "%e\t", t);                    // time
+        fprintf(of, "%e\t", (particles[c.p1].x+particles[c.p2].x)/2.);    // x position
+        fprintf(of, "%e\t", (particles[c.p1].y+particles[c.p2].y)/2.);    // y position
+        fprintf(of, "\n");
+        fclose(of);                        // close file
+    }
     return 0;
 }
 
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.*2.*M_PI)){  
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 10.*2.*M_PI)){  
+        reb_output_timing(r, 0);
+    }
 }
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	r->dt 			= 0.1*2.*M_PI;				// initial timestep
-	r->integrator 		= REB_INTEGRATOR_IAS15;
-	r->collision		= REB_COLLISION_DIRECT;
-	r->collision_resolve 	= collision_record_only;		// Set function pointer for collision recording.
-	r->heartbeat		= heartbeat;
-	r->usleep		= 10000;				// Slow down integration (for visualization only)
+    struct reb_simulation* r = reb_create_simulation();
+    r->dt             = 0.1*2.*M_PI;                // initial timestep
+    r->integrator         = REB_INTEGRATOR_IAS15;
+    r->collision        = REB_COLLISION_DIRECT;
+    r->collision_resolve     = collision_record_only;        // Set function pointer for collision recording.
+    r->heartbeat        = heartbeat;
+    r->usleep        = 10000;                // Slow down integration (for visualization only)
 
-	struct reb_particle star = {0};
-	star.m = 1;
-	star.r = 0;							// Star is pointmass
-	reb_add(r, star);
-	
-	// Add planets
-	int N_planets = 7;
-	for (int i=0; i<N_planets; i++){
-		double a = 1.+(double)i/(double)(N_planets-1);		// semi major axis
-		double v = sqrt(1./a); 					// velocity (circular orbit)
-		struct reb_particle planet = {0};
-		planet.m = 1e-4; 
-		double rhill = a * pow(planet.m/(3.*star.m),1./3.);	// Hill radius
-		planet.r = rhill;					// Set planet radius to hill radius 
-									// A collision is recorded when planets get within their hill radius
-									// The hill radius of the particles might change, so it should be recalculated after a while
-		planet.lastcollision = 0; 
-		planet.x = a;
-		planet.vy = v;
-		reb_add(r, planet); 
-	}
-	reb_move_to_com(r);				// This makes sure the planetary systems stays within the computational domain and doesn't drift.
+    struct reb_particle star = {0};
+    star.m = 1;
+    star.r = 0;                            // Star is pointmass
+    reb_add(r, star);
+    
+    // Add planets
+    int N_planets = 7;
+    for (int i=0; i<N_planets; i++){
+        double a = 1.+(double)i/(double)(N_planets-1);        // semi major axis
+        double v = sqrt(1./a);                     // velocity (circular orbit)
+        struct reb_particle planet = {0};
+        planet.m = 1e-4; 
+        double rhill = a * pow(planet.m/(3.*star.m),1./3.);    // Hill radius
+        planet.r = rhill;                    // Set planet radius to hill radius 
+                                    // A collision is recorded when planets get within their hill radius
+                                    // The hill radius of the particles might change, so it should be recalculated after a while
+        planet.lastcollision = 0; 
+        planet.x = a;
+        planet.vy = v;
+        reb_add(r, planet); 
+    }
+    reb_move_to_com(r);                // This makes sure the planetary systems stays within the computational domain and doesn't drift.
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }

--- a/examples/dragforce/problem.c
+++ b/examples/dragforce/problem.c
@@ -18,52 +18,52 @@ void heartbeat(struct reb_simulation* const r);
 double tmax = 40.;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->dt 			= 1e-4;		// initial timestep.
-	r->integrator		= REB_INTEGRATOR_IAS15;
-	r->gravity		= REB_GRAVITY_NONE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->dt             = 1e-4;        // initial timestep.
+    r->integrator        = REB_INTEGRATOR_IAS15;
+    r->gravity        = REB_GRAVITY_NONE;
 
-	// Setup callback function for velocity dependent forces.
-	r->additional_forces 	= additional_forces;
-	r->force_is_velocity_dependent = 1;
-	// Setup callback function for outputs.
-	r->heartbeat		= heartbeat;
-	r->usleep		= 10000;		// Slow down integration (for visualization only)
-	
-	struct reb_particle p = {0}; 
-	p.m  	= 0;	// massless
-	p.x 	= 1;
-	p.vx 	= -1;
-	reb_add(r, p); 
+    // Setup callback function for velocity dependent forces.
+    r->additional_forces     = additional_forces;
+    r->force_is_velocity_dependent = 1;
+    // Setup callback function for outputs.
+    r->heartbeat        = heartbeat;
+    r->usleep        = 10000;        // Slow down integration (for visualization only)
+    
+    struct reb_particle p = {0}; 
+    p.m      = 0;    // massless
+    p.x     = 1;
+    p.vx     = -1;
+    reb_add(r, p); 
 
-	// Delete previous output
-	system("rm -v r.txt");	
+    // Delete previous output
+    system("rm -v r.txt");    
 
-	// Do the integration
-	reb_integrate(r, tmax);
+    // Do the integration
+    reb_integrate(r, tmax);
 }
 
 void additional_forces(struct reb_simulation* const r){
-	// Simplest velocity dependent drag force.
-	double dragcoefficient = 1;
-	struct reb_particle* const particles = r->particles;
-	const int N = r->N;
-	for (int i=0;i<N;i++){
-		particles[i].ax = -dragcoefficient*particles[i].vx;
-		particles[i].ay = -dragcoefficient*particles[i].vy;
-		particles[i].az = -dragcoefficient*particles[i].vz;
-	}
+    // Simplest velocity dependent drag force.
+    double dragcoefficient = 1;
+    struct reb_particle* const particles = r->particles;
+    const int N = r->N;
+    for (int i=0;i<N;i++){
+        particles[i].ax = -dragcoefficient*particles[i].vx;
+        particles[i].ay = -dragcoefficient*particles[i].vy;
+        particles[i].az = -dragcoefficient*particles[i].vz;
+    }
 }
 
 void heartbeat(struct reb_simulation* const r){
-	// Output some information to the screen every 100th timestep
-	if(reb_output_check(r, 100.*r->dt)){
-		reb_output_timing(r, tmax);
-	}
-	// Output the particle position to a file every timestep.
-	const struct reb_particle* const particles = r->particles;
-	FILE* f = fopen("r.txt","a");
-	fprintf(f,"%e\t%e\t%e\n",r->t,particles[0].x, particles[1].vx);
-	fclose(f);
+    // Output some information to the screen every 100th timestep
+    if(reb_output_check(r, 100.*r->dt)){
+        reb_output_timing(r, tmax);
+    }
+    // Output the particle position to a file every timestep.
+    const struct reb_particle* const particles = r->particles;
+    FILE* f = fopen("r.txt","a");
+    fprintf(f,"%e\t%e\t%e\n",r->t,particles[0].x, particles[1].vx);
+    fclose(f);
 }

--- a/examples/eccentric_orbit/problem.c
+++ b/examples/eccentric_orbit/problem.c
@@ -16,42 +16,42 @@ double tmax;
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->G			= 1;		// Gravitational constant
-	r->integrator		= REB_INTEGRATOR_IAS15;
-	r->heartbeat		= heartbeat;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->G            = 1;        // Gravitational constant
+    r->integrator        = REB_INTEGRATOR_IAS15;
+    r->heartbeat        = heartbeat;
 
-	double e_testparticle 	= 1.-1e-7;	
-	double mass_scale	= 1.;		// Some integrators have problems when changing the mass scale, IAS15 does not. 
-	double size_scale	= 1;		// Some integrators have problems when changing the size scale, IAS15 does not.
+    double e_testparticle     = 1.-1e-7;    
+    double mass_scale    = 1.;        // Some integrators have problems when changing the mass scale, IAS15 does not. 
+    double size_scale    = 1;        // Some integrators have problems when changing the size scale, IAS15 does not.
 
-	struct reb_particle star = {0}; 
-	star.m  = mass_scale;
-	reb_add(r, star); 
-	
-	struct reb_particle planet; 
-	planet.m  = 0;
-	planet.x  = size_scale*(1.-e_testparticle); 
-	planet.vy = sqrt((1.+e_testparticle)/(1.-e_testparticle)*mass_scale/size_scale);
-	reb_add(r, planet); 
-	
-	reb_move_to_com(r);
-	
-	// initial timestep
-	r->dt 			= 1e-13*sqrt(size_scale*size_scale*size_scale/mass_scale); 
-	tmax			= 1e2*2.*M_PI*sqrt(size_scale*size_scale*size_scale/mass_scale);
+    struct reb_particle star = {0}; 
+    star.m  = mass_scale;
+    reb_add(r, star); 
+    
+    struct reb_particle planet; 
+    planet.m  = 0;
+    planet.x  = size_scale*(1.-e_testparticle); 
+    planet.vy = sqrt((1.+e_testparticle)/(1.-e_testparticle)*mass_scale/size_scale);
+    reb_add(r, planet); 
+    
+    reb_move_to_com(r);
+    
+    // initial timestep
+    r->dt             = 1e-13*sqrt(size_scale*size_scale*size_scale/mass_scale); 
+    tmax            = 1e2*2.*M_PI*sqrt(size_scale*size_scale*size_scale/mass_scale);
 
-	reb_integrate(r, tmax);	
+    reb_integrate(r, tmax);    
 }
 
 void heartbeat(struct reb_simulation* r){
-	if(reb_output_check(r,tmax/10000.)){		// outputs to the screen
-		reb_output_timing(r, tmax);
-	}
-	// Output the time and the current timestep. Plot it to see how IAS15 automatically reduces the timestep at pericentre. 
-	FILE* of = fopen("timestep.txt","a"); 
-	fprintf(of,"%e\t%e\t\n",r->t/tmax,r->dt/tmax);
-	fclose(of);
+    if(reb_output_check(r,tmax/10000.)){        // outputs to the screen
+        reb_output_timing(r, tmax);
+    }
+    // Output the time and the current timestep. Plot it to see how IAS15 automatically reduces the timestep at pericentre. 
+    FILE* of = fopen("timestep.txt","a"); 
+    fprintf(of,"%e\t%e\t\n",r->t/tmax,r->dt/tmax);
+    fclose(of);
 }
 

--- a/examples/granulardynamics/problem.c
+++ b/examples/granulardynamics/problem.c
@@ -17,127 +17,127 @@ void heartbeat(struct reb_simulation* r);
 int N_border;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->dt 			= 1e-1;	
-	r->gravity		= REB_GRAVITY_NONE;
-	r->integrator		= REB_INTEGRATOR_LEAPFROG;
-	r->collision		= REB_COLLISION_TREE;
-	r->boundary		= REB_BOUNDARY_PERIODIC;
-	// Override default collision handling to account for border particles
-	r->collision_resolve	 = collision_resolve_hardsphere_withborder;
-	r->heartbeat		= heartbeat;
-	reb_configure_box(r, 20., 1, 1, 4);
-	
-	r->nghostx = 1; r->nghosty = 1; r->nghostz = 0; 	
-	
-	double N_part 	= 0.00937*r->boxsize.x*r->boxsize.y*r->boxsize.z;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->dt             = 1e-1;    
+    r->gravity        = REB_GRAVITY_NONE;
+    r->integrator        = REB_INTEGRATOR_LEAPFROG;
+    r->collision        = REB_COLLISION_TREE;
+    r->boundary        = REB_BOUNDARY_PERIODIC;
+    // Override default collision handling to account for border particles
+    r->collision_resolve     = collision_resolve_hardsphere_withborder;
+    r->heartbeat        = heartbeat;
+    reb_configure_box(r, 20., 1, 1, 4);
+    
+    r->nghostx = 1; r->nghosty = 1; r->nghostz = 0;     
+    
+    double N_part     = 0.00937*r->boxsize.x*r->boxsize.y*r->boxsize.z;
 
-	// Add Border Particles
-	double radius 		= 1;
-	double mass		= 1;
-	double border_spacing_x = r->boxsize.x/(floor(r->boxsize.x/radius/2.)-1.);
-	double border_spacing_y = r->boxsize.y/(floor(r->boxsize.y/radius/2.)-1.);
-	struct reb_particle pt = {0};
-	pt.r 		= radius;
-	pt.m 		= mass;
-	pt.hash		= 1;
-	for(double x = -r->boxsize.x/2.; x<r->boxsize.x/2.-border_spacing_x/2.;x+=border_spacing_x){
-		for(double y = -r->boxsize.y/2.; y<r->boxsize.y/2.-border_spacing_y/2.;y+=border_spacing_y){
-			pt.x 		= x;
-			pt.y 		= y;
-			
-			// Add particle to bottom
-			pt.z 		= -r->boxsize.z/2.+radius;
-			pt.vy 		= 1;
-			reb_add(r, pt);
+    // Add Border Particles
+    double radius         = 1;
+    double mass        = 1;
+    double border_spacing_x = r->boxsize.x/(floor(r->boxsize.x/radius/2.)-1.);
+    double border_spacing_y = r->boxsize.y/(floor(r->boxsize.y/radius/2.)-1.);
+    struct reb_particle pt = {0};
+    pt.r         = radius;
+    pt.m         = mass;
+    pt.hash        = 1;
+    for(double x = -r->boxsize.x/2.; x<r->boxsize.x/2.-border_spacing_x/2.;x+=border_spacing_x){
+        for(double y = -r->boxsize.y/2.; y<r->boxsize.y/2.-border_spacing_y/2.;y+=border_spacing_y){
+            pt.x         = x;
+            pt.y         = y;
+            
+            // Add particle to bottom
+            pt.z         = -r->boxsize.z/2.+radius;
+            pt.vy         = 1;
+            reb_add(r, pt);
 
-			// Add particle to top
-			pt.z 		= r->boxsize.z/2.-radius;
-			pt.vy 		= -1;
-			reb_add(r, pt);
-		}
-	}
+            // Add particle to top
+            pt.z         = r->boxsize.z/2.-radius;
+            pt.vy         = -1;
+            reb_add(r, pt);
+        }
+    }
 
-	N_border = r->N;
-	
-	// Add real particles
-	while(r->N-N_border<N_part){
-		struct reb_particle pt = {0};
-		pt.x 		= reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
-		pt.y 		= reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
-		pt.z 		= 0.758*reb_random_uniform(-r->boxsize.z/2.,r->boxsize.z/2.);
-		pt.vx 		= reb_random_normal(0.001);
-		pt.vy 		= reb_random_normal(0.001);
-		pt.vz 		= reb_random_normal(0.001);
-		pt.r 		= radius;						// m
-		pt.m 		= 1;
-		pt.hash		= 2;
-		reb_add(r, pt);
-	}
+    N_border = r->N;
+    
+    // Add real particles
+    while(r->N-N_border<N_part){
+        struct reb_particle pt = {0};
+        pt.x         = reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
+        pt.y         = reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
+        pt.z         = 0.758*reb_random_uniform(-r->boxsize.z/2.,r->boxsize.z/2.);
+        pt.vx         = reb_random_normal(0.001);
+        pt.vy         = reb_random_normal(0.001);
+        pt.vz         = reb_random_normal(0.001);
+        pt.r         = radius;                        // m
+        pt.m         = 1;
+        pt.hash        = 2;
+        reb_add(r, pt);
+    }
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.*r->dt)){
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 10.*r->dt)){
+        reb_output_timing(r, 0);
+    }
 }
 
 int collision_resolve_hardsphere_withborder(struct reb_simulation* r, struct reb_collision c){
-	const double t = r->t;
-	struct reb_particle* particles = r->particles;
-	struct reb_particle p1 = particles[c.p1];
-	struct reb_particle p2 = particles[c.p2];
-	struct reb_ghostbox gb = c.gb;
-	double m21  = p1.m  /  p2.m; 
-	double x21  = p1.x + gb.shiftx  - p2.x; 
-	double y21  = p1.y + gb.shifty  - p2.y; 
-	double z21  = p1.z + gb.shiftz  - p2.z; 
-	double rp   = p1.r+p2.r;
-	if (rp*rp < x21*x21 + y21*y21 + z21*z21) return 0;
-	double vx21 = p1.vx + gb.shiftvx - p2.vx; 
-	double vy21 = p1.vy + gb.shiftvy - p2.vy; 
-	double vz21 = p1.vz + gb.shiftvz - p2.vz; 
-	if (vx21*x21 + vy21*y21 + vz21*z21 >0) return 0; // not approaching
-	// Bring the to balls in the xy plane.
-	// NOTE: this could probabely be an atan (which is faster than atan2)
-	double theta = atan2(z21,y21);
-	double stheta = sin(theta);
-	double ctheta = cos(theta);
-	double vy21n = ctheta * vy21 + stheta * vz21;	
-	double y21n = ctheta * y21 + stheta * z21;	
-	
-	// Bring the two balls onto the positive x axis.
-	double phi = atan2(y21n,x21);
-	double cphi = cos(phi);
-	double sphi = sin(phi);
-	double vx21nn = cphi * vx21  + sphi * vy21n;		
+    const double t = r->t;
+    struct reb_particle* particles = r->particles;
+    struct reb_particle p1 = particles[c.p1];
+    struct reb_particle p2 = particles[c.p2];
+    struct reb_ghostbox gb = c.gb;
+    double m21  = p1.m  /  p2.m; 
+    double x21  = p1.x + gb.shiftx  - p2.x; 
+    double y21  = p1.y + gb.shifty  - p2.y; 
+    double z21  = p1.z + gb.shiftz  - p2.z; 
+    double rp   = p1.r+p2.r;
+    if (rp*rp < x21*x21 + y21*y21 + z21*z21) return 0;
+    double vx21 = p1.vx + gb.shiftvx - p2.vx; 
+    double vy21 = p1.vy + gb.shiftvy - p2.vy; 
+    double vz21 = p1.vz + gb.shiftvz - p2.vz; 
+    if (vx21*x21 + vy21*y21 + vz21*z21 >0) return 0; // not approaching
+    // Bring the to balls in the xy plane.
+    // NOTE: this could probabely be an atan (which is faster than atan2)
+    double theta = atan2(z21,y21);
+    double stheta = sin(theta);
+    double ctheta = cos(theta);
+    double vy21n = ctheta * vy21 + stheta * vz21;    
+    double y21n = ctheta * y21 + stheta * z21;    
+    
+    // Bring the two balls onto the positive x axis.
+    double phi = atan2(y21n,x21);
+    double cphi = cos(phi);
+    double sphi = sin(phi);
+    double vx21nn = cphi * vx21  + sphi * vy21n;        
 
-	// Coefficient of restitution
-	double eps = 0.15;
-	double dvx2 = -(1.0+eps)*vx21nn/(1.0+m21) ;
+    // Coefficient of restitution
+    double eps = 0.15;
+    double dvx2 = -(1.0+eps)*vx21nn/(1.0+m21) ;
 
-	// Now we are rotating backwards
-	double dvx2n = cphi * dvx2;		
-	double dvy2n = sphi * dvx2;		
-	double dvy2nn = ctheta * dvy2n;	
-	double dvz2nn = stheta * dvy2n;	
+    // Now we are rotating backwards
+    double dvx2n = cphi * dvx2;        
+    double dvy2n = sphi * dvx2;        
+    double dvy2nn = ctheta * dvy2n;    
+    double dvz2nn = stheta * dvy2n;    
 
-	// Applying the changes to the particles.
-	// Do not change border particles.
-	if (p2.hash!=1){
-		particles[c.p2].vx -=	m21*dvx2n;
-		particles[c.p2].vy -=	m21*dvy2nn;
-		particles[c.p2].vz -=	m21*dvz2nn;
-		particles[c.p2].lastcollision = t;
-	}
-	if (p1.hash!=1){
-		particles[c.p1].vx +=	dvx2n; 
-		particles[c.p1].vy +=	dvy2nn; 
-		particles[c.p1].vz +=	dvz2nn; 
-		particles[c.p1].lastcollision = t;
-	}
+    // Applying the changes to the particles.
+    // Do not change border particles.
+    if (p2.hash!=1){
+        particles[c.p2].vx -=    m21*dvx2n;
+        particles[c.p2].vy -=    m21*dvy2nn;
+        particles[c.p2].vz -=    m21*dvz2nn;
+        particles[c.p2].lastcollision = t;
+    }
+    if (p1.hash!=1){
+        particles[c.p1].vx +=    dvx2n; 
+        particles[c.p1].vy +=    dvy2nn; 
+        particles[c.p1].vz +=    dvz2nn; 
+        particles[c.p1].lastcollision = t;
+    }
     return 0; // Do not remove any particle from simulation.
 }

--- a/examples/kozai/problem.c
+++ b/examples/kozai/problem.c
@@ -17,47 +17,47 @@ void heartbeat(struct reb_simulation* r);
 double tmax = 1.6e4;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->dt 			= M_PI*1e-2; 	// initial timestep
-	r->integrator		= REB_INTEGRATOR_IAS15;
-	r->heartbeat		= heartbeat;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->dt             = M_PI*1e-2;     // initial timestep
+    r->integrator        = REB_INTEGRATOR_IAS15;
+    r->heartbeat        = heartbeat;
 
-	// Initial conditions
-	
-	struct reb_particle star = {0}; 
-	star.m  = 1;
-	reb_add(r, star); 
-	
-	// The planet (a zero mass test particle)
-	struct reb_particle planet = {0}; 
-	double e_testparticle = 0;
-	planet.m  = 0.;
-	planet.x  = 1.-e_testparticle;
-	planet.vy = sqrt((1.+e_testparticle)/(1.-e_testparticle));
-	reb_add(r, planet); 
-	
-	// The perturber
-	struct reb_particle perturber = {0}; 
-	perturber.x  = 10; 
-	double inc_perturber = 89.9;
-	perturber.m  = 1;
-	perturber.vy = cos(inc_perturber/180.*M_PI)*sqrt((star.m+perturber.m)/perturber.x); 
-	perturber.vz = sin(inc_perturber/180.*M_PI)*sqrt((star.m+perturber.m)/perturber.x); 
-	reb_add(r, perturber); 
+    // Initial conditions
+    
+    struct reb_particle star = {0}; 
+    star.m  = 1;
+    reb_add(r, star); 
+    
+    // The planet (a zero mass test particle)
+    struct reb_particle planet = {0}; 
+    double e_testparticle = 0;
+    planet.m  = 0.;
+    planet.x  = 1.-e_testparticle;
+    planet.vy = sqrt((1.+e_testparticle)/(1.-e_testparticle));
+    reb_add(r, planet); 
+    
+    // The perturber
+    struct reb_particle perturber = {0}; 
+    perturber.x  = 10; 
+    double inc_perturber = 89.9;
+    perturber.m  = 1;
+    perturber.vy = cos(inc_perturber/180.*M_PI)*sqrt((star.m+perturber.m)/perturber.x); 
+    perturber.vz = sin(inc_perturber/180.*M_PI)*sqrt((star.m+perturber.m)/perturber.x); 
+    reb_add(r, perturber); 
 
-	reb_move_to_com(r);
-	
-	system("rm -v orbits.txt");		// delete previous output file
+    reb_move_to_com(r);
+    
+    system("rm -v orbits.txt");        // delete previous output file
 
-	reb_integrate(r, tmax);
+    reb_integrate(r, tmax);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if(reb_output_check(r, 20.*M_PI)){		// outputs to the screen
-		reb_output_timing(r, tmax);
-	}
-	if(reb_output_check(r, 12.)){			// outputs to a file
-		reb_output_orbits(r, "orbits.txt");
-	}
+    if(reb_output_check(r, 20.*M_PI)){        // outputs to the screen
+        reb_output_timing(r, tmax);
+    }
+    if(reb_output_check(r, 12.)){            // outputs to a file
+        reb_output_orbits(r, "orbits.txt");
+    }
 }

--- a/examples/megno/problem.c
+++ b/examples/megno/problem.c
@@ -12,22 +12,22 @@
 
 const double ss_pos[3][3] = 
 {
-	{-4.06428567034226e-3,	-6.08813756435987e-3,	-1.66162304225834e-6	}, // Sun
-	{+3.40546614227466e+0,	+3.62978190075864e+0,	+3.42386261766577e-2	}, // Jupiter
-	{+6.60801554403466e+0,	+6.38084674585064e+0,	-1.36145963724542e-1	}, // Saturn
+    {-4.06428567034226e-3,    -6.08813756435987e-3,    -1.66162304225834e-6    }, // Sun
+    {+3.40546614227466e+0,    +3.62978190075864e+0,    +3.42386261766577e-2    }, // Jupiter
+    {+6.60801554403466e+0,    +6.38084674585064e+0,    -1.36145963724542e-1    }, // Saturn
 };
 const double ss_vel[3][3] = 
 {
-	{+6.69048890636161e-6,	-6.33922479583593e-6,	-3.13202145590767e-9	}, // Sun
-	{-5.59797969310664e-3,	+5.51815399480116e-3,	-2.66711392865591e-6	}, // Jupiter
-	{-4.17354020307064e-3,	+3.99723751748116e-3,	+1.67206320571441e-5	}, // Saturn
+    {+6.69048890636161e-6,    -6.33922479583593e-6,    -3.13202145590767e-9    }, // Sun
+    {-5.59797969310664e-3,    +5.51815399480116e-3,    -2.66711392865591e-6    }, // Jupiter
+    {-4.17354020307064e-3,    +3.99723751748116e-3,    +1.67206320571441e-5    }, // Saturn
 };
 
 const double ss_mass[3] =
 {
-	1.00000597682, 	// Sun + inner planets
-	1./1047000.355,	// Jupiter
-	1./3501000.6,	// Saturn
+    1.00000597682,     // Sun + inner planets
+    1./1047000.355,    // Jupiter
+    1./3501000.6,    // Saturn
 };
 
 double tmax = 1e9;
@@ -35,44 +35,44 @@ double tmax = 1e9;
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->dt 		= 10;			// initial timestep (in days)
-	//r->integrator	= IAS15;
-	r->integrator	= REB_INTEGRATOR_WHFAST;
-	const double k	= 0.01720209895;	// Gaussian constant 
-	r->G		= k*k;			// These are the same units that mercury6 uses
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->dt         = 10;            // initial timestep (in days)
+    //r->integrator    = IAS15;
+    r->integrator    = REB_INTEGRATOR_WHFAST;
+    const double k    = 0.01720209895;    // Gaussian constant 
+    r->G        = k*k;            // These are the same units that mercury6 uses
 
-	// Initial conditions
-	for (int i=0;i<3;i++){
-		struct reb_particle p = {0};
-		p.x  = ss_pos[i][0]; 		p.y  = ss_pos[i][1];	 	p.z  = ss_pos[i][2];
-		p.vx = ss_vel[i][0]; 		p.vy = ss_vel[i][1];	 	p.vz = ss_vel[i][2];
-		p.m  = ss_mass[i];
-		reb_add(r, p); 
-	}
-	reb_move_to_com(r);
-	// Add megno particles 
-	reb_tools_megno_init(r);  // N = 6 after this function call. 
-	// The first half of particles are real particles, the second half are particles following the variational equations.
-	
-	// Set callback for outputs.
-	r->heartbeat = heartbeat;
+    // Initial conditions
+    for (int i=0;i<3;i++){
+        struct reb_particle p = {0};
+        p.x  = ss_pos[i][0];         p.y  = ss_pos[i][1];         p.z  = ss_pos[i][2];
+        p.vx = ss_vel[i][0];         p.vy = ss_vel[i][1];         p.vz = ss_vel[i][2];
+        p.m  = ss_mass[i];
+        reb_add(r, p); 
+    }
+    reb_move_to_com(r);
+    // Add megno particles 
+    reb_tools_megno_init(r);  // N = 6 after this function call. 
+    // The first half of particles are real particles, the second half are particles following the variational equations.
+    
+    // Set callback for outputs.
+    r->heartbeat = heartbeat;
 
-	reb_integrate(r, tmax);
+    reb_integrate(r, tmax);
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r, 1000.*r->dt)){
-		reb_output_timing(r, tmax);
-	}
-	if (reb_output_check(r, 362.)){
-		// Output the time and the MEGNO to the screen and a file.
-		FILE* f = fopen("Y.txt","a+");
-		fprintf(f,"        %.20e     %.20e\n",r->t, reb_tools_calculate_megno(r));
-		//printf("        %.20e     %.20e\n",r->t, reb_tools_calculate_megno(r));
-		fclose(f);
-	}
+    if (reb_output_check(r, 1000.*r->dt)){
+        reb_output_timing(r, tmax);
+    }
+    if (reb_output_check(r, 362.)){
+        // Output the time and the MEGNO to the screen and a file.
+        FILE* f = fopen("Y.txt","a+");
+        fprintf(f,"        %.20e     %.20e\n",r->t, reb_tools_calculate_megno(r));
+        //printf("        %.20e     %.20e\n",r->t, reb_tools_calculate_megno(r));
+        fclose(f);
+    }
 }
 
 void problem_finish(){

--- a/examples/mergers/problem.c
+++ b/examples/mergers/problem.c
@@ -16,38 +16,38 @@
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	r->dt                   = 0.01*2.*M_PI;				// initial timestep
-	r->integrator           = REB_INTEGRATOR_IAS15;
-	r->collision            = REB_COLLISION_DIRECT;
-	r->collision_resolve    = reb_collision_resolve_merge;		// Choose merger collision routine.
-	r->heartbeat            = heartbeat;
+    struct reb_simulation* r = reb_create_simulation();
+    r->dt                   = 0.01*2.*M_PI;                // initial timestep
+    r->integrator           = REB_INTEGRATOR_IAS15;
+    r->collision            = REB_COLLISION_DIRECT;
+    r->collision_resolve    = reb_collision_resolve_merge;        // Choose merger collision routine.
+    r->heartbeat            = heartbeat;
 
-	struct reb_particle star = {0};
-	star.m = 1;
-	star.r = 0.1;
-	reb_add(r, star);
-	
-	// Add planets
-	int N_planets = 7;
-	for (int i=0;i<N_planets;i++){
-		double a = 1.+(double)i/(double)(N_planets-1);		// semi major axis in AU
-		double v = sqrt(1./a); 					// velocity (circular orbit)
-		struct reb_particle planet = {0};
-		planet.m = 1e-4; 
-		planet.r = 4e-2; 					// radius in AU (it is unphysically large in this example)
-		planet.lastcollision = 0;				// The first time particles can collide with each other
-		planet.x = a; 
-		planet.vy = v;
-		reb_add(r, planet); 
-	}
-	reb_move_to_com(r);				// This makes sure the planetary systems stays within the computational domain and doesn't drift.
+    struct reb_particle star = {0};
+    star.m = 1;
+    star.r = 0.1;
+    reb_add(r, star);
+    
+    // Add planets
+    int N_planets = 7;
+    for (int i=0;i<N_planets;i++){
+        double a = 1.+(double)i/(double)(N_planets-1);        // semi major axis in AU
+        double v = sqrt(1./a);                     // velocity (circular orbit)
+        struct reb_particle planet = {0};
+        planet.m = 1e-4; 
+        planet.r = 4e-2;                     // radius in AU (it is unphysically large in this example)
+        planet.lastcollision = 0;                // The first time particles can collide with each other
+        planet.x = a; 
+        planet.vy = v;
+        reb_add(r, planet); 
+    }
+    reb_move_to_com(r);                // This makes sure the planetary systems stays within the computational domain and doesn't drift.
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.*2.*M_PI)){  
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 10.*2.*M_PI)){  
+        reb_output_timing(r, 0);
+    }
 }

--- a/examples/openmp/problem.c
+++ b/examples/openmp/problem.c
@@ -28,67 +28,67 @@
 
 
 void run_sim(){
-	struct reb_simulation* const r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->gravity	= REB_GRAVITY_BASIC;
-	r->boundary	= REB_BOUNDARY_OPEN;
-	r->opening_angle2	= 1.5;	// This constant determines the accuracy of the tree code gravity estimate.
-	r->G 		= 1;		
-	r->softening 	= 0.02;		// Gravitational softening length
-	r->dt 		= 3e-2;		// Timestep
-	const double boxsize = 10.2;
-	reb_configure_box(r,boxsize,1,1,1);
+    struct reb_simulation* const r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->gravity    = REB_GRAVITY_BASIC;
+    r->boundary    = REB_BOUNDARY_OPEN;
+    r->opening_angle2    = 1.5;    // This constant determines the accuracy of the tree code gravity estimate.
+    r->G         = 1;        
+    r->softening     = 0.02;        // Gravitational softening length
+    r->dt         = 3e-2;        // Timestep
+    const double boxsize = 10.2;
+    reb_configure_box(r,boxsize,1,1,1);
 
-	// Setup particles
-	double disc_mass = 2e-1;	// Total disc mass
-	int N = 2000;			// Number of particles
-	// Initial conditions
-	struct reb_particle star = {0};
-	star.m 		= 1;
-	reb_add(r, star);
-	for (int i=0;i<N;i++){
-		struct reb_particle pt = {0};
-		double a	= reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
-		double phi 	= reb_random_uniform(0,2.*M_PI);
-		pt.x 		= a*cos(phi);
-		pt.y 		= a*sin(phi);
-		pt.z 		= a*reb_random_normal(0.001);
-		double mu 	= star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
-		double vkep 	= sqrt(r->G*mu/a);
-		pt.vx 		=  vkep * sin(phi);
-		pt.vy 		= -vkep * cos(phi);
-		pt.vz 		= 0;
-		pt.m 		= disc_mass/(double)N;
-		reb_add(r, pt);
-	}
+    // Setup particles
+    double disc_mass = 2e-1;    // Total disc mass
+    int N = 2000;            // Number of particles
+    // Initial conditions
+    struct reb_particle star = {0};
+    star.m         = 1;
+    reb_add(r, star);
+    for (int i=0;i<N;i++){
+        struct reb_particle pt = {0};
+        double a    = reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
+        double phi     = reb_random_uniform(0,2.*M_PI);
+        pt.x         = a*cos(phi);
+        pt.y         = a*sin(phi);
+        pt.z         = a*reb_random_normal(0.001);
+        double mu     = star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
+        double vkep     = sqrt(r->G*mu/a);
+        pt.vx         =  vkep * sin(phi);
+        pt.vy         = -vkep * cos(phi);
+        pt.vz         = 0;
+        pt.m         = disc_mass/(double)N;
+        reb_add(r, pt);
+    }
 
-	reb_integrate(r, 1.0);
-	reb_free_simulation(r);
+    reb_integrate(r, 1.0);
+    reb_free_simulation(r);
 }
 
 int main(int argc, char* argv[]){
-	// Get the number of processors
-	int np = omp_get_num_procs();
-	// Set the number of OpenMP threads to be the number of processors	
-	omp_set_num_threads(np);
+    // Get the number of processors
+    int np = omp_get_num_procs();
+    // Set the number of OpenMP threads to be the number of processors    
+    omp_set_num_threads(np);
 
-	
-	// First, run it with the OpenMP turned on.
-	struct timeval tim;
-	gettimeofday(&tim, NULL);
-	double timing1 = tim.tv_sec+(tim.tv_usec/1000000.0);
-	run_sim();
+    
+    // First, run it with the OpenMP turned on.
+    struct timeval tim;
+    gettimeofday(&tim, NULL);
+    double timing1 = tim.tv_sec+(tim.tv_usec/1000000.0);
+    run_sim();
 
-	// Reduce the number of threads to 1 and run again.
-	gettimeofday(&tim, NULL);
-	double timing2 = tim.tv_sec+(tim.tv_usec/1000000.0);
-	omp_set_num_threads(1);
-	run_sim();
-	gettimeofday(&tim, NULL);
-	double timing3 = tim.tv_sec+(tim.tv_usec/1000000.0);
+    // Reduce the number of threads to 1 and run again.
+    gettimeofday(&tim, NULL);
+    double timing2 = tim.tv_sec+(tim.tv_usec/1000000.0);
+    omp_set_num_threads(1);
+    run_sim();
+    gettimeofday(&tim, NULL);
+    double timing3 = tim.tv_sec+(tim.tv_usec/1000000.0);
 
-	// Output speedup
-	printf("\n\nOpenMP speed-up: %.3fx (perfect scaling would give %dx)\n",(timing3-timing2)/(timing2-timing1),np);
+    // Output speedup
+    printf("\n\nOpenMP speed-up: %.3fx (perfect scaling would give %dx)\n",(timing3-timing2)/(timing2-timing1),np);
 }
 

--- a/examples/orbital_elements/problem.c
+++ b/examples/orbital_elements/problem.c
@@ -15,58 +15,58 @@
 #include "tools.h"
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	
-	struct reb_particle p; 
-	p.m  	= 1.;	
-	reb_add(r, p); 
+    struct reb_simulation* r = reb_create_simulation();
+    
+    struct reb_particle p; 
+    p.m      = 1.;    
+    reb_add(r, p); 
 
-	// Adding a particle with orbital elements requires the following 7 things
-	// There's more flexibility in python for passing different orbital elements
-	// for edge cases.  The user has to calculate these manually in C and pass
-	// the elements below
-	
-	struct reb_particle primary = r->particles[0];
-	double m = 0.;
-	double a = 0.1;
-	double e = 0.2;
-	double inc = 0.3;
-	double Omega = 0.4;
-	double omega = 0.5;
-	double f = 0.6;
+    // Adding a particle with orbital elements requires the following 7 things
+    // There's more flexibility in python for passing different orbital elements
+    // for edge cases.  The user has to calculate these manually in C and pass
+    // the elements below
+    
+    struct reb_particle primary = r->particles[0];
+    double m = 0.;
+    double a = 0.1;
+    double e = 0.2;
+    double inc = 0.3;
+    double Omega = 0.4;
+    double omega = 0.5;
+    double f = 0.6;
 
-	struct reb_particle p2 = reb_tools_orbit_to_particle(r->G, primary, m, a, e, inc, Omega, omega, f);
-	reb_add(r,p2);
+    struct reb_particle p2 = reb_tools_orbit_to_particle(r->G, primary, m, a, e, inc, Omega, omega, f);
+    reb_add(r,p2);
 
-	struct reb_orbit o= reb_tools_particle_to_orbit(r->G, r->particles[1], r->particles[0]);
-	
-	printf("a = %.16e\n", o.a);
-	printf("e = %.16e\n", o.e);
-	printf("inc = %.16e\n", o.inc);
-	printf("Omega = %.16e\n", o.Omega);
-	printf("omega = %.16e\n", o.omega);
-	printf("f = %.16e\n", o.f);
+    struct reb_orbit o= reb_tools_particle_to_orbit(r->G, r->particles[1], r->particles[0]);
+    
+    printf("a = %.16e\n", o.a);
+    printf("e = %.16e\n", o.e);
+    printf("inc = %.16e\n", o.inc);
+    printf("Omega = %.16e\n", o.Omega);
+    printf("omega = %.16e\n", o.omega);
+    printf("f = %.16e\n", o.f);
 
-	// There are also versions of the two functions above that let you pass an error integer pointer
-	// to diagnose / catch errors.  You can find error codes in the documentation for the functions
-	// at http://rebound.readthedocs.org/
-	
-	int err = 0;
-	e = 1.001;
+    // There are also versions of the two functions above that let you pass an error integer pointer
+    // to diagnose / catch errors.  You can find error codes in the documentation for the functions
+    // at http://rebound.readthedocs.org/
+    
+    int err = 0;
+    e = 1.001;
 
-	p2 = reb_tools_orbit_to_particle_err(r->G, primary, m, a, e, inc, Omega, omega, f, &err);
-	if(err == 3){			// error code for bound orbit with e > 1
-		e = 1.-1.e-15;		// set to just less than 1
-		p2 = reb_tools_orbit_to_particle_err(r->G, primary, m, a, e, inc, Omega, omega, f, &err);
-	}
-	reb_add(r,p2);
-	
-	o= reb_tools_particle_to_orbit(r->G, r->particles[2], r->particles[0]);
+    p2 = reb_tools_orbit_to_particle_err(r->G, primary, m, a, e, inc, Omega, omega, f, &err);
+    if(err == 3){            // error code for bound orbit with e > 1
+        e = 1.-1.e-15;        // set to just less than 1
+        p2 = reb_tools_orbit_to_particle_err(r->G, primary, m, a, e, inc, Omega, omega, f, &err);
+    }
+    reb_add(r,p2);
+    
+    o= reb_tools_particle_to_orbit(r->G, r->particles[2], r->particles[0]);
 
-	printf("\n\na = %.16e\n", o.a);
-	printf("e = %.16e\n", o.e);
-	printf("inc = %.16e\n", o.inc);
-	printf("Omega = %.16e\n", o.Omega);
-	printf("omega = %.16e\n", o.omega);
-	printf("f = %.16e\n", o.f);
+    printf("\n\na = %.16e\n", o.a);
+    printf("e = %.16e\n", o.e);
+    printf("inc = %.16e\n", o.inc);
+    printf("Omega = %.16e\n", o.Omega);
+    printf("omega = %.16e\n", o.omega);
+    printf("f = %.16e\n", o.f);
 }

--- a/examples/outer_solar_system/problem.c
+++ b/examples/outer_solar_system/problem.c
@@ -55,48 +55,48 @@ double tmax = 7.3e7;
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	const double k = 0.01720209895; // Gaussian constant
-	r->dt = 40;			// in days
-	r->G = k * k;			// These are the same units as used by the mercury6 code.
-	r->ri_whfast.safe_mode = 0;     // Turn of safe mode. Need to call integrator_synchronize() before outputs.
-	r->ri_whfast.corrector = 11;    // Turn on symplectic correctors (11th order).
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    const double k = 0.01720209895; // Gaussian constant
+    r->dt = 40;            // in days
+    r->G = k * k;            // These are the same units as used by the mercury6 code.
+    r->ri_whfast.safe_mode = 0;     // Turn of safe mode. Need to call integrator_synchronize() before outputs.
+    r->ri_whfast.corrector = 11;    // Turn on symplectic correctors (11th order).
 
-	// Setup callbacks:
-	r->heartbeat = heartbeat;
-	r->force_is_velocity_dependent = 0; // Force only depends on positions.
-	r->integrator = REB_INTEGRATOR_WHFAST;
-	//r->integrator	= REB_INTEGRATOR_IAS15;
+    // Setup callbacks:
+    r->heartbeat = heartbeat;
+    r->force_is_velocity_dependent = 0; // Force only depends on positions.
+    r->integrator = REB_INTEGRATOR_WHFAST;
+    //r->integrator    = REB_INTEGRATOR_IAS15;
 
-	// Initial conditions
-	for (int i = 0; i < 6; i++) {
-		struct reb_particle p = {0};
-		p.x = ss_pos[i][0];
-		p.y = ss_pos[i][1];
-		p.z = ss_pos[i][2];
-		p.vx = ss_vel[i][0];
-		p.vy = ss_vel[i][1];
-		p.vz = ss_vel[i][2];
-		p.m = ss_mass[i];
-		reb_add(r, p);
-	}
+    // Initial conditions
+    for (int i = 0; i < 6; i++) {
+        struct reb_particle p = {0};
+        p.x = ss_pos[i][0];
+        p.y = ss_pos[i][1];
+        p.z = ss_pos[i][2];
+        p.vx = ss_vel[i][0];
+        p.vy = ss_vel[i][1];
+        p.vz = ss_vel[i][2];
+        p.m = ss_mass[i];
+        reb_add(r, p);
+    }
 
     reb_move_to_com(r);
 
-	r->N_active = r->N - 1; // Pluto is treated as a test-particle.
+    r->N_active = r->N - 1; // Pluto is treated as a test-particle.
 
-	double e_initial = reb_tools_energy(r);
+    double e_initial = reb_tools_energy(r);
 
-	// Start integration
-	reb_integrate(r, tmax);
+    // Start integration
+    reb_integrate(r, tmax);
 
-	double e_final = reb_tools_energy(r);
-	printf("Done. Final time: %.4f. Relative energy error: %e\n", r->t, fabs((e_final - e_initial) / e_initial));
+    double e_final = reb_tools_energy(r);
+    printf("Done. Final time: %.4f. Relative energy error: %e\n", r->t, fabs((e_final - e_initial) / e_initial));
 }
 
 void heartbeat(struct reb_simulation* const r) {
-	if (reb_output_check(r, 10000000.)) {
-		reb_output_timing(r, tmax);
-	}
+    if (reb_output_check(r, 10000000.)) {
+        reb_output_timing(r, tmax);
+    }
 }

--- a/examples/overstability/problem.c
+++ b/examples/overstability/problem.c
@@ -35,6 +35,7 @@ int main(int argc, char* argv[]){
 	r->coefficient_of_restitution 	= coefficient_of_restitution;
 	r->integrator			= REB_INTEGRATOR_SEI;
 	r->collision			= REB_COLLISION_TREE;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	r->gravity			= REB_GRAVITY_NONE;
 	r->boundary			= REB_BOUNDARY_SHEAR;
 

--- a/examples/overstability/problem.c
+++ b/examples/overstability/problem.c
@@ -21,47 +21,47 @@ extern double OMEGA;
 extern double OMEGAZ;
 
 double coefficient_of_restitution(const struct reb_simulation*r, double v){
-	return 0.5;
+    return 0.5;
 }
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->ri_sei.OMEGA 		= 1.;
-	r->ri_sei.OMEGAZ 		= 3.6;
-	r->dt				= 2e-3*2.*M_PI;
-	double particle_r 		= 1;
-	double tau			= 1.64;
-	r->coefficient_of_restitution 	= coefficient_of_restitution;
-	r->integrator			= REB_INTEGRATOR_SEI;
-	r->collision			= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->ri_sei.OMEGA         = 1.;
+    r->ri_sei.OMEGAZ         = 3.6;
+    r->dt                = 2e-3*2.*M_PI;
+    double particle_r         = 1;
+    double tau            = 1.64;
+    r->coefficient_of_restitution     = coefficient_of_restitution;
+    r->integrator            = REB_INTEGRATOR_SEI;
+    r->collision            = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	r->gravity			= REB_GRAVITY_NONE;
-	r->boundary			= REB_BOUNDARY_SHEAR;
+    r->gravity            = REB_GRAVITY_NONE;
+    r->boundary            = REB_BOUNDARY_SHEAR;
 
-	reb_configure_box(r,1.,200,5,20);
-	r->nghostx = 1; 	r->nghosty = 1; 	r->nghostz = 0;
+    reb_configure_box(r,1.,200,5,20);
+    r->nghostx = 1;     r->nghosty = 1;     r->nghostz = 0;
 
-	// Initial conditions
-	double _N = tau * r->boxsize.x * r->boxsize.y/(M_PI*particle_r *particle_r);
-	while (r->N<_N){
-		struct reb_particle p;
-		p.x 	= ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.x;
-		p.y 	= ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.y;
-		p.z 	= 10.0*((double)rand()/(double)RAND_MAX-0.5)*particle_r;
-		p.vx 	= 0;
-		p.vy 	= -1.5*p.x; // shear
-		p.vz 	= 0;
-		p.ax 	= 0; p.ay 	= 0; p.az 	= 0;
-		p.m 	= 1.;
-		p.r 	= particle_r;
-		reb_add(r, p);
-	}
-	reb_integrate(r,INFINITY);
+    // Initial conditions
+    double _N = tau * r->boxsize.x * r->boxsize.y/(M_PI*particle_r *particle_r);
+    while (r->N<_N){
+        struct reb_particle p;
+        p.x     = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.x;
+        p.y     = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.y;
+        p.z     = 10.0*((double)rand()/(double)RAND_MAX-0.5)*particle_r;
+        p.vx     = 0;
+        p.vy     = -1.5*p.x; // shear
+        p.vz     = 0;
+        p.ax     = 0; p.ay     = 0; p.az     = 0;
+        p.m     = 1.;
+        p.r     = particle_r;
+        reb_add(r, p);
+    }
+    reb_integrate(r,INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r,2.*M_PI)){
-		reb_output_timing(r,0);
-	}
+    if (reb_output_check(r,2.*M_PI)){
+        reb_output_timing(r,0);
+    }
 }

--- a/examples/planetary_migration/problem.c
+++ b/examples/planetary_migration/problem.c
@@ -18,108 +18,108 @@
 #include <math.h>
 #include "rebound.h"
 
-double* tau_a; 	/**< Migration timescale in years for all particles */
-double* tau_e; 	/**< Eccentricity damping timescale in years for all particles */
+double* tau_a;     /**< Migration timescale in years for all particles */
+double* tau_e;     /**< Eccentricity damping timescale in years for all particles */
 double tmax;
 
 void migration_forces(struct reb_simulation* r);
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_WHFAST;
-	//r->integrator	= REB_INTEGRATOR_IAS15;
-	r->dt 		= 1e-2*2.*M_PI;		// in year/(2*pi)
-	r->additional_forces = migration_forces; 	//Set function pointer to add dissipative forces.
-	r->heartbeat = heartbeat;  
-	r->force_is_velocity_dependent = 1;
-	tmax		= 2.0e4*2.*M_PI;	// in year/(2*pi)
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_WHFAST;
+    //r->integrator    = REB_INTEGRATOR_IAS15;
+    r->dt         = 1e-2*2.*M_PI;        // in year/(2*pi)
+    r->additional_forces = migration_forces;     //Set function pointer to add dissipative forces.
+    r->heartbeat = heartbeat;  
+    r->force_is_velocity_dependent = 1;
+    tmax        = 2.0e4*2.*M_PI;    // in year/(2*pi)
 
-	// Initial conditions
-	// Parameters are those of Lee & Peale 2002, Figure 4. 
-	struct reb_particle star = {0};
-	star.m  = 0.32;			// This is a sub-solar mass star
-	reb_add(r, star); 
-	
-	struct reb_particle p1 = {0};	// Planet 1
-	p1.x 	= 0.5;
-	p1.m  	= 0.56e-3;
-	p1.vy 	= sqrt(r->G*(star.m+p1.m)/p1.x);
-	reb_add(r, p1); 
-	
-	struct reb_particle p2 = {0};	// Planet 2
-	p2.x 	= 1;
-	p2.m  	= 1.89e-3;
-	p2.vy 	= sqrt(r->G*(star.m+p2.m)/p2.x);
-	reb_add(r, p2); 
+    // Initial conditions
+    // Parameters are those of Lee & Peale 2002, Figure 4. 
+    struct reb_particle star = {0};
+    star.m  = 0.32;            // This is a sub-solar mass star
+    reb_add(r, star); 
+    
+    struct reb_particle p1 = {0};    // Planet 1
+    p1.x     = 0.5;
+    p1.m      = 0.56e-3;
+    p1.vy     = sqrt(r->G*(star.m+p1.m)/p1.x);
+    reb_add(r, p1); 
+    
+    struct reb_particle p2 = {0};    // Planet 2
+    p2.x     = 1;
+    p2.m      = 1.89e-3;
+    p2.vy     = sqrt(r->G*(star.m+p2.m)/p2.x);
+    reb_add(r, p2); 
 
-	tau_a = calloc(sizeof(double),r->N);
-	tau_e = calloc(sizeof(double),r->N);
+    tau_a = calloc(sizeof(double),r->N);
+    tau_e = calloc(sizeof(double),r->N);
 
-	tau_a[2] = 2.*M_PI*20000.0;	// Migration timescale of planet 2 is 20000 years.
-	tau_e[2] = 2.*M_PI*200.0; 	// Eccentricity damping timescale is 200 years (K=100). 
+    tau_a[2] = 2.*M_PI*20000.0;    // Migration timescale of planet 2 is 20000 years.
+    tau_e[2] = 2.*M_PI*200.0;     // Eccentricity damping timescale is 200 years (K=100). 
 
-	reb_move_to_com(r);  		
+    reb_move_to_com(r);          
 
-	system("rm -v orbits.txt"); // delete previous output file
+    system("rm -v orbits.txt"); // delete previous output file
 
-	reb_integrate(r, tmax);
+    reb_integrate(r, tmax);
 }
 
 void migration_forces(struct reb_simulation* r){
-	const double G = r->G;
-	const int N = r->N;
-	struct reb_particle* const particles = r->particles;
-	struct reb_particle com = particles[0]; // calculate migration forces with respect to center of mass;
-	for(int i=1;i<N;i++){
-		if (tau_e[i]!=0||tau_a[i]!=0){
-			struct reb_particle* p = &(particles[i]);
-			const double dvx = p->vx-com.vx;
-			const double dvy = p->vy-com.vy;
-			const double dvz = p->vz-com.vz;
+    const double G = r->G;
+    const int N = r->N;
+    struct reb_particle* const particles = r->particles;
+    struct reb_particle com = particles[0]; // calculate migration forces with respect to center of mass;
+    for(int i=1;i<N;i++){
+        if (tau_e[i]!=0||tau_a[i]!=0){
+            struct reb_particle* p = &(particles[i]);
+            const double dvx = p->vx-com.vx;
+            const double dvy = p->vy-com.vy;
+            const double dvz = p->vz-com.vz;
 
-			if (tau_a[i]!=0){ 	// Migration
-				p->ax -=  dvx/(2.*tau_a[i]);
-				p->ay -=  dvy/(2.*tau_a[i]);
-				p->az -=  dvz/(2.*tau_a[i]);
-			}
-			if (tau_e[i]!=0){ 	// Eccentricity damping
-				const double mu = G*(com.m + p->m);
-				const double dx = p->x-com.x;
-				const double dy = p->y-com.y;
-				const double dz = p->z-com.z;
+            if (tau_a[i]!=0){     // Migration
+                p->ax -=  dvx/(2.*tau_a[i]);
+                p->ay -=  dvy/(2.*tau_a[i]);
+                p->az -=  dvz/(2.*tau_a[i]);
+            }
+            if (tau_e[i]!=0){     // Eccentricity damping
+                const double mu = G*(com.m + p->m);
+                const double dx = p->x-com.x;
+                const double dy = p->y-com.y;
+                const double dz = p->z-com.z;
 
-				const double hx = dy*dvz - dz*dvy; 
-				const double hy = dz*dvx - dx*dvz;
-				const double hz = dx*dvy - dy*dvx;
-				const double h = sqrt ( hx*hx + hy*hy + hz*hz );
-				const double v = sqrt ( dvx*dvx + dvy*dvy + dvz*dvz );
-				const double r = sqrt ( dx*dx + dy*dy + dz*dz );
-				const double vr = (dx*dvx + dy*dvy + dz*dvz)/r;
-				const double ex = 1./mu*( (v*v-mu/r)*dx - r*vr*dvx );
-				const double ey = 1./mu*( (v*v-mu/r)*dy - r*vr*dvy );
-				const double ez = 1./mu*( (v*v-mu/r)*dz - r*vr*dvz );
-				const double e = sqrt( ex*ex + ey*ey + ez*ez );		// eccentricity
-				const double a = -mu/( v*v - 2.*mu/r );			// semi major axis
-				const double prefac1 = 1./(1.-e*e) /tau_e[i]/1.5;
-				const double prefac2 = 1./(r*h) * sqrt(mu/a/(1.-e*e))  /tau_e[i]/1.5;
-				p->ax += -dvx*prefac1 + (hy*dz-hz*dy)*prefac2;
-				p->ay += -dvy*prefac1 + (hz*dx-hx*dz)*prefac2;
-				p->az += -dvz*prefac1 + (hx*dy-hy*dx)*prefac2;
-			}
-		}
-		com = reb_get_com_of_pair(com,particles[i]);
-	}
+                const double hx = dy*dvz - dz*dvy; 
+                const double hy = dz*dvx - dx*dvz;
+                const double hz = dx*dvy - dy*dvx;
+                const double h = sqrt ( hx*hx + hy*hy + hz*hz );
+                const double v = sqrt ( dvx*dvx + dvy*dvy + dvz*dvz );
+                const double r = sqrt ( dx*dx + dy*dy + dz*dz );
+                const double vr = (dx*dvx + dy*dvy + dz*dvz)/r;
+                const double ex = 1./mu*( (v*v-mu/r)*dx - r*vr*dvx );
+                const double ey = 1./mu*( (v*v-mu/r)*dy - r*vr*dvy );
+                const double ez = 1./mu*( (v*v-mu/r)*dz - r*vr*dvz );
+                const double e = sqrt( ex*ex + ey*ey + ez*ez );        // eccentricity
+                const double a = -mu/( v*v - 2.*mu/r );            // semi major axis
+                const double prefac1 = 1./(1.-e*e) /tau_e[i]/1.5;
+                const double prefac2 = 1./(r*h) * sqrt(mu/a/(1.-e*e))  /tau_e[i]/1.5;
+                p->ax += -dvx*prefac1 + (hy*dz-hz*dy)*prefac2;
+                p->ay += -dvy*prefac1 + (hz*dx-hx*dz)*prefac2;
+                p->az += -dvz*prefac1 + (hx*dy-hy*dx)*prefac2;
+            }
+        }
+        com = reb_get_com_of_pair(com,particles[i]);
+    }
 }
 
 void heartbeat(struct reb_simulation* r){
-	if(reb_output_check(r, 20.*M_PI)){
-		reb_output_timing(r, tmax);
-	}
-	if(reb_output_check(r, 40.)){
-		reb_integrator_synchronize(r);
-		reb_output_orbits(r,"orbits.txt");
-		reb_move_to_com(r); 
-	}
+    if(reb_output_check(r, 20.*M_PI)){
+        reb_output_timing(r, tmax);
+    }
+    if(reb_output_check(r, 40.)){
+        reb_integrator_synchronize(r);
+        reb_output_orbits(r,"orbits.txt");
+        reb_move_to_com(r); 
+    }
 }

--- a/examples/planetesimal_disk_migration/problem.c
+++ b/examples/planetesimal_disk_migration/problem.c
@@ -25,9 +25,9 @@ double E0;
 int main(int argc, char* argv[]){
     struct reb_simulation* r = reb_create_simulation();
     
-	// Simulation Setup
-	r->integrator	= REB_INTEGRATOR_HERMES;
-    r->heartbeat	= heartbeat;
+    // Simulation Setup
+    r->integrator    = REB_INTEGRATOR_HERMES;
+    r->heartbeat    = heartbeat;
     r->testparticle_type = 1;
     
     // Collisions
@@ -37,7 +37,7 @@ int main(int argc, char* argv[]){
     r->collision_resolve_keep_sorted = 1;
     
     // Boundaries
-    r->boundary	= REB_BOUNDARY_OPEN;
+    r->boundary    = REB_BOUNDARY_OPEN;
     const double boxsize = 6;
     reb_configure_box(r,boxsize,2,2,1);
     
@@ -48,11 +48,11 @@ int main(int argc, char* argv[]){
     double a_mig_planet = 1.67;
     r->dt = 6.283*pow(a_scat_planet,1.5)/50;
     
-	// Star
-	struct reb_particle star = {0};
-	star.m 		= 1;
-    star.r		= 0.005;        // Radius of particle is in AU!
-	reb_add(r, star);
+    // Star
+    struct reb_particle star = {0};
+    star.m         = 1;
+    star.r        = 0.005;        // Radius of particle is in AU!
+    reb_add(r, star);
     
     // Planet 1 - inner massive planet to scatter planetesimals out
     {
@@ -83,16 +83,16 @@ int main(int argc, char* argv[]){
     
     // Generate Planetesimal Disk
     while(r->N<N_planetesimals + r->N_active){
-		struct reb_particle pt = {0};
-		double a    = reb_random_powerlaw(amin,amax,powerlaw);
+        struct reb_particle pt = {0};
+        double a    = reb_random_powerlaw(amin,amax,powerlaw);
         double e    = reb_random_rayleigh(0.005);
         double inc  = reb_random_rayleigh(0.005);
         double Omega = reb_random_uniform(0,2.*M_PI);
         double apsis = reb_random_uniform(0,2.*M_PI);
-        double phi 	= reb_random_uniform(0,2.*M_PI);
+        double phi     = reb_random_uniform(0,2.*M_PI);
         pt = reb_tools_orbit_to_particle(r->G, star, r->testparticle_type?planetesimal_mass:0., a, e, inc, Omega, apsis, phi);
-		pt.r 		= 0.00000934532;
-		reb_add(r, pt);
+        pt.r         = 0.00000934532;
+        reb_add(r, pt);
     }
 
     reb_move_to_com(r);

--- a/examples/prdrag/problem.c
+++ b/examples/prdrag/problem.c
@@ -14,86 +14,86 @@
 void radiation_forces(struct reb_simulation* r);
 void heartbeat(struct reb_simulation* r);
 
-double betaparticles = 0.01; 	// beta parameter, defined as the ratio of radiation pressure over gravity
+double betaparticles = 0.01;     // beta parameter, defined as the ratio of radiation pressure over gravity
 double tmax = 1e5;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// setup constants
-	r->dt 				= 1e-3;			// initial timestep
-	r->integrator			= REB_INTEGRATOR_IAS15;
-	r->ri_ias15.epsilon 		= 1e-4;			// accuracy parameter
-	r->N_active			= 1; 			// the star is the only massive particle
-	r->force_is_velocity_dependent	= 1;
-	r->additional_forces		= radiation_forces;	// setup callback function for velocity dependent forces
-	r->heartbeat			= heartbeat;
-	
-	// star is at rest at origin
-	struct reb_particle star = {0};
-	star.m  = 1.;
-	reb_add(r, star);
+    struct reb_simulation* r = reb_create_simulation();
+    // setup constants
+    r->dt                 = 1e-3;            // initial timestep
+    r->integrator            = REB_INTEGRATOR_IAS15;
+    r->ri_ias15.epsilon         = 1e-4;            // accuracy parameter
+    r->N_active            = 1;             // the star is the only massive particle
+    r->force_is_velocity_dependent    = 1;
+    r->additional_forces        = radiation_forces;    // setup callback function for velocity dependent forces
+    r->heartbeat            = heartbeat;
+    
+    // star is at rest at origin
+    struct reb_particle star = {0};
+    star.m  = 1.;
+    reb_add(r, star);
 
-	// dust particles are initially on a circular orbit
-	while(r->N<2){
-		struct reb_particle p = {0}; 
-		p.m  = 0;					// massless
-		double a = 1.;					// a = 1 AU
-		double v = sqrt(r->G*(star.m*(1.-betaparticles))/a);
-		double phi = reb_random_uniform(0,2.*M_PI);		// random phase
-		p.x  = a*sin(phi);  p.y  = a*cos(phi); 
-		p.vx = -v*cos(phi); p.vy = v*sin(phi);
-		reb_add(r, p); 
-	}
+    // dust particles are initially on a circular orbit
+    while(r->N<2){
+        struct reb_particle p = {0}; 
+        p.m  = 0;                    // massless
+        double a = 1.;                    // a = 1 AU
+        double v = sqrt(r->G*(star.m*(1.-betaparticles))/a);
+        double phi = reb_random_uniform(0,2.*M_PI);        // random phase
+        p.x  = a*sin(phi);  p.y  = a*cos(phi); 
+        p.vx = -v*cos(phi); p.vy = v*sin(phi);
+        reb_add(r, p); 
+    }
 
-	system("rm -v radius.txt");					// remove previous output
+    system("rm -v radius.txt");                    // remove previous output
 
-	reb_integrate(r, tmax);
+    reb_integrate(r, tmax);
 }
 
 void radiation_forces(struct reb_simulation* r){
-	struct reb_particle* particles = r->particles;
-	const int N = r->N;
-	const struct reb_particle star = particles[0];				// cache
+    struct reb_particle* particles = r->particles;
+    const int N = r->N;
+    const struct reb_particle star = particles[0];                // cache
 #pragma omp parallel for
-	for (int i=0;i<N;i++){
-		const struct reb_particle p = particles[i]; 			// cache
-		if (p.m!=0.) continue; 						// only dust particles feel radiation forces
-		const double prx  = p.x-star.x;
-		const double pry  = p.y-star.y;
-		const double prz  = p.z-star.z;
-		const double pr   = sqrt(prx*prx + pry*pry + prz*prz); 		// distance relative to star
-		const double prvx = p.vx-star.vx;
-		const double prvy = p.vy-star.vy;
-		const double prvz = p.vz-star.vz;
+    for (int i=0;i<N;i++){
+        const struct reb_particle p = particles[i];             // cache
+        if (p.m!=0.) continue;                         // only dust particles feel radiation forces
+        const double prx  = p.x-star.x;
+        const double pry  = p.y-star.y;
+        const double prz  = p.z-star.z;
+        const double pr   = sqrt(prx*prx + pry*pry + prz*prz);         // distance relative to star
+        const double prvx = p.vx-star.vx;
+        const double prvy = p.vy-star.vy;
+        const double prvz = p.vz-star.vz;
 
-		const double c 		= 1.006491504759635e+04; 		// speed of light in unit of G=1, M_sun=1, 1year=1
-		const double rdot 	= (prvx*prx + prvy*pry + prvz*prz)/pr; 	// radial velocity relative to star
-		const double F_r 	= betaparticles*r->G*star.m/(pr*pr);
+        const double c         = 1.006491504759635e+04;         // speed of light in unit of G=1, M_sun=1, 1year=1
+        const double rdot     = (prvx*prx + prvy*pry + prvz*prz)/pr;     // radial velocity relative to star
+        const double F_r     = betaparticles*r->G*star.m/(pr*pr);
 
-		// Equation (5) of Burns, Lamy, Soter (1979)
-		particles[i].ax += F_r*((1.-rdot/c)*prx/pr - prvx/c);
-		particles[i].ay += F_r*((1.-rdot/c)*pry/pr - prvy/c);
-		particles[i].az += F_r*((1.-rdot/c)*prz/pr - prvz/c);
-	}
+        // Equation (5) of Burns, Lamy, Soter (1979)
+        particles[i].ax += F_r*((1.-rdot/c)*prx/pr - prvx/c);
+        particles[i].ay += F_r*((1.-rdot/c)*pry/pr - prvy/c);
+        particles[i].az += F_r*((1.-rdot/c)*prz/pr - prvz/c);
+    }
 }
 
 void heartbeat(struct reb_simulation* r){
-	if(reb_output_check(r, 400.)){						// print some information to screen
-		reb_output_timing(r, tmax);;
-	}
-	if(reb_output_check(r, M_PI*2.*1000.)){ 					// output radial distance every 1000 years
-		FILE* f = fopen("radius.txt","a");
-		struct reb_particle* particles = r->particles;
-		const struct reb_particle star = particles[0];
-		const int N = r->N;
-		for (int i=1;i<N;i++){
-			const struct reb_particle p = particles[i]; 
-			const double prx  = p.x-star.x;
-			const double pry  = p.y-star.y;
-			const double prz  = p.z-star.z;
-			const double pr   = sqrt(prx*prx + pry*pry + prz*prz); 	// distance relative to star
-			fprintf(f,"%e\t%e\n",r->t,pr);
-		}
-		fclose(f);
-	}
+    if(reb_output_check(r, 400.)){                        // print some information to screen
+        reb_output_timing(r, tmax);;
+    }
+    if(reb_output_check(r, M_PI*2.*1000.)){                     // output radial distance every 1000 years
+        FILE* f = fopen("radius.txt","a");
+        struct reb_particle* particles = r->particles;
+        const struct reb_particle star = particles[0];
+        const int N = r->N;
+        for (int i=1;i<N;i++){
+            const struct reb_particle p = particles[i]; 
+            const double prx  = p.x-star.x;
+            const double pry  = p.y-star.y;
+            const double prz  = p.z-star.z;
+            const double pr   = sqrt(prx*prx + pry*pry + prz*prz);     // distance relative to star
+            fprintf(f,"%e\t%e\n",r->t,pr);
+        }
+        fclose(f);
+    }
 }

--- a/examples/profiling/problem.c
+++ b/examples/profiling/problem.c
@@ -17,81 +17,81 @@ double coefficient_of_restitution_bridges(const struct reb_simulation* const r, 
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->opening_angle2 = .5; // This determines the precission of the tree code gravity calculation.
-	r->integrator = REB_INTEGRATOR_SEI;
-	r->boundary = REB_BOUNDARY_SHEAR;
-	r->gravity = REB_GRAVITY_TREE;
-	r->collision = REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->opening_angle2 = .5; // This determines the precission of the tree code gravity calculation.
+    r->integrator = REB_INTEGRATOR_SEI;
+    r->boundary = REB_BOUNDARY_SHEAR;
+    r->gravity = REB_GRAVITY_TREE;
+    r->collision = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	double OMEGA = 0.00013143527; // 1/s
-	r->ri_sei.OMEGA = OMEGA;
-	r->G = 6.67428e-11;		  // N / (1e-5 kg)^2 m^2
-	r->softening = 0.1;		  // m
-	r->dt = 1e-3 * 2. * M_PI / OMEGA; // s
-	r->heartbeat = heartbeat;	 // function pointer for heartbeat
-	// This example uses two root boxes in the x and y direction.
-	// Although not necessary in this case, it allows for the parallelization using MPI.
-	// See Rein & Liu for a description of what a root box is in this context.
-	double surfacedensity = 400;    // kg/m^2
-	double particle_density = 400;  // kg/m^3
-	double particle_radius_min = 1; // m
-	double particle_radius_max = 4; // m
-	double particle_radius_slope = -3;
-	double boxsize = 100; // m
-	if (argc > 1) {       // Try to read boxsize from command line
-		boxsize = atof(argv[1]);
-	}
-	reb_configure_box(r, boxsize, 2, 2, 1);
-	r->nghostx = 2;
-	r->nghosty = 2;
-	r->nghostz = 0;
+    double OMEGA = 0.00013143527; // 1/s
+    r->ri_sei.OMEGA = OMEGA;
+    r->G = 6.67428e-11;          // N / (1e-5 kg)^2 m^2
+    r->softening = 0.1;          // m
+    r->dt = 1e-3 * 2. * M_PI / OMEGA; // s
+    r->heartbeat = heartbeat;     // function pointer for heartbeat
+    // This example uses two root boxes in the x and y direction.
+    // Although not necessary in this case, it allows for the parallelization using MPI.
+    // See Rein & Liu for a description of what a root box is in this context.
+    double surfacedensity = 400;    // kg/m^2
+    double particle_density = 400;  // kg/m^3
+    double particle_radius_min = 1; // m
+    double particle_radius_max = 4; // m
+    double particle_radius_slope = -3;
+    double boxsize = 100; // m
+    if (argc > 1) {       // Try to read boxsize from command line
+        boxsize = atof(argv[1]);
+    }
+    reb_configure_box(r, boxsize, 2, 2, 1);
+    r->nghostx = 2;
+    r->nghosty = 2;
+    r->nghostz = 0;
 
-	// Initial conditions
-	printf("Toomre wavelength: %f\n", 4. * M_PI * M_PI * surfacedensity / OMEGA / OMEGA * r->G);
-	// Use Bridges et al coefficient of restitution.
-	r->coefficient_of_restitution = coefficient_of_restitution_bridges;
-	// When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
-	// By adding a small repulsive velocity to each collision, we prevent this from happening.
-	r->minimum_collision_velocity = particle_radius_min * OMEGA * 0.001; // small fraction of the shear accross a particle
+    // Initial conditions
+    printf("Toomre wavelength: %f\n", 4. * M_PI * M_PI * surfacedensity / OMEGA / OMEGA * r->G);
+    // Use Bridges et al coefficient of restitution.
+    r->coefficient_of_restitution = coefficient_of_restitution_bridges;
+    // When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
+    // By adding a small repulsive velocity to each collision, we prevent this from happening.
+    r->minimum_collision_velocity = particle_radius_min * OMEGA * 0.001; // small fraction of the shear accross a particle
 
-	// Add all ring paricles
-	double total_mass = surfacedensity * r->boxsize.x * r->boxsize.y;
-	double mass = 0;
-	while (mass < total_mass) {
-		struct reb_particle pt = {0};
-		pt.x = reb_random_uniform(-r->boxsize.x / 2., r->boxsize.x / 2.);
-		pt.y = reb_random_uniform(-r->boxsize.y / 2., r->boxsize.y / 2.);
-		pt.z = reb_random_normal(1.); // m
-		pt.vy = -1.5 * pt.x * OMEGA;
-		double radius = reb_random_powerlaw(particle_radius_min, particle_radius_max, particle_radius_slope);
-		pt.r = radius; // m
-		double particle_mass = particle_density * 4. / 3. * M_PI * radius * radius * radius;
-		pt.m = particle_mass; // kg
-		reb_add(r, pt);
-		mass += particle_mass;
-	}
-	reb_integrate(r, INFINITY);
+    // Add all ring paricles
+    double total_mass = surfacedensity * r->boxsize.x * r->boxsize.y;
+    double mass = 0;
+    while (mass < total_mass) {
+        struct reb_particle pt = {0};
+        pt.x = reb_random_uniform(-r->boxsize.x / 2., r->boxsize.x / 2.);
+        pt.y = reb_random_uniform(-r->boxsize.y / 2., r->boxsize.y / 2.);
+        pt.z = reb_random_normal(1.); // m
+        pt.vy = -1.5 * pt.x * OMEGA;
+        double radius = reb_random_powerlaw(particle_radius_min, particle_radius_max, particle_radius_slope);
+        pt.r = radius; // m
+        double particle_mass = particle_density * 4. / 3. * M_PI * radius * radius * radius;
+        pt.m = particle_mass; // kg
+        reb_add(r, pt);
+        mass += particle_mass;
+    }
+    reb_integrate(r, INFINITY);
 }
 
 // This example is using a custom velocity dependend coefficient of restitution
 double coefficient_of_restitution_bridges(const struct reb_simulation* const r, double v) {
-	// assumes v in units of [m/s]
-	double eps = 0.32 * pow(fabs(v) * 100., -0.234);
-	if (eps > 1)
-		eps = 1;
-	if (eps < 0)
-		eps = 0;
-	return eps;
+    // assumes v in units of [m/s]
+    double eps = 0.32 * pow(fabs(v) * 100., -0.234);
+    if (eps > 1)
+        eps = 1;
+    if (eps < 0)
+        eps = 0;
+    return eps;
 }
 
 void heartbeat(struct reb_simulation* const r) {
-	if (reb_output_check(r, 1e-3 * 2. * M_PI / r->ri_sei.OMEGA)) {
-		reb_output_timing(r, 0);
-		//reb_output_append_velocity_dispersion("veldisp.txt");
-	}
-	if (reb_output_check(r, 2. * M_PI / r->ri_sei.OMEGA)) {
-		//reb_output_ascii("position.txt");
-	}
+    if (reb_output_check(r, 1e-3 * 2. * M_PI / r->ri_sei.OMEGA)) {
+        reb_output_timing(r, 0);
+        //reb_output_append_velocity_dispersion("veldisp.txt");
+    }
+    if (reb_output_check(r, 2. * M_PI / r->ri_sei.OMEGA)) {
+        //reb_output_ascii("position.txt");
+    }
 }

--- a/examples/profiling/problem.c
+++ b/examples/profiling/problem.c
@@ -24,6 +24,7 @@ int main(int argc, char* argv[]) {
 	r->boundary = REB_BOUNDARY_SHEAR;
 	r->gravity = REB_GRAVITY_TREE;
 	r->collision = REB_COLLISION_TREE;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	double OMEGA = 0.00013143527; // 1/s
 	r->ri_sei.OMEGA = OMEGA;
 	r->G = 6.67428e-11;		  // N / (1e-5 kg)^2 m^2

--- a/examples/removing_particles_from_simulation/problem.c
+++ b/examples/removing_particles_from_simulation/problem.c
@@ -11,68 +11,68 @@
 #include "rebound.h"
 
 void print_hashes(struct reb_simulation* r){
-	printf("hashes = ");
-	for (int i=0;i<r->N;i++){
-		printf("%u ", r->particles[i].hash);
-	}
-	printf("\n");
+    printf("hashes = ");
+    for (int i=0;i<r->N;i++){
+        printf("%u ", r->particles[i].hash);
+    }
+    printf("\n");
 }
 
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
+    struct reb_simulation* r = reb_create_simulation();
 
-	for (int i=0;i<9;i++){
+    for (int i=0;i<9;i++){
         struct reb_particle p = {0};
         p.hash = i;
         reb_add(r, p);
-	}
+    }
 
     struct reb_particle p = {0};
     p.hash = reb_hash("Planet 9");
     reb_add(r, p);
 
     printf("Initial hashes:\n");
-	print_hashes(r);
+    print_hashes(r);
 
-	int success;
-	int keepSorted = 0;
-	printf("\nTry to remove index 3 (4th particle)...\n");
-	success = reb_remove(r, 3, keepSorted);
-	if (success){
-		printf("Particle successfully removed\n");
-	}
-	print_hashes(r);
-	printf("Because keepSorted = 0, last particle replaced removed particle and indices got scrambled:\n\n");
+    int success;
+    int keepSorted = 0;
+    printf("\nTry to remove index 3 (4th particle)...\n");
+    success = reb_remove(r, 3, keepSorted);
+    if (success){
+        printf("Particle successfully removed\n");
+    }
+    print_hashes(r);
+    printf("Because keepSorted = 0, last particle replaced removed particle and indices got scrambled:\n\n");
 
-	keepSorted = 1;
-	printf("Try to remove index 6 (7th particle)  while preserving the order with keepSorted=1...\n");
-	success = reb_remove(r, 6, keepSorted);
-	if (success){
-		printf("Particle successfully removed\n");
-	}
-	print_hashes(r);
-	
+    keepSorted = 1;
+    printf("Try to remove index 6 (7th particle)  while preserving the order with keepSorted=1...\n");
+    success = reb_remove(r, 6, keepSorted);
+    if (success){
+        printf("Particle successfully removed\n");
+    }
+    print_hashes(r);
+    
     printf("\nWe can also remove particles by the hashes we assign them (this is robust to particles switching indices in the particles array during the simulation).\n");  
     printf("Try to remove Planet 9...\n");
     success = reb_remove_by_hash(r, reb_hash("Planet 9"), keepSorted);
-	if (success){
-		printf("Particle successfully removed\n");
-	}
-	print_hashes(r);
+    if (success){
+        printf("Particle successfully removed\n");
+    }
+    print_hashes(r);
    
     printf("\nFinally, we can remove particles by their hash directly.\n");
-	success = reb_remove_by_hash(r, 1, keepSorted);
-	if (success){
-		printf("Particle successfully removed\n");
-	}
-	print_hashes(r);
-	
-	printf("\nAlso, if we try to remove an index > N, we get an error and no particle is removed:\n");
-	printf("Try to remove index 15...\n");
-	success = reb_remove(r, 15, keepSorted);
-	if (success){
-		printf("Particle successfully removed\n");
-	}
+    success = reb_remove_by_hash(r, 1, keepSorted);
+    if (success){
+        printf("Particle successfully removed\n");
+    }
+    print_hashes(r);
+    
+    printf("\nAlso, if we try to remove an index > N, we get an error and no particle is removed:\n");
+    printf("Try to remove index 15...\n");
+    success = reb_remove(r, 15, keepSorted);
+    if (success){
+        printf("Particle successfully removed\n");
+    }
 }
 

--- a/examples/restarting_simulation/problem.c
+++ b/examples/restarting_simulation/problem.c
@@ -14,44 +14,44 @@
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]){
-	{
-		printf("Running simulation until t=1.\n");
-		struct reb_simulation* r = reb_create_simulation();
-		r->integrator	= REB_INTEGRATOR_SEI;
-		r->collision	= REB_COLLISION_DIRECT;
+    {
+        printf("Running simulation until t=1.\n");
+        struct reb_simulation* r = reb_create_simulation();
+        r->integrator    = REB_INTEGRATOR_SEI;
+        r->collision    = REB_COLLISION_DIRECT;
         r->collision_resolve = reb_collision_resolve_hardsphere;
-		r->boundary 	= REB_BOUNDARY_SHEAR;
-		r->ri_sei.OMEGA	= 1.;	
-		r->dt 		= 1e-4*2.*M_PI; 
-		r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
-		r->nghostx = 1; r->nghosty = 1; r->nghostz = 0;
-		reb_configure_box(r,2.,1,1,1);
+        r->boundary     = REB_BOUNDARY_SHEAR;
+        r->ri_sei.OMEGA    = 1.;    
+        r->dt         = 1e-4*2.*M_PI; 
+        r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
+        r->nghostx = 1; r->nghosty = 1; r->nghostz = 0;
+        reb_configure_box(r,2.,1,1,1);
 
-		while (r->N<50){
-			struct reb_particle p = {0};
-			p.x  = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.x;
-			p.y  = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.y;
-			p.z  = 0.1*((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.z;
-			p.vy = -1.5*p.x*r->ri_sei.OMEGA;
-			p.m  = 0.0001;
-			p.r  = 0.1;
-			reb_add(r, p);
-		}
+        while (r->N<50){
+            struct reb_particle p = {0};
+            p.x  = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.x;
+            p.y  = ((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.y;
+            p.z  = 0.1*((double)rand()/(double)RAND_MAX-0.5)*r->boxsize.z;
+            p.vy = -1.5*p.x*r->ri_sei.OMEGA;
+            p.m  = 0.0001;
+            p.r  = 0.1;
+            reb_add(r, p);
+        }
         r->heartbeat = heartbeat;
-		reb_integrate(r,1.);
-		printf("Saving simulation to binary file and freeing up memory.\n");
-		reb_output_binary(r, "restart.bin");
-		reb_free_simulation(r);
-		r = NULL;
-	}
-	{
-		printf("Creating simulation from binary file and integrating until t=2.\n");
-		struct reb_simulation* r = reb_create_simulation_from_binary("restart.bin");
+        reb_integrate(r,1.);
+        printf("Saving simulation to binary file and freeing up memory.\n");
+        reb_output_binary(r, "restart.bin");
+        reb_free_simulation(r);
+        r = NULL;
+    }
+    {
+        printf("Creating simulation from binary file and integrating until t=2.\n");
+        struct reb_simulation* r = reb_create_simulation_from_binary("restart.bin");
         // Need to reset function pointers
         r->heartbeat = heartbeat;
-		reb_integrate(r,2.);
-		printf("Done.\n");
-	}
+        reb_integrate(r,2.);
+        printf("Done.\n");
+    }
 }
 
 void heartbeat(struct reb_simulation* const r){

--- a/examples/restarting_simulation/problem.c
+++ b/examples/restarting_simulation/problem.c
@@ -19,6 +19,7 @@ int main(int argc, char* argv[]){
 		struct reb_simulation* r = reb_create_simulation();
 		r->integrator	= REB_INTEGRATOR_SEI;
 		r->collision	= REB_COLLISION_DIRECT;
+        r->collision_resolve = reb_collision_resolve_hardsphere;
 		r->boundary 	= REB_BOUNDARY_SHEAR;
 		r->ri_sei.OMEGA	= 1.;	
 		r->dt 		= 1e-4*2.*M_PI; 

--- a/examples/selfgravity_disc/problem.c
+++ b/examples/selfgravity_disc/problem.c
@@ -18,47 +18,47 @@
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* const r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->gravity	= REB_GRAVITY_TREE;
-	r->boundary	= REB_BOUNDARY_OPEN;
-	r->opening_angle2	= 1.5;		// This constant determines the accuracy of the tree code gravity estimate.
-	r->G 		= 1;		
-	r->softening 	= 0.02;		// Gravitational softening length
-	r->dt 		= 3e-2;		// Timestep
-	const double boxsize = 10.2;
-	reb_configure_box(r,boxsize,1,1,1);
+    struct reb_simulation* const r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->gravity    = REB_GRAVITY_TREE;
+    r->boundary    = REB_BOUNDARY_OPEN;
+    r->opening_angle2    = 1.5;        // This constant determines the accuracy of the tree code gravity estimate.
+    r->G         = 1;        
+    r->softening     = 0.02;        // Gravitational softening length
+    r->dt         = 3e-2;        // Timestep
+    const double boxsize = 10.2;
+    reb_configure_box(r,boxsize,1,1,1);
 
-	// Setup particles
-	double disc_mass = 2e-1;	// Total disc mass
-	int N = 10000;			// Number of particles
-	// Initial conditions
-	struct reb_particle star = {0};
-	star.m 		= 1;
-	reb_add(r, star);
-	for (int i=0;i<N;i++){
-		struct reb_particle pt = {0};
-		double a	= reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
-		double phi 	= reb_random_uniform(0,2.*M_PI);
-		pt.x 		= a*cos(phi);
-		pt.y 		= a*sin(phi);
-		pt.z 		= a*reb_random_normal(0.001);
-		double mu 	= star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
-		double vkep 	= sqrt(r->G*mu/a);
-		pt.vx 		=  vkep * sin(phi);
-		pt.vy 		= -vkep * cos(phi);
-		pt.vz 		= 0;
-		pt.m 		= disc_mass/(double)N;
-		reb_add(r, pt);
-	}
+    // Setup particles
+    double disc_mass = 2e-1;    // Total disc mass
+    int N = 10000;            // Number of particles
+    // Initial conditions
+    struct reb_particle star = {0};
+    star.m         = 1;
+    reb_add(r, star);
+    for (int i=0;i<N;i++){
+        struct reb_particle pt = {0};
+        double a    = reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
+        double phi     = reb_random_uniform(0,2.*M_PI);
+        pt.x         = a*cos(phi);
+        pt.y         = a*sin(phi);
+        pt.z         = a*reb_random_normal(0.001);
+        double mu     = star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
+        double vkep     = sqrt(r->G*mu/a);
+        pt.vx         =  vkep * sin(phi);
+        pt.vy         = -vkep * cos(phi);
+        pt.vz         = 0;
+        pt.m         = disc_mass/(double)N;
+        reb_add(r, pt);
+    }
 
-	r->heartbeat = heartbeat;
-	reb_integrate(r, INFINITY);
+    r->heartbeat = heartbeat;
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r,10.0*r->dt)){
-		reb_output_timing(r,0);
-	}
+    if (reb_output_check(r,10.0*r->dt)){
+        reb_output_timing(r,0);
+    }
 }

--- a/examples/selfgravity_disc_mpi/problem.c
+++ b/examples/selfgravity_disc_mpi/problem.c
@@ -24,54 +24,54 @@
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* const r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->gravity	= REB_GRAVITY_TREE;
-	r->boundary	= REB_BOUNDARY_OPEN;
-	r->opening_angle2	= 1.5;		// This constant determines the accuracy of the tree code gravity estimate.
-	r->G 		= 1;		
-	r->softening 	= 0.02;		// Gravitational softening length
-	r->dt 		= 3e-2;		// Timestep
-	const double boxsize = 10.2;
+    struct reb_simulation* const r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->gravity    = REB_GRAVITY_TREE;
+    r->boundary    = REB_BOUNDARY_OPEN;
+    r->opening_angle2    = 1.5;        // This constant determines the accuracy of the tree code gravity estimate.
+    r->G         = 1;        
+    r->softening     = 0.02;        // Gravitational softening length
+    r->dt         = 3e-2;        // Timestep
+    const double boxsize = 10.2;
     // Setup root boxes for gravity tree.
     // Here, we use 2x2=4 root boxes (each with length 'boxsize')
     // This allows you to use up to 4 MPI nodes.
-	reb_configure_box(r,boxsize,2,2,1);
+    reb_configure_box(r,boxsize,2,2,1);
 
     // Initialize MPI
     // This can only be done after reb_configure_box.
     reb_mpi_init(r);
 
-	// Setup particles only on master node
+    // Setup particles only on master node
     // In the first timestep, the master node will 
     // distribute particles to other nodes. 
     // Note that this is not the most efficient method
     // for very large particle numbers.
-    double disc_mass = 2e-1/r->mpi_num;	// Total disc mass
-    int N = 10000/r->mpi_num;			// Number of particles
+    double disc_mass = 2e-1/r->mpi_num;    // Total disc mass
+    int N = 10000/r->mpi_num;            // Number of particles
     // Initial conditions
     struct reb_particle star = {0};
-    star.m 		= 1;
+    star.m         = 1;
     if (r->mpi_id==0){
         reb_add(r, star);
     }
     for (int i=0;i<N;i++){
         struct reb_particle pt = {0};
-        double a	= reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
-        double phi 	= reb_random_uniform(0,2.*M_PI);
-        pt.x 		= a*cos(phi);
-        pt.y 		= a*sin(phi);
-        pt.z 		= a*reb_random_normal(0.001);
-        double mu 	= star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
-        double vkep 	= sqrt(r->G*mu/a);
-        pt.vx 		=  vkep * sin(phi);
-        pt.vy 		= -vkep * cos(phi);
-        pt.vz 		= 0;
-        pt.m 		= disc_mass/(double)N;
+        double a    = reb_random_powerlaw(boxsize/10.,boxsize/2./1.2,-1.5);
+        double phi     = reb_random_uniform(0,2.*M_PI);
+        pt.x         = a*cos(phi);
+        pt.y         = a*sin(phi);
+        pt.z         = a*reb_random_normal(0.001);
+        double mu     = star.m + disc_mass * (pow(a,-3./2.)-pow(boxsize/10.,-3./2.))/(pow(boxsize/2./1.2,-3./2.)-pow(boxsize/10.,-3./2.));
+        double vkep     = sqrt(r->G*mu/a);
+        pt.vx         =  vkep * sin(phi);
+        pt.vy         = -vkep * cos(phi);
+        pt.vz         = 0;
+        pt.m         = disc_mass/(double)N;
         reb_add(r, pt);
     }
-	r->heartbeat = heartbeat;
+    r->heartbeat = heartbeat;
 
 #ifdef OPENGL
     // Hack to artificially increase particle array.
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]){
     r->particles = realloc(r->particles,sizeof(struct reb_particle)*r->allocatedN);
 #endif // OPENGL
     
-	// Start the integration
+    // Start the integration
     reb_integrate(r, INFINITY);
 
     // Cleanup
@@ -89,7 +89,7 @@ int main(int argc, char* argv[]){
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r,10.0*r->dt)){
-		reb_output_timing(r,0);
-	}
+    if (reb_output_check(r,10.0*r->dt)){
+        reb_output_timing(r,0);
+    }
 }

--- a/examples/selfgravity_plummer/problem.c
+++ b/examples/selfgravity_plummer/problem.c
@@ -16,34 +16,34 @@
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
+    struct reb_simulation* r = reb_create_simulation();
 
-	// Setup system characteristics
-	int _N = 100; 			// Number of particles
-	double G = 1;			// Gravitational constant
-	double M = 1;			// Total mass of the cluster
-	double R = 1;			// Radius of the cluster
-	double E = 3./64.*M_PI*M*M/R;	// Energy of the cluster
-	double r0 = 16./(3.*M_PI)*R;	// Chacateristic length scale
-	double t0 = r->G*pow(M,5./2.)*pow(4.*E,-3./2.)*(double)_N/log(0.4*(double)_N); // Rellaxation time
-	printf("Characteristic size:              %f\n", r0);
-	printf("Characteristic time (relaxation): %f\n", t0);
+    // Setup system characteristics
+    int _N = 100;             // Number of particles
+    double G = 1;            // Gravitational constant
+    double M = 1;            // Total mass of the cluster
+    double R = 1;            // Radius of the cluster
+    double E = 3./64.*M_PI*M*M/R;    // Energy of the cluster
+    double r0 = 16./(3.*M_PI)*R;    // Chacateristic length scale
+    double t0 = r->G*pow(M,5./2.)*pow(4.*E,-3./2.)*(double)_N/log(0.4*(double)_N); // Rellaxation time
+    printf("Characteristic size:              %f\n", r0);
+    printf("Characteristic time (relaxation): %f\n", t0);
 
-	// Setup constants
-	r->G 		= G;		
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->dt 		= 2e-5*t0; 	// timestep
-	r->softening 	= 0.01*r0;	// Softening parameter
-	r->heartbeat	= heartbeat;
-	
-	reb_configure_box(r, 20.*r0, 1, 1, 1);
-	reb_tools_init_plummer(r, _N, M, R);	// Adds particles
-	reb_move_to_com(r); 
-	reb_integrate(r, INFINITY);
+    // Setup constants
+    r->G         = G;        
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->dt         = 2e-5*t0;     // timestep
+    r->softening     = 0.01*r0;    // Softening parameter
+    r->heartbeat    = heartbeat;
+    
+    reb_configure_box(r, 20.*r0, 1, 1, 1);
+    reb_tools_init_plummer(r, _N, M, R);    // Adds particles
+    reb_move_to_com(r); 
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10.0*r->dt)){
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 10.0*r->dt)){
+        reb_output_timing(r, 0);
+    }
 }

--- a/examples/shearing_sheet/problem.c
+++ b/examples/shearing_sheet/problem.c
@@ -17,86 +17,86 @@ double coefficient_of_restitution_bridges(const struct reb_simulation* const r, 
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->opening_angle2	= .5;					// This determines the precission of the tree code gravity calculation.
-	r->integrator			= REB_INTEGRATOR_SEI;
-	r->boundary			= REB_BOUNDARY_SHEAR;
-	r->gravity			= REB_GRAVITY_TREE;
-	r->collision			= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->opening_angle2    = .5;                    // This determines the precission of the tree code gravity calculation.
+    r->integrator            = REB_INTEGRATOR_SEI;
+    r->boundary            = REB_BOUNDARY_SHEAR;
+    r->gravity            = REB_GRAVITY_TREE;
+    r->collision            = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	double OMEGA 			= 0.00013143527;	// 1/s
-	r->ri_sei.OMEGA 		= OMEGA;
-	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2
-	r->softening 			= 0.1;			// m
-	r->dt 				= 1e-3*2.*M_PI/OMEGA;	// s
-	r->heartbeat			= heartbeat;	// function pointer for heartbeat
-	// This example uses two root boxes in the x and y direction. 
-	// Although not necessary in this case, it allows for the parallelization using MPI. 
-	// See Rein & Liu for a description of what a root box is in this context.
-	double surfacedensity 		= 400; 			// kg/m^2
-	double particle_density		= 400;			// kg/m^3
-	double particle_radius_min 	= 1;			// m
-	double particle_radius_max 	= 4;			// m
-	double particle_radius_slope 	= -3;	
-	double boxsize 			= 100;			// m
-	if (argc>1){						// Try to read boxsize from command line
-		boxsize = atof(argv[1]);
-	}
-	reb_configure_box(r, boxsize, 2, 2, 1);
-	r->nghostx = 2;
-	r->nghosty = 2;
-	r->nghostz = 0;
-	
-	// Initial conditions
-	printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
-	// Use Bridges et al coefficient of restitution.
-	r->coefficient_of_restitution = coefficient_of_restitution_bridges;
-	// When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
-	// By adding a small repulsive velocity to each collision, we prevent this from happening.
-	r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
+    double OMEGA             = 0.00013143527;    // 1/s
+    r->ri_sei.OMEGA         = OMEGA;
+    r->G                 = 6.67428e-11;        // N / (1e-5 kg)^2 m^2
+    r->softening             = 0.1;            // m
+    r->dt                 = 1e-3*2.*M_PI/OMEGA;    // s
+    r->heartbeat            = heartbeat;    // function pointer for heartbeat
+    // This example uses two root boxes in the x and y direction. 
+    // Although not necessary in this case, it allows for the parallelization using MPI. 
+    // See Rein & Liu for a description of what a root box is in this context.
+    double surfacedensity         = 400;             // kg/m^2
+    double particle_density        = 400;            // kg/m^3
+    double particle_radius_min     = 1;            // m
+    double particle_radius_max     = 4;            // m
+    double particle_radius_slope     = -3;    
+    double boxsize             = 100;            // m
+    if (argc>1){                        // Try to read boxsize from command line
+        boxsize = atof(argv[1]);
+    }
+    reb_configure_box(r, boxsize, 2, 2, 1);
+    r->nghostx = 2;
+    r->nghosty = 2;
+    r->nghostz = 0;
+    
+    // Initial conditions
+    printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
+    // Use Bridges et al coefficient of restitution.
+    r->coefficient_of_restitution = coefficient_of_restitution_bridges;
+    // When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
+    // By adding a small repulsive velocity to each collision, we prevent this from happening.
+    r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
 
 
-	// Add all ring paricles
-	double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y;
-	double mass = 0;
-	while(mass<total_mass){
-		struct reb_particle pt;
-		pt.x 		= reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
-		pt.y 		= reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
-		pt.z 		= reb_random_normal(1.);					// m
-		pt.vx 		= 0;
-		pt.vy 		= -1.5*pt.x*OMEGA;
-		pt.vz 		= 0;
-		pt.ax 		= 0;
-		pt.ay 		= 0;
-		pt.az 		= 0;
-		double radius 	= reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
-		pt.r 		= radius;						// m
-		double		particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
-		pt.m 		= particle_mass; 	// kg
-		reb_add(r, pt);
-		mass += particle_mass;
-	}
-	reb_integrate(r, INFINITY);
+    // Add all ring paricles
+    double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y;
+    double mass = 0;
+    while(mass<total_mass){
+        struct reb_particle pt;
+        pt.x         = reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
+        pt.y         = reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
+        pt.z         = reb_random_normal(1.);                    // m
+        pt.vx         = 0;
+        pt.vy         = -1.5*pt.x*OMEGA;
+        pt.vz         = 0;
+        pt.ax         = 0;
+        pt.ay         = 0;
+        pt.az         = 0;
+        double radius     = reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
+        pt.r         = radius;                        // m
+        double        particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
+        pt.m         = particle_mass;     // kg
+        reb_add(r, pt);
+        mass += particle_mass;
+    }
+    reb_integrate(r, INFINITY);
 }
 
 // This example is using a custom velocity dependend coefficient of restitution
 double coefficient_of_restitution_bridges(const struct reb_simulation* const r, double v){
-	// assumes v in units of [m/s]
-	double eps = 0.32*pow(fabs(v)*100.,-0.234);
-	if (eps>1) eps=1;
-	if (eps<0) eps=0;
-	return eps;
+    // assumes v in units of [m/s]
+    double eps = 0.32*pow(fabs(v)*100.,-0.234);
+    if (eps>1) eps=1;
+    if (eps<0) eps=0;
+    return eps;
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
-		reb_output_timing(r, 0);
-		//reb_output_append_velocity_dispersion("veldisp.txt");
-	}
-	if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
-		//reb_output_ascii("position.txt");
-	}
+    if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
+        reb_output_timing(r, 0);
+        //reb_output_append_velocity_dispersion("veldisp.txt");
+    }
+    if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
+        //reb_output_ascii("position.txt");
+    }
 }
 

--- a/examples/shearing_sheet/problem.c
+++ b/examples/shearing_sheet/problem.c
@@ -24,6 +24,7 @@ int main(int argc, char* argv[]) {
 	r->boundary			= REB_BOUNDARY_SHEAR;
 	r->gravity			= REB_GRAVITY_TREE;
 	r->collision			= REB_COLLISION_TREE;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	double OMEGA 			= 0.00013143527;	// 1/s
 	r->ri_sei.OMEGA 		= OMEGA;
 	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2

--- a/examples/shearing_sheet_2/problem.c
+++ b/examples/shearing_sheet_2/problem.c
@@ -30,6 +30,7 @@ int main(int argc, char* argv[]) {
 	r->boundary			= REB_BOUNDARY_SHEAR;
 	r->gravity			= REB_GRAVITY_TREE;
 	r->collision			= REB_COLLISION_TREE;
+    r->collision_resolve = collision_resolve_hardsphere_pullaway;
 	double OMEGA 			= 0.00013143527;	// 1/s
 	r->ri_sei.OMEGA 		= OMEGA;
 	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2

--- a/examples/shearing_sheet_2/problem.c
+++ b/examples/shearing_sheet_2/problem.c
@@ -23,171 +23,171 @@ double coefficient_of_restitution_bridges(const struct reb_simulation* const r, 
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->opening_angle2	= .5;					// This determines the precission of the tree code gravity calculation.
-	r->integrator			= REB_INTEGRATOR_SEI;
-	r->boundary			= REB_BOUNDARY_SHEAR;
-	r->gravity			= REB_GRAVITY_TREE;
-	r->collision			= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->opening_angle2    = .5;                    // This determines the precission of the tree code gravity calculation.
+    r->integrator            = REB_INTEGRATOR_SEI;
+    r->boundary            = REB_BOUNDARY_SHEAR;
+    r->gravity            = REB_GRAVITY_TREE;
+    r->collision            = REB_COLLISION_TREE;
     r->collision_resolve = collision_resolve_hardsphere_pullaway;
-	double OMEGA 			= 0.00013143527;	// 1/s
-	r->ri_sei.OMEGA 		= OMEGA;
-	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2
-	r->softening 			= 0.1;			// m
-	r->dt 				= 1e-3*2.*M_PI/OMEGA;	// s
-	r->heartbeat			= heartbeat;	// function pointer for heartbeat
-	// This example uses two root boxes in the x and y direction. 
-	// Although not necessary in this case, it allows for the parallelization using MPI. 
-	// See Rein & Liu for a description of what a root box is in this context.
-	double surfacedensity 		= 400; 			// kg/m^2
-	double particle_density		= 400;			// kg/m^3
-	double particle_radius_min 	= 1;			// m
-	double particle_radius_max 	= 4;			// m
-	double particle_radius_slope 	= -3;	
-	double boxsize 			= 100;			// m
-	if (argc>1){						// Try to read boxsize from command line
-		boxsize = atof(argv[1]);
-	}
-	reb_configure_box(r, boxsize, 2, 2, 1);
-	r->nghostx = 2;
-	r->nghosty = 2;
-	r->nghostz = 0;
-	
-	// Initial conditions
-	printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
-	// Use Bridges et al coefficient of restitution.
-	r->coefficient_of_restitution = coefficient_of_restitution_bridges;
-	// When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
-	// By adding a small repulsive velocity to each collision, we prevent this from happening.
-	r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
+    double OMEGA             = 0.00013143527;    // 1/s
+    r->ri_sei.OMEGA         = OMEGA;
+    r->G                 = 6.67428e-11;        // N / (1e-5 kg)^2 m^2
+    r->softening             = 0.1;            // m
+    r->dt                 = 1e-3*2.*M_PI/OMEGA;    // s
+    r->heartbeat            = heartbeat;    // function pointer for heartbeat
+    // This example uses two root boxes in the x and y direction. 
+    // Although not necessary in this case, it allows for the parallelization using MPI. 
+    // See Rein & Liu for a description of what a root box is in this context.
+    double surfacedensity         = 400;             // kg/m^2
+    double particle_density        = 400;            // kg/m^3
+    double particle_radius_min     = 1;            // m
+    double particle_radius_max     = 4;            // m
+    double particle_radius_slope     = -3;    
+    double boxsize             = 100;            // m
+    if (argc>1){                        // Try to read boxsize from command line
+        boxsize = atof(argv[1]);
+    }
+    reb_configure_box(r, boxsize, 2, 2, 1);
+    r->nghostx = 2;
+    r->nghosty = 2;
+    r->nghostz = 0;
+    
+    // Initial conditions
+    printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
+    // Use Bridges et al coefficient of restitution.
+    r->coefficient_of_restitution = coefficient_of_restitution_bridges;
+    // When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
+    // By adding a small repulsive velocity to each collision, we prevent this from happening.
+    r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
 
 
-	// Add all ring paricles
-	double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y;
-	double mass = 0;
-	while(mass<total_mass){
-		struct reb_particle pt = {0};
-		pt.x 		= reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
-		pt.y 		= reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
-		pt.z 		= reb_random_normal(1.);					// m
-		pt.vy 		= -1.5*pt.x*OMEGA;
-		double radius 	= reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
-		pt.r 		= radius;						// m
-		double		particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
-		pt.m 		= particle_mass; 	// kg
-		reb_add(r, pt);
-		mass += particle_mass;
-	}
-	reb_integrate(r, INFINITY);
+    // Add all ring paricles
+    double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y;
+    double mass = 0;
+    while(mass<total_mass){
+        struct reb_particle pt = {0};
+        pt.x         = reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
+        pt.y         = reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
+        pt.z         = reb_random_normal(1.);                    // m
+        pt.vy         = -1.5*pt.x*OMEGA;
+        double radius     = reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
+        pt.r         = radius;                        // m
+        double        particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
+        pt.m         = particle_mass;     // kg
+        reb_add(r, pt);
+        mass += particle_mass;
+    }
+    reb_integrate(r, INFINITY);
 }
 
 // This example is using a custom velocity dependend coefficient of restitution
 double coefficient_of_restitution_bridges(const struct reb_simulation* const r, double v){
-	// assumes v in units of [m/s]
-	double eps = 0.32*pow(fabs(v)*100.,-0.234);
-	if (eps>1) eps=1;
-	if (eps<0) eps=0;
-	return eps;
+    // assumes v in units of [m/s]
+    double eps = 0.32*pow(fabs(v)*100.,-0.234);
+    if (eps>1) eps=1;
+    if (eps<0) eps=0;
+    return eps;
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
-		reb_output_timing(r, 0);
-		//reb_output_append_velocity_dispersion("veldisp.txt");
-	}
-	if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
-		//reb_output_ascii("position.txt");
-	}
+    if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
+        reb_output_timing(r, 0);
+        //reb_output_append_velocity_dispersion("veldisp.txt");
+    }
+    if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
+        //reb_output_ascii("position.txt");
+    }
 }
 
 // Function written by Akihiko Fujii
 int collision_resolve_hardsphere_pullaway(struct reb_simulation* r, struct reb_collision c){
-	struct reb_particle* particles = r->particles;
-	struct reb_particle p1 = particles[c.p1];
-	struct reb_particle p2 = particles[c.p2];
-	struct reb_ghostbox gb = c.gb;
-	double x21  = p1.x + gb.shiftx  - p2.x; 
-	double y21  = p1.y + gb.shifty  - p2.y; 
-	double z21  = p1.z + gb.shiftz  - p2.z; 
-	double _r = sqrt(x21*x21 + y21*y21 + z21*z21);
-	/* double r21 = sqrt(x21*x21 + y21*y21 + z21*z21); */
-	double rp   = p1.r+p2.r;
-	double oldvyouter;
+    struct reb_particle* particles = r->particles;
+    struct reb_particle p1 = particles[c.p1];
+    struct reb_particle p2 = particles[c.p2];
+    struct reb_ghostbox gb = c.gb;
+    double x21  = p1.x + gb.shiftx  - p2.x; 
+    double y21  = p1.y + gb.shifty  - p2.y; 
+    double z21  = p1.z + gb.shiftz  - p2.z; 
+    double _r = sqrt(x21*x21 + y21*y21 + z21*z21);
+    /* double r21 = sqrt(x21*x21 + y21*y21 + z21*z21); */
+    double rp   = p1.r+p2.r;
+    double oldvyouter;
 
-	if (x21>0){
-		oldvyouter = p1.vy;
-	}else{
-		oldvyouter = p2.vy;
-	}
+    if (x21>0){
+        oldvyouter = p1.vy;
+    }else{
+        oldvyouter = p2.vy;
+    }
 
-	if (rp*rp < x21*x21 + y21*y21 + z21*z21) return 0;
+    if (rp*rp < x21*x21 + y21*y21 + z21*z21) return 0;
 
-	double vx21 = p1.vx + gb.shiftvx - p2.vx; 
-	double vy21 = p1.vy + gb.shiftvy - p2.vy; 
-	double vz21 = p1.vz + gb.shiftvz - p2.vz; 
+    double vx21 = p1.vx + gb.shiftvx - p2.vx; 
+    double vy21 = p1.vy + gb.shiftvy - p2.vy; 
+    double vz21 = p1.vz + gb.shiftvz - p2.vz; 
 
-	if (vx21*x21 + vy21*y21 + vz21*z21 >0) return 0; // not approaching
+    if (vx21*x21 + vy21*y21 + vz21*z21 >0) return 0; // not approaching
 
-	// Bring the to balls in the xy plane.
-	// NOTE: this could probabely be an atan (which is faster than atan2) 
-	double theta = atan2(z21,y21);
-	double stheta = sin(theta);
-	double ctheta = cos(theta);
-	double vy21n = ctheta * vy21 + stheta * vz21;
-	double y21n = ctheta * y21 + stheta * z21;
+    // Bring the to balls in the xy plane.
+    // NOTE: this could probabely be an atan (which is faster than atan2) 
+    double theta = atan2(z21,y21);
+    double stheta = sin(theta);
+    double ctheta = cos(theta);
+    double vy21n = ctheta * vy21 + stheta * vz21;
+    double y21n = ctheta * y21 + stheta * z21;
 
-	// Bring the two balls onto the positive x axis.
-	double phi = atan2(y21n,x21);
-	double cphi = cos(phi);
-	double sphi = sin(phi);
-	double vx21nn = cphi * vx21  + sphi * vy21n;
-	double vy21nn = -sphi* vx21  + cphi * vy21n;
+    // Bring the two balls onto the positive x axis.
+    double phi = atan2(y21n,x21);
+    double cphi = cos(phi);
+    double sphi = sin(phi);
+    double vx21nn = cphi * vx21  + sphi * vy21n;
+    double vy21nn = -sphi* vx21  + cphi * vy21n;
 
-	// Coefficient of restitution
-	double eps= r->coefficient_of_restitution(r, vx21nn);
-	double dvx2 = -(1.0+eps)*vx21nn;
-	double dvy2 = (_r/rp-1.)*vy21nn;
+    // Coefficient of restitution
+    double eps= r->coefficient_of_restitution(r, vx21nn);
+    double dvx2 = -(1.0+eps)*vx21nn;
+    double dvy2 = (_r/rp-1.)*vy21nn;
 
-	double minr = (p1.r>p2.r)?p2.r:p1.r;
-	double maxr = (p1.r<p2.r)?p2.r:p1.r;
-	double mindv= minr*r->minimum_collision_velocity;
-	mindv *= 1.-(_r - maxr)/minr;
-	if (mindv>maxr*r->minimum_collision_velocity)mindv = maxr*r->minimum_collision_velocity;
-	if (dvx2<mindv) dvx2 = mindv;
+    double minr = (p1.r>p2.r)?p2.r:p1.r;
+    double maxr = (p1.r<p2.r)?p2.r:p1.r;
+    double mindv= minr*r->minimum_collision_velocity;
+    mindv *= 1.-(_r - maxr)/minr;
+    if (mindv>maxr*r->minimum_collision_velocity)mindv = maxr*r->minimum_collision_velocity;
+    if (dvx2<mindv) dvx2 = mindv;
 
-	double dxx2 = rp-_r;
-	double dxx2n = cphi * dxx2;
-	double dxy2n = sphi * dxx2;
-	double dxy2nn = ctheta * dxy2n;
-	double dxz2nn = stheta * dxy2n;
+    double dxx2 = rp-_r;
+    double dxx2n = cphi * dxx2;
+    double dxy2n = sphi * dxx2;
+    double dxy2nn = ctheta * dxy2n;
+    double dxz2nn = stheta * dxy2n;
 
-	double dvx2n = cphi * dvx2 - sphi * dvy2;
-	double dvy2n = sphi * dvx2 + cphi * dvy2;
+    double dvx2n = cphi * dvx2 - sphi * dvy2;
+    double dvy2n = sphi * dvx2 + cphi * dvy2;
 
-	double dvy2nn = ctheta * dvy2n;
-	double dvz2nn = stheta * dvy2n;
+    double dvy2nn = ctheta * dvy2n;
+    double dvz2nn = stheta * dvy2n;
 
-	// Applying the changes to the particles.
-	const double p1pf = p1.m/(p1.m+p2.m);
-	const double p2pf = p2.m/(p1.m+p2.m);
-	particles[c.p2].vx -=	p1pf*dvx2n;
-	particles[c.p2].vy -=	p1pf*dvy2nn;
-	particles[c.p2].vz -=	p1pf*dvz2nn;
-	particles[c.p2].lastcollision = r->t;
-	particles[c.p2].x -=	p1pf*dxx2n;
-	particles[c.p2].y -=	p1pf*dxy2nn;
-	particles[c.p2].z -=	p1pf*dxz2nn;
+    // Applying the changes to the particles.
+    const double p1pf = p1.m/(p1.m+p2.m);
+    const double p2pf = p2.m/(p1.m+p2.m);
+    particles[c.p2].vx -=    p1pf*dvx2n;
+    particles[c.p2].vy -=    p1pf*dvy2nn;
+    particles[c.p2].vz -=    p1pf*dvz2nn;
+    particles[c.p2].lastcollision = r->t;
+    particles[c.p2].x -=    p1pf*dxx2n;
+    particles[c.p2].y -=    p1pf*dxy2nn;
+    particles[c.p2].z -=    p1pf*dxz2nn;
 
 
-	particles[c.p1].vx +=	p2pf*dvx2n;
-	particles[c.p1].vy +=	p2pf*dvy2nn;
-	particles[c.p1].vz +=	p2pf*dvz2nn;
-	particles[c.p1].x +=	p2pf*dxx2n; 
-	particles[c.p1].y +=	p2pf*dxy2nn; 
-	particles[c.p1].z +=	p2pf*dxz2nn; 
+    particles[c.p1].vx +=    p2pf*dvx2n;
+    particles[c.p1].vy +=    p2pf*dvy2nn;
+    particles[c.p1].vz +=    p2pf*dvz2nn;
+    particles[c.p1].x +=    p2pf*dxx2n; 
+    particles[c.p1].y +=    p2pf*dxy2nn; 
+    particles[c.p1].z +=    p2pf*dxz2nn; 
 
-	particles[c.p1].lastcollision = r->t;
+    particles[c.p1].lastcollision = r->t;
 
     return 0; // Do not remove any particle
 }

--- a/examples/shearing_sheet_mpi/problem.c
+++ b/examples/shearing_sheet_mpi/problem.c
@@ -20,71 +20,71 @@ double coefficient_of_restitution_bridges(const struct reb_simulation* const r, 
 void heartbeat(struct reb_simulation* const r);
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->opening_angle2	= .5;					// This determines the precission of the tree code gravity calculation.
-	r->integrator		= REB_INTEGRATOR_SEI;
-	r->boundary			= REB_BOUNDARY_SHEAR;
-	r->gravity			= REB_GRAVITY_TREE;
-	r->collision		= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->opening_angle2    = .5;                    // This determines the precission of the tree code gravity calculation.
+    r->integrator        = REB_INTEGRATOR_SEI;
+    r->boundary            = REB_BOUNDARY_SHEAR;
+    r->gravity            = REB_GRAVITY_TREE;
+    r->collision        = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-	double OMEGA 		= 0.00013143527;	// 1/s
-	r->ri_sei.OMEGA 	= OMEGA;
-	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2
-	r->softening 		= 0.1;			// m
-	r->dt 				= 1e-3*2.*M_PI/OMEGA;	// s
-	r->heartbeat		= heartbeat;	// function pointer for heartbeat
-	// This example uses two root boxes in the x and y direction. 
-	// Although not necessary in this case, it allows for the parallelization using MPI. 
-	// See Rein & Liu for a description of what a root box is in this context.
-	double surfacedensity 		= 400; 			// kg/m^2
-	double particle_density		= 400;			// kg/m^3
-	double particle_radius_min 	= 1;			// m
-	double particle_radius_max 	= 4;			// m
-	double particle_radius_slope 	= -3;	
-	double boxsize 			= 100;			// m
-	if (argc>1){						// Try to read boxsize from command line
-		boxsize = atof(argv[1]);
-	}
+    double OMEGA         = 0.00013143527;    // 1/s
+    r->ri_sei.OMEGA     = OMEGA;
+    r->G                 = 6.67428e-11;        // N / (1e-5 kg)^2 m^2
+    r->softening         = 0.1;            // m
+    r->dt                 = 1e-3*2.*M_PI/OMEGA;    // s
+    r->heartbeat        = heartbeat;    // function pointer for heartbeat
+    // This example uses two root boxes in the x and y direction. 
+    // Although not necessary in this case, it allows for the parallelization using MPI. 
+    // See Rein & Liu for a description of what a root box is in this context.
+    double surfacedensity         = 400;             // kg/m^2
+    double particle_density        = 400;            // kg/m^3
+    double particle_radius_min     = 1;            // m
+    double particle_radius_max     = 4;            // m
+    double particle_radius_slope     = -3;    
+    double boxsize             = 100;            // m
+    if (argc>1){                        // Try to read boxsize from command line
+        boxsize = atof(argv[1]);
+    }
     // Setup 2x2 root boxes.
     // This allows you to use up to 4 MPI nodes.
-	reb_configure_box(r, boxsize, 2, 2, 1);
+    reb_configure_box(r, boxsize, 2, 2, 1);
     // Initialize MPI (this only works after reb_configure_box)
     reb_mpi_init(r);
-	r->nghostx = 2;
-	r->nghosty = 2;
-	r->nghostz = 0;
-	
-	// Initial conditions
-	printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
-	// Use Bridges et al coefficient of restitution.
-	r->coefficient_of_restitution = coefficient_of_restitution_bridges;
-	// When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
-	// By adding a small repulsive velocity to each collision, we prevent this from happening.
-	r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
+    r->nghostx = 2;
+    r->nghosty = 2;
+    r->nghostz = 0;
+    
+    // Initial conditions
+    printf("Toomre wavelength: %f\n",4.*M_PI*M_PI*surfacedensity/OMEGA/OMEGA*r->G);
+    // Use Bridges et al coefficient of restitution.
+    r->coefficient_of_restitution = coefficient_of_restitution_bridges;
+    // When two particles collide and the relative velocity is zero, the might sink into each other in the next time step.
+    // By adding a small repulsive velocity to each collision, we prevent this from happening.
+    r->minimum_collision_velocity = particle_radius_min*OMEGA*0.001;  // small fraction of the shear accross a particle
 
 
-	// Add all ring paricles
-	double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y/r->mpi_num;
-	double mass = 0;
-	while(mass<total_mass){
-		struct reb_particle pt;
-		pt.x 		= reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
-		pt.y 		= reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
-		pt.z 		= reb_random_normal(1.);					// m
-		pt.vx 		= 0;
-		pt.vy 		= -1.5*pt.x*OMEGA;
-		pt.vz 		= 0;
-		pt.ax 		= 0;
-		pt.ay 		= 0;
-		pt.az 		= 0;
-		double radius 	= reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
-		pt.r 		= radius;						// m
-		double		particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
-		pt.m 		= particle_mass; 	// kg
-		reb_add(r, pt);
-		mass += particle_mass;
-	}
+    // Add all ring paricles
+    double total_mass = surfacedensity*r->boxsize.x*r->boxsize.y/r->mpi_num;
+    double mass = 0;
+    while(mass<total_mass){
+        struct reb_particle pt;
+        pt.x         = reb_random_uniform(-r->boxsize.x/2.,r->boxsize.x/2.);
+        pt.y         = reb_random_uniform(-r->boxsize.y/2.,r->boxsize.y/2.);
+        pt.z         = reb_random_normal(1.);                    // m
+        pt.vx         = 0;
+        pt.vy         = -1.5*pt.x*OMEGA;
+        pt.vz         = 0;
+        pt.ax         = 0;
+        pt.ay         = 0;
+        pt.az         = 0;
+        double radius     = reb_random_powerlaw(particle_radius_min,particle_radius_max,particle_radius_slope);
+        pt.r         = radius;                        // m
+        double        particle_mass = particle_density*4./3.*M_PI*radius*radius*radius;
+        pt.m         = particle_mass;     // kg
+        reb_add(r, pt);
+        mass += particle_mass;
+    }
 #ifdef OPENGL
     // Hack to artificially increase particle array.
     // This cannot be done once OpenGL is activated. 
@@ -93,7 +93,7 @@ int main(int argc, char* argv[]) {
 #endif // OPENGL
 
     // Start the integration
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 
     // Cleanup
     reb_mpi_finalize(r);
@@ -102,20 +102,20 @@ int main(int argc, char* argv[]) {
 
 // This example is using a custom velocity dependend coefficient of restitution
 double coefficient_of_restitution_bridges(const struct reb_simulation* const r, double v){
-	// assumes v in units of [m/s]
-	double eps = 0.32*pow(fabs(v)*100.,-0.234);
-	if (eps>1) eps=1;
-	if (eps<0) eps=0;
-	return eps;
+    // assumes v in units of [m/s]
+    double eps = 0.32*pow(fabs(v)*100.,-0.234);
+    if (eps>1) eps=1;
+    if (eps<0) eps=0;
+    return eps;
 }
 
 void heartbeat(struct reb_simulation* const r){
-	if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
-		reb_output_timing(r, 0);
-		//reb_output_append_velocity_dispersion("veldisp.txt");
-	}
-	if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
-		//reb_output_ascii("position.txt");
-	}
+    if (reb_output_check(r, 1e-3*2.*M_PI/r->ri_sei.OMEGA)){
+        reb_output_timing(r, 0);
+        //reb_output_append_velocity_dispersion("veldisp.txt");
+    }
+    if (reb_output_check(r, 2.*M_PI/r->ri_sei.OMEGA)){
+        //reb_output_ascii("position.txt");
+    }
 }
 

--- a/examples/shearing_sheet_mpi/problem.c
+++ b/examples/shearing_sheet_mpi/problem.c
@@ -27,6 +27,7 @@ int main(int argc, char* argv[]) {
 	r->boundary			= REB_BOUNDARY_SHEAR;
 	r->gravity			= REB_GRAVITY_TREE;
 	r->collision		= REB_COLLISION_TREE;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
 	double OMEGA 		= 0.00013143527;	// 1/s
 	r->ri_sei.OMEGA 	= OMEGA;
 	r->G 				= 6.67428e-11;		// N / (1e-5 kg)^2 m^2

--- a/examples/simplest/problem.c
+++ b/examples/simplest/problem.c
@@ -12,24 +12,24 @@
 void heartbeat(struct reb_simulation* r){
     // This function gets called after every timestep.
     // Here, we simply print out the current simulation time.
-	printf("%f\n",r->t);
+    printf("%f\n",r->t);
 }
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r = reb_create_simulation();
-	r->dt = 0.1;
-	r->heartbeat = heartbeat;
-	r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
+    struct reb_simulation* r = reb_create_simulation();
+    r->dt = 0.1;
+    r->heartbeat = heartbeat;
+    r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
 
-	struct reb_particle p1 = {0}; // always initizialize a struct with this syntax to ensure all variables are set to 0.
-	p1.m = 1.;
-	reb_add(r, p1);  // reb_add makes a copy of the particle and adds it to the simulation.
-	
-	struct reb_particle p2 = {0};
-	p2.x = 1;
-	p2.vy = 1;
-	reb_add(r, p2); // notice that we didn't set a mass. All parameters default to 0.
+    struct reb_particle p1 = {0}; // always initizialize a struct with this syntax to ensure all variables are set to 0.
+    p1.m = 1.;
+    reb_add(r, p1);  // reb_add makes a copy of the particle and adds it to the simulation.
+    
+    struct reb_particle p2 = {0};
+    p2.x = 1;
+    p2.vy = 1;
+    reb_add(r, p2); // notice that we didn't set a mass. All parameters default to 0.
 
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
 }
 

--- a/examples/solar_system/problem.c
+++ b/examples/solar_system/problem.c
@@ -12,44 +12,44 @@
 
 double ss_pos[10][3] = 
 {
-	{3.256101656448802E-03  , -1.951205394420489E-04 , -1.478264728548705E-04},  
-	{-1.927589645545195E-01 , 2.588788361485397E-01  , 3.900432597062033E-02 }, 
-	{-5.976537074581466E-01 , 3.918678996109574E-01  , 3.990356741282203E-02 }, 
-	{-7.986189029000561E-01 , -6.086873314992410E-01 , -1.250824315650566E-04}, 
-	{7.897942807177173E-01  , 1.266671734964037E+00  , 7.092292179885432E-03 }, 
-	{-4.314503046344270E+00 , 3.168094294126697E+00  , 8.331048545353310E-02 }, 
-	{-4.882304833383455E+00 , -8.689263067189865E+00 , 3.453930436208210E-01 }, 
-	{1.917757033372740E+01  , 5.671738750949031E+00  , -2.273858614425555E-01},  
-	{2.767031517959636E+01  , -1.150331645280942E+01 , -4.008018419157927E-01},  
-	{7.765250227278298E+00  , -3.190996242617413E+01 , 1.168394015703735E+00 }, 
+    {3.256101656448802E-03  , -1.951205394420489E-04 , -1.478264728548705E-04},  
+    {-1.927589645545195E-01 , 2.588788361485397E-01  , 3.900432597062033E-02 }, 
+    {-5.976537074581466E-01 , 3.918678996109574E-01  , 3.990356741282203E-02 }, 
+    {-7.986189029000561E-01 , -6.086873314992410E-01 , -1.250824315650566E-04}, 
+    {7.897942807177173E-01  , 1.266671734964037E+00  , 7.092292179885432E-03 }, 
+    {-4.314503046344270E+00 , 3.168094294126697E+00  , 8.331048545353310E-02 }, 
+    {-4.882304833383455E+00 , -8.689263067189865E+00 , 3.453930436208210E-01 }, 
+    {1.917757033372740E+01  , 5.671738750949031E+00  , -2.273858614425555E-01},  
+    {2.767031517959636E+01  , -1.150331645280942E+01 , -4.008018419157927E-01},  
+    {7.765250227278298E+00  , -3.190996242617413E+01 , 1.168394015703735E+00 }, 
 
 };
 double ss_vel[10][3] = 
 {
-	{3.039963463108432E-06 ,  6.030576499910942E-06 ,  -7.992931269075703E-08}, 
-	{-2.811550184725887E-02,  -1.586532995282261E-02,  1.282829413699522E-03 }, 
-	{-1.113090630745269E-02,  -1.703310700277280E-02,  4.089082927733997E-04 },
-	{1.012305635253317E-02 ,  -1.376389620972473E-02,  3.482505080431706E-07 }, 
-	{-1.135279609707971E-02,  8.579013475676980E-03 ,  4.582774369441005E-04 }, 
-	{-4.555986691913995E-03,  -5.727124269621595E-03,  1.257262404884127E-04 }, 
-	{4.559352462922572E-03 ,  -2.748632232963112E-03,  -1.337915989241807E-04}, 
-	{-1.144087185031310E-03,  3.588282323722787E-03 ,  2.829006644043203E-05 }, 
-	{1.183702780101068E-03 ,  2.917115980784960E-03 ,  -8.714411604869349E-05}, 
-	{3.112825364672655E-03 ,  1.004673400082409E-04 ,  -9.111652976208292E-04},
+    {3.039963463108432E-06 ,  6.030576499910942E-06 ,  -7.992931269075703E-08}, 
+    {-2.811550184725887E-02,  -1.586532995282261E-02,  1.282829413699522E-03 }, 
+    {-1.113090630745269E-02,  -1.703310700277280E-02,  4.089082927733997E-04 },
+    {1.012305635253317E-02 ,  -1.376389620972473E-02,  3.482505080431706E-07 }, 
+    {-1.135279609707971E-02,  8.579013475676980E-03 ,  4.582774369441005E-04 }, 
+    {-4.555986691913995E-03,  -5.727124269621595E-03,  1.257262404884127E-04 }, 
+    {4.559352462922572E-03 ,  -2.748632232963112E-03,  -1.337915989241807E-04}, 
+    {-1.144087185031310E-03,  3.588282323722787E-03 ,  2.829006644043203E-05 }, 
+    {1.183702780101068E-03 ,  2.917115980784960E-03 ,  -8.714411604869349E-05}, 
+    {3.112825364672655E-03 ,  1.004673400082409E-04 ,  -9.111652976208292E-04},
 };
 
 double ss_mass[10] =
 {
-	1.988544e30,
-	3.302e23,
-	48.685e23,
-	6.0477246e24,
-	6.4185e23,
-	1898.13e24,
-	5.68319e26,
-	86.8103e24,
-	102.41e24,
-	1.4639248e+22,
+    1.988544e30,
+    3.302e23,
+    48.685e23,
+    6.0477246e24,
+    6.4185e23,
+    1898.13e24,
+    5.68319e26,
+    86.8103e24,
+    102.41e24,
+    1.4639248e+22,
 };
 
 void heartbeat(struct reb_simulation* r);
@@ -57,40 +57,40 @@ double e_init;
 double tmax;
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->dt 			= 4;				// in days
-	tmax			= 7.3e10;			// 200 Myr
-	r->G			= 1.4880826e-34;		// in AU^3 / kg / day^2.
-	r->ri_whfast.safe_mode 	= 0;		// Turn off safe mode. Need to call reb_integrator_synchronize() before outputs. 
-	r->ri_whfast.corrector 	= 11;		// 11th order symplectic corrector
-	r->integrator		= REB_INTEGRATOR_WHFAST;
-	r->heartbeat		= heartbeat;
-	r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
-	//r->integrator		= REB_INTEGRATOR_IAS15;		// Alternative non-symplectic integrator
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->dt             = 4;                // in days
+    tmax            = 7.3e10;            // 200 Myr
+    r->G            = 1.4880826e-34;        // in AU^3 / kg / day^2.
+    r->ri_whfast.safe_mode     = 0;        // Turn off safe mode. Need to call reb_integrator_synchronize() before outputs. 
+    r->ri_whfast.corrector     = 11;        // 11th order symplectic corrector
+    r->integrator        = REB_INTEGRATOR_WHFAST;
+    r->heartbeat        = heartbeat;
+    r->exact_finish_time = 1; // Finish exactly at tmax in reb_integrate(). Default is already 1.
+    //r->integrator        = REB_INTEGRATOR_IAS15;        // Alternative non-symplectic integrator
 
-	// Initial conditions
-	for (int i=0;i<10;i++){
-		struct reb_particle p = {0};
-		p.x  = ss_pos[i][0]; 		p.y  = ss_pos[i][1];	 	p.z  = ss_pos[i][2];
-		p.vx = ss_vel[i][0]; 		p.vy = ss_vel[i][1];	 	p.vz = ss_vel[i][2];
-		p.m  = ss_mass[i];
-		reb_add(r, p); 
-	}
-	reb_move_to_com(r);
-	e_init = reb_tools_energy(r);
-	system("rm -f energy.txt");
-	reb_integrate(r, tmax);
+    // Initial conditions
+    for (int i=0;i<10;i++){
+        struct reb_particle p = {0};
+        p.x  = ss_pos[i][0];         p.y  = ss_pos[i][1];         p.z  = ss_pos[i][2];
+        p.vx = ss_vel[i][0];         p.vy = ss_vel[i][1];         p.vz = ss_vel[i][2];
+        p.m  = ss_mass[i];
+        reb_add(r, p); 
+    }
+    reb_move_to_com(r);
+    e_init = reb_tools_energy(r);
+    system("rm -f energy.txt");
+    reb_integrate(r, tmax);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 10000.)){
-		reb_output_timing(r, tmax);
-		reb_integrator_synchronize(r);
-		FILE* f = fopen("energy.txt","a");
-		double e = reb_tools_energy(r);
-		fprintf(f,"%e %e\n",r->t, fabs((e-e_init)/e_init));
-		fclose(f);
-	}
+    if (reb_output_check(r, 10000.)){
+        reb_output_timing(r, tmax);
+        reb_integrator_synchronize(r);
+        FILE* f = fopen("energy.txt","a");
+        double e = reb_tools_energy(r);
+        fprintf(f,"%e %e\n",r->t, fabs((e-e_init)/e_init));
+        fclose(f);
+    }
 }
 

--- a/examples/spreading_ring/problem.c
+++ b/examples/spreading_ring/problem.c
@@ -12,49 +12,49 @@
 void heartbeat(struct reb_simulation* r);
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	// Setup constants
-	r->integrator	= REB_INTEGRATOR_LEAPFROG;
-	r->collision	= REB_COLLISION_TREE;
+    struct reb_simulation* r = reb_create_simulation();
+    // Setup constants
+    r->integrator    = REB_INTEGRATOR_LEAPFROG;
+    r->collision    = REB_COLLISION_TREE;
     r->collision_resolve = reb_collision_resolve_hardsphere;
-    r->boundary	= REB_BOUNDARY_OPEN;
-	r->G 		= 1;		
-	r->N_active	= 1;
-	r->softening 	= 0.01;		
-	r->dt 		= 1e-3;
-	r->heartbeat	= heartbeat;
-	
-	double boxsize = 4.8;
-	reb_configure_box(r, boxsize, 1, 1, 1);
+    r->boundary    = REB_BOUNDARY_OPEN;
+    r->G         = 1;        
+    r->N_active    = 1;
+    r->softening     = 0.01;        
+    r->dt         = 1e-3;
+    r->heartbeat    = heartbeat;
+    
+    double boxsize = 4.8;
+    reb_configure_box(r, boxsize, 1, 1, 1);
 
-	// Setup particles
-	int _N = 1000;
-	// Initial conditions
-	struct reb_particle star = {0};
-	star.m 		= 1;
-	star.r		= 0.01;
-	reb_add(r, star);
+    // Setup particles
+    int _N = 1000;
+    // Initial conditions
+    struct reb_particle star = {0};
+    star.m         = 1;
+    star.r        = 0.01;
+    reb_add(r, star);
 
-	while(r->N<_N){
-		struct reb_particle pt = {0};
-		double a	= reb_random_powerlaw(boxsize/2.9,boxsize/3.1,.5);
-		double phi 	= reb_random_uniform(0,2.*M_PI);
-		pt.x 		= a*cos(phi);
-		pt.y 		= a*sin(phi);
-		pt.z 		= a*reb_random_normal(0.0001);
-		double vkep 	= sqrt(r->G*star.m/a);
-		pt.vx 		=  vkep * sin(phi);
-		pt.vy 		= -vkep * cos(phi);
-		pt.m 		= 0.0001;
-		pt.r 		= .3/sqrt((double)_N);
-		reb_add(r, pt);
-	}
+    while(r->N<_N){
+        struct reb_particle pt = {0};
+        double a    = reb_random_powerlaw(boxsize/2.9,boxsize/3.1,.5);
+        double phi     = reb_random_uniform(0,2.*M_PI);
+        pt.x         = a*cos(phi);
+        pt.y         = a*sin(phi);
+        pt.z         = a*reb_random_normal(0.0001);
+        double vkep     = sqrt(r->G*star.m/a);
+        pt.vx         =  vkep * sin(phi);
+        pt.vy         = -vkep * cos(phi);
+        pt.m         = 0.0001;
+        pt.r         = .3/sqrt((double)_N);
+        reb_add(r, pt);
+    }
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }
 
 void heartbeat(struct reb_simulation* r){
-	if (reb_output_check(r, 0.0*r->dt)){
-		reb_output_timing(r, 0);
-	}
+    if (reb_output_check(r, 0.0*r->dt)){
+        reb_output_timing(r, 0);
+    }
 }

--- a/examples/spreading_ring/problem.c
+++ b/examples/spreading_ring/problem.c
@@ -16,7 +16,8 @@ int main(int argc, char* argv[]){
 	// Setup constants
 	r->integrator	= REB_INTEGRATOR_LEAPFROG;
 	r->collision	= REB_COLLISION_TREE;
-	r->boundary	= REB_BOUNDARY_OPEN;
+    r->collision_resolve = reb_collision_resolve_hardsphere;
+    r->boundary	= REB_BOUNDARY_OPEN;
 	r->G 		= 1;		
 	r->N_active	= 1;
 	r->softening 	= 0.01;		

--- a/examples/star_of_david/problem.c
+++ b/examples/star_of_david/problem.c
@@ -15,33 +15,33 @@
 
 
 int main(int argc, char* argv[]){
-	struct reb_simulation* r = reb_create_simulation();
-	r->integrator = REB_INTEGRATOR_IAS15;
-	r->dt = -1;
-	r->usleep = 10000;   // Slowing down integrator (for visualization only)
+    struct reb_simulation* r = reb_create_simulation();
+    r->integrator = REB_INTEGRATOR_IAS15;
+    r->dt = -1;
+    r->usleep = 10000;   // Slowing down integrator (for visualization only)
 
-	struct reb_particle p = {0};
-	p.m = 1.;
-	p.z = 0.;
-	p.vz = 0.;
-	
-	p.x =  -1.842389804706855; p.y =  -1.063801316823613; 
-	p.vx =  -0.012073765486548; p.vy =   0.021537467220014; 
-	reb_add(r, p);
+    struct reb_particle p = {0};
+    p.m = 1.;
+    p.z = 0.;
+    p.vz = 0.;
+    
+    p.x =  -1.842389804706855; p.y =  -1.063801316823613; 
+    p.vx =  -0.012073765486548; p.vy =   0.021537467220014; 
+    reb_add(r, p);
 
-	p.x =  -0.689515464218133; p.y =  -0.398759403276399; 
-	p.vx =   0.637331229856386; p.vy =  -1.103822313621890; 
-	reb_add(r, p);
-	
-	p.x =   0.689515464218133; p.y =   0.398759403276399; 
-	p.vx =  -0.637331229856386; p.vy =   1.103822313621890; 
-	reb_add(r, p);
-	
-	p.x =   1.842389804706855; p.y =   1.063801316823613; 
-	p.vx =   0.012073765486548; p.vy =  -0.021537467220014; 
-	reb_add(r, p);
-	
-	reb_move_to_com(r);
+    p.x =  -0.689515464218133; p.y =  -0.398759403276399; 
+    p.vx =   0.637331229856386; p.vy =  -1.103822313621890; 
+    reb_add(r, p);
+    
+    p.x =   0.689515464218133; p.y =   0.398759403276399; 
+    p.vx =  -0.637331229856386; p.vy =   1.103822313621890; 
+    reb_add(r, p);
+    
+    p.x =   1.842389804706855; p.y =   1.063801316823613; 
+    p.vx =   0.012073765486548; p.vy =  -0.021537467220014; 
+    reb_add(r, p);
+    
+    reb_move_to_com(r);
 
-	reb_integrate(r, INFINITY);
+    reb_integrate(r, INFINITY);
 }

--- a/examples/variational_equations/problem.c
+++ b/examples/variational_equations/problem.c
@@ -11,7 +11,7 @@
 
 // This function creates a simulation with one star, one planet and one test particle.
 struct reb_simulation* create_sim(){
-	struct reb_simulation* r = reb_create_simulation();
+    struct reb_simulation* r = reb_create_simulation();
     // r->integrator = REB_INTEGRATOR_WHFAST;  Only first order variational equations supported in WHFast.
     struct reb_particle star = {0.};
     star.m = 1;
@@ -24,12 +24,12 @@ struct reb_simulation* create_sim(){
 }
 
 int main(int argc, char* argv[]) {
-	struct reb_simulation* r;
+    struct reb_simulation* r;
     int var_i, var_ii;
 
     // We first integrate the vanilla simulation forward in time and look at the position of the testparticle at the end of the simulation.
     r = create_sim();
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100:                             %.8f %.8f\n",r->particles[2].x,r->particles[2].y);
     reb_free_simulation(r);
     
@@ -38,7 +38,7 @@ int main(int argc, char* argv[]) {
     printf("\nShifting planet's x coordinate by %f.\n", DeltaX);
     r = create_sim();
     r->particles[1].x += DeltaX;
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 in shifted simulation:       %.8f %.8f\n",r->particles[2].x,r->particles[2].y);
     reb_free_simulation(r);
     
@@ -49,7 +49,7 @@ int main(int argc, char* argv[]) {
     // By default all components of variational particles are initialized to zero.
     // We are interested in shifting the planet's x coordinates and thus initialize the x coordinate of the variational particle to 1.
     r->particles[var_i+1].x = 1.;           
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     // After the integration ran, we can estimate where the test particle would have been had we shifted the inner planet's initial x coordinate.
     printf("Position of testparticle at t=100 using 1st order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i+2].x,r->particles[2].y+DeltaX*r->particles[var_i+2].y);
     reb_free_simulation(r);
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) {
     var_i = reb_add_var_1st_order(r, -1);
     var_ii = reb_add_var_2nd_order(r, -1, var_i, var_i);
     r->particles[var_i+1].x = 1.;
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 using 2nd order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i+2].x+DeltaX*DeltaX/2.*r->particles[var_ii+2].x,r->particles[2].y+DeltaX*r->particles[var_i+2].y+DeltaX*DeltaX/2.*r->particles[var_ii+2].y);
     reb_free_simulation(r);
 
@@ -68,14 +68,14 @@ int main(int argc, char* argv[]) {
     printf("\nShifting testparticle's x coordinate by %f.\n", DeltaX);
     r = create_sim();
     r->particles[2].x += DeltaX;
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 in shifted simulation:       %.8f %.8f\n",r->particles[2].x,r->particles[2].y);
     reb_free_simulation(r);
     
     r = create_sim();
     var_i = reb_add_var_1st_order(r, 2); // The 2 corresponds to the index of the testparticle that we vary.
     r->particles[var_i].x = 1.;
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 using 1st order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i].x,r->particles[2].y+DeltaX*r->particles[var_i].y);
     reb_free_simulation(r);
 
@@ -83,7 +83,7 @@ int main(int argc, char* argv[]) {
     var_i = reb_add_var_1st_order(r, 2);
     var_ii = reb_add_var_2nd_order(r, 2, var_i, var_i);
     r->particles[var_i].x = 1.;
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 using 2nd order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i].x+DeltaX*DeltaX/2.*r->particles[var_ii].x,r->particles[2].y+DeltaX*r->particles[var_i].y+DeltaX*DeltaX/2.*r->particles[var_ii].y);
     reb_free_simulation(r);
 
@@ -92,7 +92,7 @@ int main(int argc, char* argv[]) {
     printf("\nShifting planet's semi-major axis by %f.\n", DeltaX);
     r = create_sim();
     r->particles[2] = reb_tools_orbit_to_particle(1.,r->particles[0],0.,1.7+DeltaX,0.1,0.2,0.3,0.4,0.5);
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 in shifted simulation:       %.8f %.8f\n",r->particles[2].x,r->particles[2].y);
     reb_free_simulation(r);
 
@@ -100,7 +100,7 @@ int main(int argc, char* argv[]) {
     var_i = reb_add_var_1st_order(r, 2);
     // The function that sets up the variational particle gets the same orbital parameters as the original particle.
     r->particles[var_i] = reb_derivatives_a(1.,r->particles[0],r->particles[2]);
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 using 1st order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i].x,r->particles[2].y+DeltaX*r->particles[var_i].y);
     reb_free_simulation(r);
     
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
     r->particles[var_i] = reb_derivatives_a(1.,r->particles[0],r->particles[2]);
     // second derivative with respect to a
     r->particles[var_ii] = reb_derivatives_a_a(1.,r->particles[0],r->particles[2]);
-	reb_integrate(r,100.);
+    reb_integrate(r,100.);
     printf("Position of testparticle at t=100 using 2nd order var. eqs.:   %.8f %.8f\n",r->particles[2].x+DeltaX*r->particles[var_i].x+DeltaX*DeltaX/2.*r->particles[var_ii].x,r->particles[2].y+DeltaX*r->particles[var_i].y+DeltaX*DeltaX/2.*r->particles[var_ii].y);
     reb_free_simulation(r);
 

--- a/ipython_examples/CloseEncounters.ipynb
+++ b/ipython_examples/CloseEncounters.ipynb
@@ -15,9 +15,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import rebound\n",
@@ -42,9 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim = setupSimulation()\n",
@@ -61,9 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -93,9 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -134,7 +126,6 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false,
     "scrolled": false
    },
    "outputs": [
@@ -142,7 +133,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmQAAAFACAYAAAASxGABAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzs3Xd41FXaBuDnTElvpIeQRhIIISEBQm+igjQBsVcU1FVx\nm+76ubuWdXWbu66raxdRsReQIkhVkBYgtISEFlJI771P5nx/JLisUiZhJmfKc1/XXJDkl5kHzUze\nOeU9QkoJIiIiIlJHozoAERERkaNjQUZERESkGAsyIiIiIsVYkBEREREpxoKMiIiISDEWZERERESK\nsSAjIiIiUowFGREREZFiLMiIiIiIFNOpDtBT/v7+MjIyUnUMIiIioks6cOBApZQy4FLX2VxBFhkZ\nibS0NNUxiIiIiC5JCJFvynWcsiQiIiJSjAUZERERkWIsyIiIiIgUY0FGREREpBgLMiIiIiLFWJAR\nERERKcaCjIiIiEgxFmREREREirEgIyIiIlKMBRnZvNMVjVh7pBgF1c2qoxAREfWKzR2dRAQAORWN\nWJ9Rgq/TS3C8tOGHz0f4uWF8tD8mxvhjXLQffN2dFKYkIiIyDQsyshm5lU0/FGHHSuoBACkR/fDU\nnHiMiOiHQ2dqsCu7CmuPFOOTfWcAAEP7e2FCjD8mxPhjVGQ/uDnxR56IiKyPkFKqztAjKSkpkoeL\nO46zRdi69BJkdRdhIyP6YXZiCGYmBiPE2/Un32PoNCK9qA67TlViZ3YlDp6pQUenhF4rMDy8HybG\n+GNSrD+Sw3wghOjrfxIRETkQIcQBKWXKJa9jQUbWpqqxDZ/uL8D6jBJkFv+3CJuVGIJZFyjCLqa5\n3YD9eTXYnd1VoGWV1ENK4PoRA/CXBQlw1mkt8c8gIiIyuSDj/A1ZlZK6FtzyViryq5oxItwHT86J\nx8yEYPT36VkRdi43Jx2mDArAlEEBAIDqpna8uysX//k2G3lVTXjjjpEI8HQ21z+BiIiox1iQkdU4\nW4xVN7ZjxYPjMTKin0Uex9fdCY9OH4y4YC88+sVhzHtlJ95emIKh/b0t8nhERESXwrYXZBXOLcbe\nXzzaYsXYuWYPC8GXD4yHBHDD63uw4WiJxR+TiIjofFiQkXIldS249a1UVHUXYyPCLV+MnZUQ6o3V\nD09AXIgnHvjwIF7eegq2tq6SiIhsHwsyUqq0rhW3vpWKysZ2LO/jYuysQE8XfHLfWCwYHop/bT6J\nhz85hJb2zj7PQUREjotryEiZ0rpW3PLWHqXF2Fkuei1euCkJg4M98bcNx3Gmqhlv3TWyxzs6iYiI\neoMjZKTEucXY+4vUFmNnCSHwsynRWHpXCnIqGjH3lV04dKZGdSwiInIALMioz/24GOuLBfw9cdWQ\nIHy1ZAJc9Brc/FYqVh0qUh2JiIjsHAsy6lOlda249e1Uqy3GzhoU5InVSyZieJgPfvXZYfx9w3EY\njVzsT0RElsGCjPrM2WKsoqEN7y8aZbXF2Fm+7k74YPEY3Do6HK9vO43n1h1THYmIiOwUF/VTnyir\n7yrGyutbsXzxaIyM8FUdySROOg3+cl0C9FqBZbtyMXmQP64YHKg6FhER2RkWZGRxZfWtuOUt2yvG\nzhJC4PezhmBvTjV+80U6NvxqEvw9eNQSkSMydBrR2GZAfYsB9a0dqG/pQH3r//69obUDXi56TI0L\nxLBQb2g0QnVssgE8XJwsymiUmP/aLpwub7TJYuxcx0vrMfeVXZgU44+lC1MgBF9kiexZTVM71h8t\nwdojxcivakZ9SweaTOhR6OmsQ1O7AUYJ+Hs44YrBgbgqLhATY/3h6aLvg+RkTXi4OFmFlYeKkF5Y\nh5duSbbpYgwA4oK98LuZcXhmbRY+TM3HneMiVUciIjNrbjdgc1YZ1hwuxvaTFTAYJWICPTAhxh/e\nrnp4uujg5aKHl6seXi46eP3ocx7OOmg1AjVN7dh+sgJbj5djU2YpvjxQCL1WYHSUL6YODsRVQ4IQ\n5e+u+p9LVoQjZGQxze0GTP3nNoR4u+Krh8bbxYiSlBJ3v7sfqTlV+PrnExEb5Kk6EhFdpo5OI3ae\nqsTqw0XYlFWG5vZOhHi7YG5Sf8xN7o/4EK/Lev0ydBpxIL8G354ox7fHynGqvBEAMNDfHVPjukbP\nUiJ94aTjPjt7ZOoIGQsysph/bzmJf285hRUPjrP50bFzlTe0Yua/dyDQywWrloyHs06rOhIR9ZDR\nKHHwTA1WHy7GuowSVDe1w9tVj1mJIZif3B+jIn0ttvaroLoZ3x4vx9bj5Ug9XYX2TiP8PZzx75uT\nMTHW3yKPSeqwICOlSutaMfWf23DlkEC8etsI1XHMbuuxMix+Pw33TozCE3PiVcchIhM1tHbg7e9z\nsOJgEYpqW+Ci12BafDDmJfXH5EEBfT5K1dRmwM7sSvxz4wlkVzTi11cPwsNTY7gRwI5wDRkp9c9N\nJ9BplHh8RpzqKBZx1ZAg3Dk2Akt35mLK4ABMig1QHYmILkJKiY2ZZfjjmkyUNbRicmwAfnPNIEyL\nD4aHs7pfhe7OOlwzNBiTYv3x+5UZ+Nfmk0jLr8G/b06Gr7uTslzU9zhhTWZ3tKgOKw4W4p6JkQjz\ndVMdx2L+MHsIYgI98OjnR1Dd1K46DhFdQFFtC+5bfgAPfHgAPm56rHxwPN5fNBrXDR+gtBg7l5uT\nDi/enIw/X5eA1NNVmP3yDhzkWboOhQUZmZWUEs+ty0I/NycsmRqjOo5Fuei1ePmW4aht7sD/rUiH\nrU3/E9k7Q6cRS3fkYNq/tmNXdiV+PysOa38+EcPDrfOUECEEbh8TgZUPjYdOK3DTG3uwbGcuX1sc\nBAsyMqvNWWVIzanGr6cNgpcD9NuJ7++Fx2YMxuasMny874zqOETU7UhBLea+sgvPrTuGsQP9sPmR\nybh/cjT0Wuv/tZcQ6o2vH56EKwYH4k9fZ2HJxwfR0NqhOhZZmPX/ZJLNaDcY8ddvjiMm0AO3jgpT\nHafPLJoQhUmx/nj26yxkd29nJyI1Glo78PTqo5j/2i5UNbXh9dtH4J2FKRjQz7aWT3i76fH2XSPx\nu5lx2JhZhrmv7MKxknrVsciCWJCR2XyYmo/cyib8YfYQ6GzgXai5aDQCL9yYBFe9Fr/89BDaDUbV\nkYgcjpQS32SU4Op/bcfy1HwsHBeJLY9MwczEEJvtgSiEwM+mROOT+8aiqc2A+a/uwudpBapjkYU4\nzm9Nsqja5na8tPUUJsX644pBjrfjMNDLBc/fkITM4nq8sOmE6jhEDqWguhmL30/Dgx8dhJ+7M756\naAL+OHeo3RxTNDrKF+t+MQkjI/rhsS/T8diXR9DacekjnMi2sCAjs3h5azYaWjvwh9lDbPbd6OWa\nFh+E28eE483vc7Aru1J1HCKHsOZIMaa/+D1Sc6rwxOwhWPPwBCSH+aiOZXYBns74YPEY/OLKGHye\nVoj5r+5CZWOb6lhkRizI6LLlVDRi+Z483DwqHHHBXqrjKPXE7HhEB7jjkc8Po4atMIgsxmiU+OfG\nE/jFJ4eQEOqFzY9Mwb2TBtr1cgmtRuCR6YPx7j2jkFPZhN98cQRGI3dg2gv7/cmlPvO3b47DWafB\nI9MGqY6inKuTFi/dMhzVTe3409dZquMQ2aWmNgMe+PAAXvkuG7eMCsNH945FqI+r6lh9ZurgQDw5\newi2najAOztzVcchM7FYQSaECBNCfCeEyBJCZAohfnmea4QQ4mUhRLYQIl0IYX9n7Ni5PaersCmr\nDA9NjUGAp7PqOFYhIdQb904aiFWHi3CqrEF1HCK7UljTjOtf340tx8rw1Jx4/HVBokMeyn3H2Ahc\nMzQIf99wHEcKalXHITOw5E+xAcCjUsp4AGMBLBFC/PjQv5kAYrtv9wN43YJ5yMyMxq4msKE+rlg8\nMUp1HKty36SBcNNr8fK32aqjENmN/XnVmPfKLhTVtuDde0Zj0cQoh12zKoTA89cnIcjLBT//5BDq\n2afM5lmsIJNSlkgpD3b/vQHAMQChP7psHoDlsksqAB8hRIilMpF5rTxUhMziejw2YzBc9FrVcayK\nr7sTFo6PxNfpxRwlIzKDz/cX4La3U+HlqseqJRMwxQF3c/+Yt5seL92SjKLaFvx+ZQY7+tu4Phnn\nFUJEAhgOYO+PvhQK4NymKoX4adEGIcT9Qog0IURaRUWFpWJSDzS3G/CPjceRHOaDuUn9VcexSmdH\nyV7aekp1FCKb1WmUeO7rLDy2Ih1jovyw6qEJiA7wUB3LaqRE+uKRaYPwdXoJe5TZOIsXZEIIDwAr\nAPxKStmrNsNSyreklClSypSAAL4rsgZvbs9BWX0bnpzjuG0uLqWfuxPunhCJdRklOMlRMqIeq2/t\nwKL39mPpzlzcPT4S790zCt5u9tFbzJwemBKNCTF+eHpNJrLL+VpjqyxakAkh9Ogqxj6SUq48zyVF\nAM49Y2dA9+fIipXWteLN709j9rAQjIzwVR3Hqt07sXstGUfJiHokt7IJ1726C7uyK/GX6xLxx7lD\n7bqlxeXQagRevCkZ7k46PPzxITaNtVGW3GUpALwD4JiU8l8XuGwNgLu6d1uOBVAnpSyxVCYyj39s\nPAGjEXh8RpzqKFaPo2REPbcruxLzX92F6qZ2fHjvGNw2Jlx1JKsX6OWCF25KwvHSBjy3ji13bJEl\n325MAHAngCuFEIe7b7OEEA8IIR7ovmY9gBwA2QDeBvCQBfOQGZTUteCrQ4VYOD4CYb62dVivKvdO\nHAh3Jx1HyYhM8NHefNy1bB+CvJyxeslEjB3opzqSzbhicCDunzwQH6aewTcZHNuwNTpL3bGUcieA\niy4ukl1bQpZYKgOZ38qDRTBK4M6xkaqj2Ix+7k64e3wkXt2WjV+UNWBQkKfqSERWx2iU+NuG43jr\n+xxcGReIl25JtpuzKPvSb6YPxt6cKjy2Ih0Jod5842xDOCFPJpNS4ou0AoyJ8kW4H5/kPbF4YhTc\nnXTccUl0Hq0dnVjy8UG89X0O7hoXgbfuHMlirJecdBr859YRgAR++ekhdHQaVUciE7EgI5Ptz6tB\nXlUzbkwJu/TF9D/OjpKtzyjBiVKuJSM6q7KxDbe+nYoNmaV4YvYQPMPF+5ct3M8Nf1mQiINnavHi\n5pOq45CJ+FNPJvsirQDuTlrMSgxWHcUmnR0le/lbjpIRAUB2eSOue20XjpXU4/XbR+LeSQPZRsdM\nrk3qj1tGheH17aex4xT7d9oCFmRkkqY2A9ZllGDOsP5wc7LY0kO7xlEyov9KzanC9a/vRkt7Jz69\nfxxmJPCNnrk9fe1QRAd44NefHUFFQ5vqOHQJLMjIJOszStDc3okbUwaojmLT7p0UxR2X5PC+OlSI\nO9/ZiwBPZ3z10AQkh/mojmSXXJ20eOW24Who7cCjXxyB0cijlawZCzIyyRdphRjo746REf1UR7Fp\nPm5OuKe7LxlHycjRSCnx0pZT+PVnR5AS4YsVD4znLkALiwv2wlPXxuP7kxX4dD+PVrJmLMjokvIq\nm7AvrxrXjxzA9R1msHhiFDycOUpGjqXdYMRvvkjHi1tOYsGIULy/aDSPQeojt40Ox/BwH7z6XTZ3\nXVoxFmR0SV8eKIRGANeP4HSlOXCUjBxNXXMHFi7bhxUHC/HrqwfhhRuT4KTjr5++IoTAw1NjUFTb\ngtWHi1XHoQvgM4IuqtMoseJgISYPCkCwt4vqOHZj8cQoeDrr8NJWbkkn+1ZQ3Yzr39iNtPxq/Oum\nJPzy6liOtCtwZVwghoR44bVt2ejkWjKrxIKMLmpXdiVK6lpx40j2HjOns6Nk6zNKcby0XnUcIovY\nnV2Jua/sRHl9K5YvGoMFHGVXRgiBJVOjkVPRhA1HS1XHofNgQUYX9XlaAXzc9Lg6PlB1FLuzqHuU\njGvJyN5IKfHOzlzcuWwf/DycsWrJBIyL5pmUqs1MCMHAAHe88l02uk4uJGvCgowuqK65A5uyyjAv\nqT+cdVrVcewOR8nIHrV2dOLRL47g2a+zcFVcIFYtmYCBAR6qYxEArUbgwSnROFZSj+9OlKuOQz/C\ngowuaM2RIrQbjDwqyYLOjpK9tIWjZGT7imtbcNObe7DyYBF+ffUgvHHHSHg4s5G0NZk/PBShPq54\n5VuOklkbFmR0QV8cKMSQEC8khHqrjmK3zo6SfXO0FMdKOEpGtmtvThXmvrITORVNePuuFPzy6lho\nNFy8b230Wg0euCIaB8/UYk9Oleo4dA4WZHRex0vrkV5YhxtHchGupS2eOJBrychmSSnxwZ483L50\nL7xc9Fi1ZAKmxQepjkUXcePIAQj0dMar32WrjkLnYEFG5/VFWiH0WoH5w0NVR7F73m56LBwfiQ2Z\npThT1aw6DpHJ2gydeHxFBp5cnYnJgwKw6uEJiAnkejFr56LX4r5JA7EruwoHz9SojkPdWJDRT3R0\nGrHqUBGuHhIEX3cn1XEcwp3jIqAVAsv35KmOQmSSsvpW3PxmKj5LK8DPr4zB0rtS4OXCzvu24rYx\n4fBx0+PVbzlKZi1YkNFPfHu8HFVN7TxIvA8FeblgZmIIPksrQFObQXUcoos6kF+NOf/ZiZNlDXjj\njhF4dPpgrhezMe7OOiyaEIWtx8uRVcz1q9aABRn9xBdphQj0dMbk2ADVURzK3eMj0dBqwMpDRaqj\nEF3Qp/vO4Ja3UuHmpMVXD03AjIQQ1ZGolxaOi4SHsw6vbuMomTVgQUb/o7yhFd+dKMd1I0Kh0/LH\noy+NCPfBsAHeeG9XLrejk9XpNEo8szYTj6/MwLhof6xZMhGDgz1Vx6LL4O2mx53jIrA+owSnKxpV\nx3F4/I1L/2PVoSJ0GiWPSlJACIG7x0fidEUTdmZXqo5D9IOG1g4sfn8/3t2Vh0UTorBsYQq83bhe\nzB4snhgFZ50Gr287rTqKw2NBRj+QUuKLtEKMCPfhTilFZg8Lgb+HE97fnac6ChGA7sPBX9+Nnacq\n8efrEvDUtfEcPbcj/h7OuGVUOFYdKkJhDXd5q8RnFf3gSGEdTpU3sjO/Qs46LW4bHY6tx8uRX9Wk\nOg45uLS8asx7dRdK61qxfNFo3D4mQnUksoCfTRkIIYA3t+eojuLQWJDRDz5PK4CLXoM5w7hIV6Xb\nx55tgZGvOgo5sJUHC3Hb23vh7drV7HV8jL/qSGQhId6uuGHkAHyWVoDy+lbVcRwWCzIC0HUg8Noj\nxZiZEAJP9hJSKsjLBbMSQ/D5frbAoL5nNEo8v+E4Hvn8CEZG9MNXD43n4eAO4IEp0TB0GrF0Z67q\nKA6LBRkBADZmlqKh1cCjkqzE3RMi0dBmwMqDhaqjkANpbjfgwY8O4LVtp3Hr6DAsXzwaPm5sDu0I\nIvzcMTepPz5MzUdNU7vqOA6JBRkB6Oo9NqCfK8YO9FMdhQAMD+tugbE7jy0wqE+U1LXgxjf2YHNW\nGZ6cE4+/XJcIPRfvO5SHpsagub0T73JTkRJ8thEKa5qx63Qlbhg5gN22rQRbYFBfOlJQi3mv7EJ+\nVTOWLkzB4olREIKvBY5mUJAnrhkahPd25aKhtUN1HIfDgoyw4kARpASuH8HpSmtytgXGe7vyVEch\nO7YuvQQ3vbkHeq0GKx4cjyvjglRHIoUenhqL+lYDPkw9ozqKw2FB5uCMRokvDxZgfLQfwnzdVMeh\nczjrtLhtTAS+PVGOvEq2wCDzW3ukGA9/chAJod5Y/fAEdt4nJA7wxuRBAVi6Iwct7Z2q4zgUFmQO\n7uCZGhRUt+AGLua3SneMCWcLDLKIHacq8Mjnh5ES0Q8f3TsG/h7OqiORlXh4agyqmtrx2X6OkvUl\nFmQOblNWGfRagavjOU1hjQK7W2B8kcYWGGQ+Rwpq8bMPDiA6wANLF46Ci16rOhJZkdFRvkgK88Gn\n+wtUR3EoLMgcmJQSGzNLMS7aH17sPWa12AKDzCm7vBF3v7sPfh5OWL5oNLxd+dynn7p+RCiOlzbg\neGm96igOgwWZAztV3oj8qmZM5+iYVRse5oOk7hYYRiNbYFDvldS1YOGyfdBqBD5YNAaBXi6qI5GV\nmp0YAq1GYNWhYtVRHAYLMge2KbMUAFiQWTkhBO6ewBYYdHlqm9tx1zv7UNfSgffuGY1If3fVkciK\n+Xk4Y3KsP9YcLuIbwT7CgsyBbcoqw/BwH75LtgGzErtbYLBhI/VCc7sBi97bj/yqZrx9VwoSQr1V\nRyIbMH94KIrrWrE/r1p1FIfAgsxBFde2IL2wDtPjg1VHIROcbYHxHVtgUA91dBrx0EcHcbigFi/f\nmoxx0TyNg0wzLT4Ibk5arDrMacu+wILMQW05VgYAmD6U05W2gi0wqKeMRonHvkzHthMV+PN1iZiR\nEKI6EtkQNycdrhkajHXpxWgzsCeZpbEgc1AbM0sRHeCO6AAP1VHIRIFeLpg9rKsFRiNbYNAlSCnx\n3Lpj+OpQEX57zWDcOjpcdSSyQfOS+6O+1YBtJypUR7F7LMgcUF1zB1JzqjF9KKcrbc3d49kCg0zz\n+vbTWLYrF/dMiMRDV0SrjkM2amKMP/w9nLD6cJHqKHaPBZkD+vZEGTqNkrsrbdDw8H5sgUGX9Om+\nM3h+wwnMS+6PJ2fH86Bw6jWdVoM5w/pjy7Fy1PPAcYtiQeaANmWWIdDTGUkDfFRHoV64e0IkctgC\ngy5gw9FS/P6rDEwZFIB/3JAEjYbFGF2eecn90W4wYkNGqeoodo0FmYNp7ejE9pMVmBYfxBdqG9XV\nAsOZLTDoJ44W1eEXnx5CUpgPXr9jBJx0fImny5cc5oMIPzes4rSlRfHZ6mB2ZVeiub2T68dsmLNO\ni9vHhOPb4+XILm9UHYeshKHTiN+tzICXix7LFo6Cm5NOdSSyE0IIzE8OxZ6cKpTWtaqOY7csVpAJ\nIZYJIcqFEEcv8PUrhBB1QojD3benLJWF/mtTZhk8nXUYN5C9iGzZXeMi4KLX4LVt2aqjkJV4f08+\nMorq8PS18ejn7qQ6DtmZ+cNDISWw9gh7klmKJUfI3gMw4xLX7JBSJnff/mTBLASg0yix5VgZpsYF\ncirDxvl5OOO20RFYfbgYBdXNquOQYkW1LXhh0wlcMTgAc4ax1xiZX5S/O5IGeHPa0oIs9ltZSvk9\nAJ63YEUO5NegqqmdzWDtxP2TB0IrBF7fflp1FFJISomnVx+FlMCz8xK4o5IsZl5yKDKL63GqrEF1\nFLukephkvBAiXQjxjRBiqOIsdm9TZimctBpMGRSgOgqZQbC3C25IGYAv0wq5rsOBbThaii3HyvHr\nabEI83VTHYfs2JykEGgEOEpmISoLsoMAwqWUwwD8B8CqC10ohLhfCJEmhEirqGC34N6QUmJTVhnG\nx/jB00WvOg6ZyYNTotEpJd7ekaM6CilQ39qBp9dkIj7EC4smRKmOQ3Yu0NMFE2MDsPpwMaRkH0Rz\nU1aQSSnrpZSN3X9fD0AvhPC/wLVvSSlTpJQpAQEc3emNE2UNOFPdzMPE7UyYrxvmJffHR3vzUdXY\npjoO9bF/bDiBysY2/HVBInRa1RMe5AjmJ/dHYU0LDuTXqI5id5Q9g4UQwaJ7sYMQYnR3lipVeezd\npswyCAFcHR+oOgqZ2UNXxKDNYMSyXbmqo1AfOpBfgw/35uOucZFICmOTZ+ob04cGw0WvwVeHOG1p\nbpZse/EJgD0ABgshCoUQi4UQDwghHui+5AYAR4UQRwC8DOAWyTFQi9mUVYrhYT4I9HRRHYXMLCbQ\nAzMTgrF8dz7qWni0iSPo6DTi9yszEOzlgt9cM1h1HHIgHs46TIsPxrqMErQbjKrj2BVL7rK8VUoZ\nIqXUSykHSCnfkVK+IaV8o/vrr0gph0opk6SUY6WUuy2VxdEV1bbgaFE9m8HasSVTY9DQZsBydu93\nCG/vyMGJsgY8M3coPJzZAJb61vzk/qht7sD3J7mm25y46MABbM7sOn/sGhZkdmtof29cGReIZbty\n0dRmUB2HLCi/qgkvbTmFa4YG8U0WKTF5UAD6uem529LMWJA5gI2ZZYgN9ECUv7vqKGRBS6bGoKa5\nA5/sO6M6ClmIlBJPrDoKvVaDZ+YmqI5DDkqv1WDOsP7YnFWGhlYukzAXFmR2rqapHfvyqtkM1gGM\njOiH8dF+ePP7HLR2dKqOQxaw+nAxdpyqxGMzBiPYm+tBSZ35w/ujzWDExswy1VHsBgsyO/ft8XJ0\nGiXbXTiIh6fGoKKhDV8cKFQdhcystrkdz36dheQwH9w+JkJ1HHJwI8L7IczXFas5bWk2LMjs3Kas\nUgR7uSAx1Ft1FOoD46L9MCLcB29sO42OTu6Asid/WX8MdS0d+OuCRGg1PB6J1BJCYF5SKHZlV6K8\ngSeFmAMLMjvW0t6J7ScrMC0+CBq+gDsEIQQevjIGRbUtWMU+QXYjNacKn6cV4t5JAzEkxEt1HCIA\nXdOWRgmsPVKiOopdYEFmx3ZmV6K1w8j1Yw5m6uBAxId44fVtp9FpZGs/W9dm6MTvv8pAmK8rfnlV\nrOo4RD+ICfREQqgX3/yZCQsyO7YpsxSeLjqMifJTHYX60NlRspzKJqzP4DtXW/f6ttPIqWjCn+cn\nwtVJqzoO0f+YnxyKjKI6nK5oVB3F5rEgs1OGTiO2HCvDlXGBcNLxf7OjmTE0GNEB7nj1u2weAmzD\nTlc04rXvTmNecn9MHsRzfMn6XJvUH0IAqzlKdtn4m9pOHcivQU1zB5vBOiiNRmDJ1BgcL23A1mPl\nquNQL73ybTb0WoEn58SrjkJ0XkFeLhgf7YdVh4v55u8ysSCzUxszy+Ck0/BdtQObm9QfYb6u+A9H\nyWxSaV0r1h4pxk2jwuDv4aw6DtEFzU8OxZnqZhwqqFUdxaaxILNDUkpsyirFxBh/nnPnwHRaDR6Y\nEo0jBbXYlV2lOg710PI9eTBKiXvGR6mOQnRRMxKC4azTcHH/ZWJBZoeOlTSgsKYF0+O5u9LR3TBy\nAIK8nPHKd6dUR6EeaGnvxMf7zmB6fDDC/dxUxyG6KE8XPa4aEoj1GaUwcmd3r5lUkAkhBgkhtgoh\njnZ/PEwI8YRlo1FvbcoqhRDAVUNYkDk6Z50W90+ORmpONdLyqlXHIROtOFiI2uYOLJ7E0TGyDdPj\ng1HZ2MY5PHIjAAAgAElEQVRpy8tg6gjZ2wB+B6ADAKSU6QBusVQoujybMsswMrwfAjy57oSAW0eH\nwc/dCa98l606CpnAaJRYtisXwwZ4IyWin+o4RCaZOjgQOo3A5iyebdlbphZkblLKfT/6nMHcYejy\nFVQ3I6ukns1g6QduTjosmhiFbScqcPBMjeo4dAnbTpYjp6IJiydGQQiesEG2wdtNjzEDfbE5q1R1\nFJtlakFWKYSIBiABQAhxAwB2nLRCGzO7ngw8TJzOdde4CAR7ueDxFeloM3SqjkMX8c7OXAR7uWBW\nYojqKEQ9Mm1IEE5XNLFJbC+ZWpAtAfAmgDghRBGAXwF40GKpqNfWZZQgPsQLkf7uqqOQFfF00eMv\nCxJwsqwRr37LqUtrdaykHruyq7BwfCT0Wu65IttydfdGMk5b9o5Jz3gpZY6U8moAAQDipJQTpZR5\nFk1GPVZY04xDZ2oxJ4nvrOmnrowLwoLhoXht22lkFtepjkPnsWxnLlz1Wtw2Olx1FKIeG9DPDUP7\ne7Eg6yVTd1n+RQjhI6VsklI2CCH6CSGes3Q46plvMrqmK2dzqoMu4Klr4+Hj5oTffpGOjk6j6jh0\njvKGVqw+XIwbRg6At5tedRyiXpkWH4SDZ2pQ0dCmOorNMXVMfKaU8oe9rFLKGgCzLBOJeuvrjBIk\nhnojwo/TlXR+Pm5OeG5+ArJK6vHm9tOq49A5Pkw9g/ZOI+6ZEKk6ClGvTYsPgpTAt8c5StZTphZk\nWiHEDz0UhBCuANhTwYoUVDfjSEEtZg/j6Bhd3IyEYMweFoKXt2bjZFmD6jgEoLWjEx+l5uOquEAM\nDPBQHYeo1+JDvBDq48ppy14wtSD7CMBWIcRiIcRiAJsBvG+5WNRT6zK6Nr1yupJM8ae5Q+HhosNv\nvzgCA6culVt9uAhVTe1sBEs2TwiBafFB2HGqEs3t7I7VE6Yu6v87gD8DGNJ9e1ZK+bwlg1HPrEsv\nQdIAb4T58pgVujQ/D2f8ce5QHCmswzs7c1XHcWhSSryzMxdDQrwwbqCf6jhEl216fBDaDEZ8f7JS\ndRSbYvK+ainlN1LK33TfNloyFPVMflUTMorqOF1JPXLtsBBMjw/CC5tPsm+QQjtOVeJkWSMbwZLd\nGBXlCy8XHacte8jUXZYLhBCnhBB1Qoh6IUSDEKLe0uHINGenK9lIknpCCIHn5ifAVa/F/32Zjk4e\nCqzEOztz4e/hjGvZrobshF6rwZVxgfj2eBmXRPSAqSNkzwOYK6X0llJ6SSk9pZRelgxGpluXXoLk\nMB8M6MfpSuqZQC8XPDUnHmn5NVi+J091HIdzqqwB209W4K5xEXDWaVXHITKbafHBqGnuQFo+j2sz\nlakFWZmU8phFk1Cv5FY2IbO4HnM4XUm9tGBEKK4YHIDnN5xAflWT6jgOZdmuXDjpNLh9DBvBkn2Z\nMjgATloNpy17wNSCLE0I8ZkQ4tbu6csFQogFFk1GJlnfPV05k9OV1EtCCPx1QSJ0GoHHV2TAyKnL\nPlHd1I6VB4tw/YhQ+HmwixDZFw9nHcbH+GFzVhmk5GuKKUwtyLwANAOYDuDa7tscS4Ui032dXoIR\n4T4I9XFVHYVsWIi3K34/ewj25FTh431nVMdxCB+l5qPNYMSiCWx1QfZpWnwQzlQ342QZNw2ZwtS2\nF/ec57bI0uHo4k5XNOJYST1mD+uvOgrZgVtGhWFCjB/+uv4YimpbVMexa22GTixPzcfkQQGIDfJU\nHYfIIq4ecvaw8VLFSWyDqbssXYQQS4QQrwkhlp29WTocXdz6dDaDJfMRQuBvC4ZBAvjdygxOM1jQ\n10dKUNHQhsUTOTpG9ivIywVJYT7YxHVkJjF1yvIDAMEArgGwHcAAADxzRbF1GSUYFdkPwd4uqqOQ\nnQjzdcPjM+Pw/ckKfHGgUHUcuySlxNKduYgN9MDkWH/VcYgsanp8ENIL61Ba16o6itUztSCLkVI+\nCaBJSvk+gNkAxlguFl1KdnkDjpc2cHSMzO6OMREYHeWLZ7/O4ouoBezJqcKxkno2giWHMD2+e9ry\nGEfJLsXUgqyj+89aIUQCAG8AgZaJRKZYl14KIbi7ksxPoxF4/vphMHRKPPjRAbR2dKqOZFeW7cyF\nr7sT5g8PVR2FyOJiAj0Q6efG9hcmMLUge0sI0Q/AEwDWAMgC8HeLpaJLWpdRjFGRvgjy4nQlmV+k\nvztevDkZhwtq8cjnh9kKw0xyKhqx9Xg57hgTDhc9G8GS/Tt72Pie05Wob+249Dc4MFMLsq1Syhop\n5fdSyoFSykAAmywZjC7sZFkDTpY1shksWdSMhGD8YdYQrM8oxd83Hlcdxy4s35MPvUaDO8ZFqI5C\n1GemxQejo1Ni+4kK1VGsmqkF2YrzfO5LcwYh032dXgIhun5hElnS4olRuHNsBN7cnoOP97I/2eXo\n6DRizZFiTIsPQqAnR7bJcYyM6AdfdydOW16C7mJfFELEARgKwPtHnfm9APAVRQEpJdalF2NMlC9f\n1MnihBB4+tp4FNY048nVR9HfxwVXDOby0d7YeaoS1U3tmJfMvoHkWLQagaviArEhsxQdnUbotaaO\nBTmWS/1XGYyujvw++G+H/msBjABwn2Wj0fmcKGvA6YomNoOlPqPTavDKbSMwOMgTSz46iKzietWR\nbNLqw0XwdtWzoCWHNC0+CA2tBuzNqVYdxWpdtCCTUq6WUt4DYM6PuvT/Qkq5u48y0jnWpZdAI4AZ\nQzldSX3H3VmHZXePgperHove2892GD3U3G7ApqwyzEoMhpOOowPkeCbFBsBFr8Emdu2/IFNfGa4T\nQngJIfRCiK1CiAohxB0WTUY/0TVdWYKxA/0Q4MnDiKlvBXu7YNndo9DYZsCi9/ajsc2gOpLN2JxV\nhub2TsxNYqsLckyuTlpMig3AFh42fkGmFmTTpZT16Jq+zAMQA+C3lgpF53espAE5lU2Yzd2VpMiQ\nEC+8evsInChrwM8/PghDp1F1JJuw5nAxgr1cMCbKV3UUImWmxQehuK4VmVz2cF6mFmT67j9nA/hC\nSllnoTx0EesyiqHVCE5XklJTBgXg2XkJ+O5EBZ5Zm8V3u5dQ3dSO7ScrMDe5PzQaduYnx3VVXCA0\nAjzb8gJMLcjWCiGOAxgJYKsQIgAAF5H0obPTleOj/eDnwelKUuu2MeH42ZSB+CA1H+/szFUdx6qt\nzyiBwSi5u5Icnp+HM0ZG9MOmTK4jOx+TCjIp5eMAxgNIkVJ2AGgCMO9i3yOEWCaEKBdCHL3A14UQ\n4mUhRLYQIl0IMaKn4R1JZnE98qqaeXYlWY3/uyYOsxND8Of1x7DhaInqOFZr9eEixAR6ID7ES3UU\nIuWmxQfheGkDCqqbVUexOhctyIQQV3b/uQDAFQDmdf99BroKtIt5r/u6C5kJILb7dj+A101K7KDW\nZZRAqxG4htOVZCU0GoEXbkrC8DAf/PLTwzh0pkZ1JKtTWNOM/Xk1mJ/cnweJE6Graz8ANok9j0uN\nkE3u/vNadC3o//GfFySl/B7AxRqOzAOwXHZJBeAjhODwz3mcna6cEOOPfu5OquMQ/cBFr8Xbd6Ug\nyMsF976fxne9P7L2SNfIIXdXEnWJ8ndHbKAHC7LzuFRB1iCEeATA0XNumQAyuv9+OUIBFJzzcWH3\n535CCHG/ECJNCJFWUeF4Z2EdLarHmepmzOF0JVkhPw9nvHvPKBiMEne/uw91zTxA+KzVh4swPNwH\n4X5uqqMQWY1p8UHYl1eN2uZ21VGsyqUKMg8AnuhazP8ggBAA/QE8gK5u/X1CSvmWlDJFSpkSEBDQ\nVw9rNb7OKIZOIzB9aJDqKETnFR3ggbfuHImC6hY88OEBtBvYDuN4aT2OlzZgfjJHx4jONS0+CJ1G\niW+Pl6uOYlUu1an/GSnlMwAGABghpfyNlPJRdBVo4Zf52EUAws75eED35+gcZ6crJ8b6w8eN05Vk\nvcYM9MPzNwzDnpwqPL4y3eHbYaw+3NWmhn0Dif5X0gAfBHo6c9ryR0xtexEE4Nyxxfbuz12ONQDu\n6t5tORZAnZSSW7V+5EhhHQprWri7kmzC/OGheGTaIKw8WISXt2arjqOM0Six5nAxJsb4w59taoj+\nh0YjcHV8ELafrEBrR6fqOFbD1IJsOYB9Qog/CiH+CGAvunZRXpAQ4hMAewAMFkIUCiEWCyEeEEI8\n0H3JegA5ALIBvA3goV7kt3urDhVBrxWYHs/dlWQbfn5lDG4YOQAvbjmJrw4Vqo6jxMEzNSiqbWHv\nMaILmDE0GM3tndh+0vHWhV+IzpSLpJR/FkJ8A2BS96fukVIeusT33HqJr0sAS0xK6aDqWjrwRVoB\nZieGwNtNf+lvILICQgj85bpEFNe24LEv0xHs5Ypx0X6qY/WpVYeL4KLXYDrb1BCd17hoP/i46bE+\no4TtnLqZOkIGKeVBKeVL3beLFmNkHp/uO4Om9k7cO2mg6ihEPeKk0+D1O0Yiws8dP/sgDdnljaoj\n9ZmOTiPWpZfg6iFB8HA26T0vkcPRazW4Jj4YW4+Vc9qym8kFGfWtdoMR7+7Kw/hoPySEequOQ9Rj\n3q56vHv3KDjpNLjnvX2obGxTHalP7DhVgZrmDszj7kqii5qZGIzGNgN2nKpUHcUqsCCzUusyilFa\n34r7ODpGNizM1w1LF45CRUMb7lue5hDvhFcfLoa3qx5TBjleix6inpgQ4w9v165pS2JBZpWklHj7\n+1zEBnrwRZ1sXnKYD/5983AcLqjFrz87DKPRftthNLUZsCmzDLMSQ+Ck48sr0cXotRpMjw/Clqwy\ntBns/83apfAVwwrtPl2FrJJ63DspChoNz78j2zcjIRh/mDUE3xwtxd83HFcdx2K2HCtDS0cn5nN3\nJZFJZg0LQUObATs5bcmCzBq9vSMH/h7OXINCdmXxxCjcNS4Cb36fgw9T81XHsYjVh4sR4u2CUZG+\nqqMQ2YQJ0f7wctFhHactWZBZm5NlDdh2ogILx0XARa9VHYfIbIQQeGpOPK6MC8RTq4/iuxP2dWxK\ndVM7vj9ZgblJ/TmyTWQiJ50G0+KDsZnTlizIrM3SHTlw0Wtwx9gI1VGIzE6n1eA/tw7HkBAvPPzR\nQWQV16uOZDbrMkpgMEqObBP10OxhwWhoNWBXtmNPW7IgsyLlDa1YdagYN44MQz93nltJ9sndWYdl\nd4+Cl6se9y1PQ31rh+pIZrH6UBFiAz0wJMRTdRQimzIxJgCeLjqszyhVHUUpFmRWZPnufHQYjVg8\nMUp1FCKLCvJywWu3j0BJXQue+zpLdZzLVlDdjLT8GswfHgohOF1J1BNd05ZB2JRZinaDUXUcZViQ\nWYnmdgM+SM3H9PggRPq7q45DZHHDw/vhgSnR+DytEN8eL1Md57KsTS8GAMxN4u5Kot6YnRiC+lYD\ndp123GlLFmRW4ssDhahr6cD9k9kIlhzHL6+ORVywJx5fkYHa5nbVcXpt9aFijIzohzBfN9VRiGzS\nxFh/eDrrsD7dcXdbsiCzAp1GiXd25mJ4uA9GRnC7PDkOZ50W/7wxCdVN7fjjmkzVcXrleGk9TpQ1\nYB57jxH1mrNOi6vjg7ApqwwdnY45bcmCzApszipFflUzj0kih5QQ6o2Hr4zBqsPF2HDU9hb1rjpU\nDK1GYFZiiOooRDZtVmII6lo6sPt0leooSrAgswJv78hFmK8rrhkarDoKkRJLpsZgaH8v/OGrDFTZ\n0CHkRqPE2iPFmBTrD38PZ9VxiGzapFh/eDjwtCULMsUO5NfgQH4NFk+IgpbNJMlB6bUavHBTEupb\nO/Dk6qOQ0jbOuzxwpgZFtS2criQyAxe9FlcNCcTGrFKHnLZkQabY0h058HbV48aUMNVRiJSKC/bC\nr64ehPUZpVhrI++QVx0qgoteg+nxHN0mModZiSGobe7AHgectmRBplB+VRM2ZJbi9jHhcHfWqY5D\npNzPJg9EUpgPnlp9FOUNrarjXFRLeyfWHinG9PhgPn+JzGTKoAC4O2nxzVHbeFNmTizIFFq2Mxc6\njcDd4yNVRyGyCjqtBi/cmISW9k78fmWGVU9drj1SjPpWA24bE646CpHd6Jq2DMLGzDIYHGzakgWZ\nIrXN7fg8rRDzkkMR6OWiOg6R1YgJ9MBvrxmMLcfKseJgkeo4F/Th3nzEBnpgTBRb1RCZ06zEEFQ3\ntSM1p1p1lD7FgkyRj/aeQUtHJ1tdEJ3HPROiMCqyH55Zm4mSuhbVcX7iSEEt0gvrcMfYCB6VRGRm\nVwwOgJuTFusyHGvakgWZAm2GTry3Ow+TBwVgcDAPIib6Ma1G4J83JsHQKfHYl+lWN3X5YWo+3Jy0\nuG5EqOooRHbHRa/FlXGB2JRZ6lDTlizIFFh9uBgVDW24n6NjRBcU4eeO382Kw45TlfhkX4HqOD+o\nbW7HmiPFmD88FF4uetVxiOzS7MQQVDW1Y1+u40xbsiDrY1JKLN2Rg7hgT0yI8VMdh8iq3TEmAuOj\n/fDndVkoqG5WHQdA17mzbQYj7hgToToKkd26YnAgXPWONW3JgqyPbT9ZgZNljbh/8kCuPSG6BI1G\n4PkbhgEAfvvlERiNaqcujUaJj/aewciIfojv76U0C5E9c3XqmrbcmFmKTsXP+77CgqwPGY0Sr3yb\njSAvZ8wZxs7eRKYY0M8NT8yJR2pONZbvyVOaZdfpSuRWNuHOsRwdI7K0WYkhqGx0nGlLFmR9aPme\nPKTl1+DR6YPhpON/eiJT3TIqDFMGBeBvG44rnbr8YE8+fN2dMDORnfmJLG1qXABc9Bqsd5BpS1YF\nfSS/qgl/33ACUwcH4MaRA1THIbIpQgj8dUEiNELgKUVnXZbUtWDLsTLclBIGZ522zx+fyNG4Oelw\nZVwgvjnqGNOWLMj6gNEo8dsv06HTCvx1wTCuHSPqhf4+rnhk2iB8d6ICG46W9vnjf7L3DCSA29mZ\nn6jPdE1btmF/nv1PW7Ig6wPv78nDvtxqPDknHsHe7MpP1Ft3j4/EkBAv/HFtJhrbDH32uB2dRnyy\nvwBXDApAmK9bnz0ukaObOjgQzjoNvnGAaUsWZBaWV9mEv284zqlKIjPQaTX4y3UJKG9ow782neyz\nx92UWYaKhjbcOY6L+Yn6kruzDlMHd01bqt5lbWksyCzIaOzqMq7XajhVSWQmw8P74bbR4Xhvdy6O\nFtX1yWN+kJqHUB9XTBkU2CePR0T/NWtYCMob2pCWX6M6ikWxILOg9/fkYV9eNZ7iVCWRWT12TRx8\n3Z3wh68yLL7YN7u8Aak51bh9bDi0Gr6pIuprV8Z1TVva+25LFmQWcnaq8sq4QNzAqUois/J20+OJ\n2fE4UliHj/fmW/SxPkw9AyetBjelhFn0cYjo/DycdZgyKADfHC2x62lLFmQWcO5U5V+uS+RUJZEF\nzEvujwkxfnh+wwmUN7Ra5DGa2gxYcaAQMxOD4e/hbJHHIKJLmz0sBGX1bdh9ukp1FIthQWYB7+3m\nVCWRpQkh8Oy8BLQZjHju62MWeYw1R4rR0GZgZ34ixa4ZGgx/Dycs3ZmjOorFsCAzs9zKJjy/kVOV\nRH1hYIAHHrwiGmuOFGPHqQqz3reUEh/syUdcsCdGRvQz630TUc+46LW4a1wktp2owKmyBtVxLIIF\nmRl1TVUe4VQlUR968IpoRPm748lVR9Ha0Wm2+z1UUIusknrcMTaCz2UiK3DH2Ai46DVYuiNXdRSL\nYEFmRu/uzsP+vBo8fe1QTlUS9REXvRbPzktAXlUzXtt22mz3++GefHg46zB/eKjZ7pOIes/X3QnX\njxiArw4VoaKhTXUcs2NBZia5lU34R/dU5fUj+AJO1JcmxvpjXnJ/vLHtNE5XNF72/VU3tePr9BIs\nGBEKD2edGRISkTksnhiFDqMRH+zJUx3F7FiQmcHZqUonrQZ/XcCpSiIV/jB7CJz1Gjy56vIPH/8i\nrQDtnUbcwcX8RFZlYIAHrh4ShA9S89HSbr4lCtaABZkZnDtVGeTFqUoiFQI9XfB/M+Kw+3QVVh0u\n6vX9GI0SH+7Nx+goXwwK8jRjQiIyh/smDURNcwe+PFioOopZsSC7TOdOVS7gVCWRUreNDkdymA+e\n+/oY6po7enUf209VoKC6haNjRFZqVGQ/JA3wxrKduXbVKJYF2WVoM3Ti0c8Pc6qSyEpoNAJ/vi4B\nNc3t+PvG4726j49S8+Hv4YQZQ4PNnI6IzEEIgfsmD0RuZRO2HCtTHcdsLFqQCSFmCCFOCCGyhRCP\nn+frVwgh6oQQh7tvT1kyjzl1GiV+9elhHDxTiz9fl8ipSiIrMbS/N+6ZEIWP957BgR4eRlxY04yt\nx8txy6hwOOn4fpXIWs0YGoxQH1e8vcN+GsVa7BVHCKEF8CqAmQDiAdwqhIg/z6U7pJTJ3bc/WSqP\nOUkp8cSqDHxztBRPzonHtUn9VUcionP8etoghHi74A9fZeC7E+XYc7oKhwtqcby0HvlVTSirb0Vd\nSwfaDcb/2QDwyb4zEABuHROuLjwRXZJOq8GiiVHYn1eDwwW1quOYhSX3c48GkC2lzAEAIcSnAOYB\nyLLgY/aJf2w8gU/2FeDhqTFYPDFKdRwi+hEPZx2emTsUP/vwAO55d/9Fr9UIwFWvhYtei4ZWA66M\nC0Koj2sfJSWi3rp5VBj+veUk3t6Rg1dvG6E6zmWzZEEWCqDgnI8LAYw5z3XjhRDpAIoA/EZKmfnj\nC4QQ9wO4HwDCw9W+c126IwevbTuN28aE49Hpg5RmIaILmz40GDsem4rKxna0tHeitaPr1tJ9a+0w\ndn3c/t/PtxuMWDyJb7KIbIGHsw63jQnH29/noKC6GWG+bqojXRbVHQ8PAgiXUjYKIWYBWAUg9scX\nSSnfAvAWAKSkpCjbUvHlgUI8t+4YZiUG49l5CVzET2TlBvRzw4B+tv0iTUQXdvf4SLyzIxfv7srD\nU9eeb1WU7bDkqtUiAGHnfDyg+3M/kFLWSykbu/++HoBeCOFvwUy9tjmrDP+3Ih0TY/zx4s3J0GpY\njBEREakU4u2Ka5P647P9Z1DX0rtWN9bCkgXZfgCxQogoIYQTgFsArDn3AiFEsOgeZhJCjO7OU2XB\nTL2yN6cKSz4+iIRQb7x550g467SqIxERERGAeydFoam9E5/sO6M6ymWxWEEmpTQAeBjARgDHAHwu\npcwUQjwghHig+7IbABwVQhwB8DKAW+TlnnliZpnFdbj3/TSE+7rh3btHwZ3n2hEREVmNof29MT7a\nD+/tykO7wag6Tq8JK6t/LiklJUWmpaX1yWPlVjbhxjd2w1mnxZcPjkOIN3deERERWZvvTpTjnnf3\n48Wbk3Dd8AGq4/wPIcQBKWXKpa5j58MLKKtvxZ3v7IVRAssXj2YxRkREZKWuGBSA2EAPvPV9Lmxt\noOksFmTnUdfcgbve2Yeapna8d88oRAd4qI5EREREFyCEwL2TonCspB67T1vdUnSTsCD7keZ2Axa9\nvx+5lU14+64UDBvgozoSERERXcK85FD4ezjZ7HFKLMjO0WboxEMfHcShMzV4+dZkjI+xyg4cRERE\n9CMuei0WjovEthMVOFXWoDpOj7Eg61bf2oGFy/Zh24kK/HVBImYkhKiORERERD1wx9gIuOg1WLoj\nV3WUHmNBhq4F/De9sQcH8mvw0i3JuHkUDxYmIiKyNf3cnXDDyAH46lARyhtaVcfpEYcvyLLLG7Hg\ntd0oqG7Gu3ePxrzkUNWRiIiIqJcWTxyIDqMRH+zJVx2lRxy6IDuQX4Mb3tiNNoMRn/1sHCbGcs0Y\nERGRLYvyd8e0IUH4MDUfLe2dquOYzGELsq3HynD70lT4uOqx8sHxSAj1Vh2JiIiIzOC+yQNR09yB\nF7ecVB3FZA5ZkH22/wzu/+AABgd54ssHxyPcz011JCIiIjKTUZG+uGNsON76PgfL9+SpjmMShzqY\nUUqJV77NxgubT2LKoAC8dvsInk1JRERkh56Zm4DSujY8vSYTQV4uuGZosOpIF+UwI2SdRoknVh3F\nC5tPYsGIUCxdmMJijIiIyE5pNQL/uXU4kgb44BefHMKB/BrVkS7KIQqy1o5OPPjhAXy09wwemBKN\nF25Mgl7rEP90IiIih+XqpMU7C1MQ4u2Ce9/fj5yKRtWRLsjuq5La5nbcsXQvNh8rw1Nz4vH4zDgI\nIVTHIiIioj7g5+GM9xeNhkYILHx3Hyoa2lRHOi+7LsgOF9Tixjf2IL2wDi/fMhyLJkapjkRERER9\nLMLPHcvuHoXKhnYsem8/mtoMqiP9hN0VZEajxKbMUtz4xm7Mf3UXyhva8N49o3BtUn/V0YiIiEiR\npDAfvHLbcGQW1+Hhjw/C0GlUHel/2M2q9pb2Tqw4WIh3duYit7IJoT6ueHJOPG4eFQYPLt4nIiJy\neFcNCcJz8xPx+68y8MSqo/jrgkSrWcZk85VKZWMblu/Jxwd78lDT3IGkAd545bbhmDE0GDou3Cci\nIqJz3DYmHCV1LfjPt9kI8XbFL6+OVR0JgA0XZNnljXhnZw5WHCxCR6cRV8UF4b5JURgd5Ws11S4R\nERFZn0emDUJxbSte3HISIT4uuCklTHUk2yvImtoMWPzefmw9Xg5nnQY3jByAxROjEB3goToaERER\n2QAhBP52fSLKG1rxu5UZCPJywZRBAWozSSmVBugp55BYmfDQa7hzXATuHBsBPw9n1ZGIiIjIBjW2\nGXDTG3uQV9WEz382ziLnWgshDkgpUy55na0VZAOHDJNZ6YfgoteqjkJEREQ2rry+Fde9thttBiM+\nuW8MYoM8zXr/phZkNrfq3dfdicUYERERmUWglwveXzQKBqMR0178Hncs3Yuv04vRbujbthg2N0KW\nkpIi09LSVMcgIiIiO1JW34rP9hfgs/0FKKptga+7E24YOQA3jwq7rHXqdjtlyYKMiIiILKXTKLHj\nVAU+3VeALcfKYDBKjI7yxa2jwzAzIaTHs3SmFmQ2t8sSlaeAd2erTkFERER2SAvgiu5b+0AjKhra\nUPRQ7QwAAAjoSURBVF7WiravjMhYLRDg4YxAT2e4OZm3hLK9goyIiIioDzhpNQj1cUV/HxfUtxhQ\n3tCKsvpWlNa3wsNZhwH9XOHj6mSWx7K9gsw/FrhnneoURERE5CAEAO/uW3VTO1YeLMQHqfkoL2nD\nlkenINTH9cLfvMi0ZvU2t8uSiIiISBVfdyfcO2kgPrp3DCQknl2bZZb7ZUFGRERE1EMD+rnh51fG\nYkNmKbadKL/s+2NBRkRERNQL906KwkB/dzy9JhOtHZ2XdV8syIiIiIh6wVmnxTPzhiK/qhlvfZ9z\nWffFgoyIiIiolybFBmB2Yghe/S4bBdXNvb4fFmREREREl+GJOUOg1Qg8szaz1/fBgoyIiIjoMoR4\nu+KXV8Viy7FybMkq69V9sCAjIiIiukyLJkYhNtADf1zbuwX+LMiIiIiILpNeq8Gf5iWgsKYFr32X\n3ePvZ0FGREREZAbjov0wL7k/3tieg7zKph59LwsyIiIiIjP5w6whcNJp8PSaTEgpTf4+FmRERERE\nZhLo5YJfTxuE7ScrsDHT9AX+LMiIiIiIzGjhuAjEBXviTz1og8GCjIiIiMiMdFoNnp2fgOK6VpO/\nhwUZERERkZmNivTF9SMGmHw9CzIiIiIiC3h8ZpzJ11q0IBNCzBBCnBBCZAshHj/P14UQ4uXur6cL\nIUZYMg8RERFRXwnwdDb5WosVZEIILYBXAcwEEA/gViFE/I8umwkgtvt2P4DXLZWHiIiIyFpZcoRs\nNIBsKWWOlLIdwKcA5v3omnkAlssuqQB8hBAhFsxEREREZHUsWZCFAig45+PC7s/19BoIIe4XQqSJ\n/2/v7kP1rOs4jr8/TU3BYpj7o9xoJqNaohsNEzWIgbBMVOgByzJDCEnBrCgjqNlfgZH2iIyS0Kyo\nNmqWJAMXiVk620NbJhs2yClsK9QthzL99sd9JceDbjvuvv2d677fL7g51/P1uc6Pc873/t2/c13J\nhj179gw9qCRJUku9GNRfVauqallVLZs3b17rOJIkSUM1yoJsF7Bgyvz8btlMt5EkSRproyzIHgQW\nJTk1yXHApcDaadusBS7v/tvybOCpqnpihJkkSZJmnWNGdeCqOpjkGuBuYA5wa1VtS3JVt/4W4C7g\nAmAH8AzwqVHlkSRJmq1GVpABVNVdDIquqctumTJdwNWjzCBJkjTb9WJQvyRJ0jizIJMkSWrMgkyS\nJKkxCzJJkqTGLMgkSZIasyCTJElqzIJMkiSpsQxuBdYfSfYBj7TOoZE7GdjbOoRGznaeDLbzZLCd\nX95bq+qwD+Ie6Y1hR+SRqlrWOoRGK8kG23n82c6TwXaeDLbz0fEjS0mSpMYsyCRJkhrrY0G2qnUA\nvSZs58lgO08G23ky2M5HoXeD+iVJksZNH3vIJEmSxooFmSRJUmO9KsiSrEjySJIdSa5vnUfDl+TW\nJLuTbG2dRaORZEGS9Un+nmRbkmtbZ9LwJTk+yQNJNnftfEPrTBqdJHOSbEzy29ZZ+qo3BVmSOcD3\ngfcDi4GPJlncNpVG4MfAitYhNFIHgc9X1WLgbOBqf5bH0rPA8qo6E1gCrEhyduNMGp1rgYdbh+iz\n3hRkwFnAjqp6tKqeA34OXNw4k4asqv4I/Kd1Do1OVT1RVX/tpvcx+CV+SttUGrYa2N/NHtu9/C+y\nMZRkPvAB4Iets/RZnwqyU4B/TZl/DH+JS72WZCGwFPhL2yQahe5jrE3AbmBdVdnO4+lm4IvAC62D\n9FmfCjJJYyTJicBq4LNV9XTrPBq+qnq+qpYA84GzkpzeOpOGK8mFwO6qeqh1lr7rU0G2C1gwZX5+\nt0xSzyQ5lkExdkdVrWmdR6NVVU8C63F86Dg6F7goyU4GQ4mWJ/lJ20j91KeC7EFgUZJTkxwHXAqs\nbZxJ0gwlCfAj4OGq+lbrPBqNJPOSzO2mTwDOB/7RNpWGraq+XFXzq2ohg7/L91TVxxvH6qXeFGRV\ndRC4BribwSDgX1TVtrapNGxJfgbcD7w9yWNJrmydSUN3LvAJBu+kN3WvC1qH0tC9GVifZAuDN9Tr\nqspbIkivwEcnSZIkNdabHjJJkqRxZUEmSZLUmAWZJElSYxZkkiRJjVmQSZIkNWZBJmnWSDI3yWem\nzL8lya9GcJ6VSXYl+foM97siyfdeYd2fuq8Lk3zsMMc5obvdx3NJTp5JBknjyYJM0mwyF3ixIKuq\nx6vqQyM6101V9dUj3TjJMYdaX1XndJMLgUMWZFV1oHuk0ONHen5J482CTNJs8g3gtK736Maut2kr\nvNg79esk65LsTHJNks8l2Zjkz0lO6rY7LcnvkzyU5N4k7zjcSZOc1B17S3esM7rlK5PcnuQ+4PZu\n8wVJ/pBke5KvTTnG/inX8N7uGq5L8q4kD3TzW5IsGuL3S9KYOOQ7Pkl6jV0PnN71HpFk4bT1pwNL\ngeOBHcCXqmppkpuAy4GbgVXAVVW1Pcl7gB8Ayw9z3huAjVV1SZLlwG3Akm7dYuC8qjqQ5ArgrC7H\nM8CDSX5XVRumXcMXqurC7hq+C3y7qu7oHvs2Z0bfEUkTwYJMUp+sr6p9wL4kTwF3dsv/BpyR5ETg\nHOCXg0dmAvD6IzjuecAHAarqniRvSvLGbt3aqjowZdt1VfVvgCRrun038MruB76SZD6wpqq2H0Ee\nSRPGjywl9cmzU6ZfmDL/AoM3mK8DnqyqJVNe7zzKc/532vz0580d8vlzVfVT4CLgAHBX1wMnSS9h\nQSZpNtkHvOHV7lxVTwP/TPJhgAyceQS73gtc1u3zPmBvd6yXc3435uwE4BLgvmnrX3INSd4GPFpV\n3wF+A5wxg0uSNCEsyCTNGt1Hgfcl2Zrkxld5mMuAK5NsBrYBFx/BPiuBdyfZwmBQ/icPse0DwGpg\nC7B62vgxuuXPJ9mc5DrgI8DWJJsYjD27bSYXI2kypOqQve2SNHaSrAT2V9U3G+fYCSyrqr0tc0hq\nzx4ySZNoP/Dpmd4Ydlj+f2NY4FgG498kTTh7yCRJkhqzh0ySJKkxCzJJkqTGLMgkSZIasyCTJElq\nzIJMkiSpsf8BduCzs/RwHroAAAAASUVORK5CYII=\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x108ca2c88>"
+       "<matplotlib.figure.Figure at 0x111bad748>"
       ]
      },
      "metadata": {},
@@ -171,9 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -234,9 +223,23 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def setupSimulation():\n",
+    "    sim = rebound.Simulation()\n",
+    "    sim.integrator = \"ias15\" # IAS15 is the default integrator, so we don't need this line\n",
+    "    sim.add(m=1.)\n",
+    "    sim.add(m=1e-3, a=1., r=np.sqrt(1e-3/3.)) # we now set collision radii!\n",
+    "    sim.add(m=5e-3, a=1.25, r=1.25*np.sqrt(5e-3/3.))\n",
+    "    sim.move_to_com()\n",
+    "    return sim"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -248,22 +251,65 @@
     }
    ],
    "source": [
-    "sim = rebound.Simulation()\n",
-    "sim.integrator = \"ias15\" \n",
+    "sim = setupSimulation()\n",
     "sim.collision = \"direct\"\n",
     "sim.collision_resolve = \"merge\"\n",
-    "sim.add(m=1.)\n",
-    "sim.add(m=1e-3,a=1.,r=np.sqrt(1e-3/3.))\n",
-    "sim.add(m=5e-3,a=1.25,r=1.25*np.sqrt(5e-3/3.))\n",
+    "\n",
     "print(\"Particles in the simulation at t=%6.1f: %d\"%(sim.t,sim.N))\n",
     "sim.integrate(100.)\n",
     "print(\"Particles in the simulation at t=%6.1f: %d\"%(sim.t,sim.N))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use the built-in collision detection and apply our own function to resolve the collision. By default, if we don't set the sim.collision function pointer, `REBOUND` will raise a `Collision` exception when a collision occurs, which we can catch. \n",
+    "\n",
+    "An indirect way of checking which particles collided is to check which ones have a `lastcollision` time equal to the current simulation time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Particles [1, 2] collided\n"
+     ]
+    }
+   ],
+   "source": [
+    "sim = setupSimulation()\n",
+    "sim.collision = \"direct\"\n",
+    "# we don't set sim.collision_resolve this time\n",
+    "\n",
+    "try:\n",
+    "    sim.integrate(100.)\n",
+    "except rebound.Collision:\n",
+    "    collided = []\n",
+    "    for p in sim.particles:\n",
+    "        if p.lastcollision == sim.t:\n",
+    "            collided.append(p.index)\n",
+    "    # Custom resolution\n",
+    "\n",
+    "print(\"Particles {0} collided\".format(collided))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },
@@ -277,9 +323,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/ipython_examples/SaturnsRings.ipynb
+++ b/ipython_examples/SaturnsRings.ipynb
@@ -14,9 +14,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import rebound\n",
@@ -54,9 +52,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim.ri_sei.OMEGA = OMEGA"
@@ -164,9 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim.configure_ghostboxes(2,2,0)"
@@ -190,7 +184,8 @@
     "sim.integrator = \"sei\"\n",
     "sim.boundary   = \"shear\"\n",
     "sim.gravity    = \"tree\"\n",
-    "sim.collision  = \"tree\""
+    "sim.collision  = \"tree\"\n",
+    "sim.collision_resolve = \"hardsphere\""
    ]
   },
   {
@@ -250,9 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "total_mass = 0.\n",
@@ -282,9 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -326,9 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sim.integrate(2.*np.pi/OMEGA)"
@@ -344,9 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -373,9 +360,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [conda env:p2]",
    "language": "python",
-   "name": "python2"
+   "name": "conda-env-p2-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -387,9 +374,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/python_examples/longtermtest/problem.py
+++ b/python_examples/longtermtest/problem.py
@@ -143,8 +143,8 @@ axarr.set_xlim(extent[0], extent[1])
 axarr.set_ylim(extent[2], extent[3])
 axarr.set_xlabel(r"time [orbits]")
 axarr.set_ylabel(r"relative energy error")
-plt.xscale('log', nonposy='clip')
-plt.yscale('log', nonposy='clip')
+plt.xscale('log')
+plt.yscale('log')
 plt.grid(True)
 
 

--- a/rebound/__init__.py
+++ b/rebound/__init__.py
@@ -50,6 +50,11 @@ class Encounter(Exception):
     You may want to search for the pair of bodies which have the smallest distance."""
     pass
 
+class Collision(Exception):
+    """The simulation exited because a collision has been detected.
+    You may want to search for which particles have a lastcollision time equal to the simulation time."""
+    pass
+
 class Escape(Exception):
     """The simulation exited because a particle has been se encounter has been detected.
     You may want to search for the particle with the largest distance from the 
@@ -71,4 +76,4 @@ from .tools import hash
 from .simulationarchive import SimulationArchive
 from .interruptible_pool import InterruptiblePool
 
-__all__ = ["__version__", "__build__", "__githash__", "SimulationArchive", "Simulation", "Orbit", "OrbitPlot", "Particle", "SimulationError", "Encounter", "Escape", "NoParticles", "ParticleNotFound", "InterruptiblePool","Variation", "reb_simulation_integrator_whfast", "reb_simulation_integrator_sei","reb_simulation_integrator_mercurius", "clibrebound"]
+__all__ = ["__version__", "__build__", "__githash__", "SimulationArchive", "Simulation", "Orbit", "OrbitPlot", "Particle", "SimulationError", "Encounter", "Collision", "Escape", "NoParticles", "ParticleNotFound", "InterruptiblePool","Variation", "reb_simulation_integrator_whfast", "reb_simulation_integrator_sei","reb_simulation_integrator_mercurius", "clibrebound"]

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1,5 +1,5 @@
 from ctypes import Structure, c_double, POINTER, c_float, c_int, c_uint, c_uint32, c_int64, c_long, c_ulong, c_ulonglong, c_void_p, c_char_p, CFUNCTYPE, byref, create_string_buffer, addressof, pointer, cast
-from . import clibrebound, Escape, NoParticles, Encounter, SimulationError, ParticleNotFound
+from . import clibrebound, Escape, NoParticles, Encounter, Collision, SimulationError, ParticleNotFound
 from .particle import Particle
 from .units import units_convert_particle, check_units, convert_G
 from .tools import hash as rebhash
@@ -1378,6 +1378,8 @@ class Simulation(Structure):
                 raise Escape("User caused exit. Simulation did not finish.") # should not occur in python
             if ret_value == 6:
                 raise KeyboardInterrupt
+            if ret_value == 7:
+                raise Collision("Two particles collided (d < r1+r2)")
         else:
             debug.integrate_other_package(tmax,exact_finish_time)
         self.process_messages()

--- a/rebound/tests/test_collisions.py
+++ b/rebound/tests/test_collisions.py
@@ -13,6 +13,7 @@ class TestCollisions(unittest.TestCase):
         sim.boundary   = "open"
         sim.gravity    = "tree"
         sim.collision  = "tree"
+        sim.collision_resolve = "hardsphere"
         def cor_remove_both(r, c):
             r.contents.collisions_Nlog += 1
             return 3

--- a/rebound/tests/test_shearingsheet.py
+++ b/rebound/tests/test_shearingsheet.py
@@ -21,6 +21,7 @@ class TestShearingSheet(unittest.TestCase):
         sim.boundary   = "shear"
         sim.gravity    = "tree"
         sim.collision  = "tree"
+        sim.collision_resolve = "hardsphere"
         def cor_bridges(r, v):
             eps = 0.32*pow(abs(v)*100.,-0.234)
             if eps>1.:

--- a/rebound/tests/test_simulation.py
+++ b/rebound/tests/test_simulation.py
@@ -253,6 +253,7 @@ class TestSimulationCollisions(unittest.TestCase):
         self.sim = rebound.Simulation()
         self.sim.gravity = "none"
         self.sim.collision = "direct"
+        self.sim.collision_resolve = "hardsphere"
         self.sim.integrator = "leapfrog"
         self.sim.G = 0.0
         self.sim.dt = 0.01
@@ -280,6 +281,7 @@ class TestSimulationCollisions(unittest.TestCase):
     def test_tree(self):
         self.sim.configure_box(10)
         self.sim.collision = "tree"
+        self.sim.collision_resolve = "hardsphere"
         self.sim.add(m=1.,x=-1,vx=1.,r=0.5)
         self.sim.add(m=1.,x=1,vx=-1.,r=0.5)
         self.sim.integrate(1.)

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -4,7 +4,7 @@ ifndef OS
 	OS=$(shell uname)
 endif
 ifeq ($(OS), Linux)
-	OPT+= -Wall -g
+	OPT+= -Wall -g -Wno-unused-result
 	LIB+= -lm -lrt
 endif
 ifeq ($(OS), Darwin)

--- a/src/collision.c
+++ b/src/collision.c
@@ -303,7 +303,7 @@ void reb_collision_search(struct reb_simulation* const r){
 	int (*resolve) (struct reb_simulation* const r, struct reb_collision c) = r->collision_resolve;
 	if (resolve==NULL){
 		// Default is hard sphere
-		resolve = reb_collision_resolve_hardsphere;
+		resolve = reb_collision_resolve_halt;
 	}
 	for (int i=0;i<collisions_N;i++){
         
@@ -562,6 +562,12 @@ int reb_collision_resolve_hardsphere(struct reb_simulation* const r, struct reb_
     return 0;
 }
 
+int reb_collision_resolve_halt(struct reb_simulation* const r, struct reb_collision c){
+    r->status = REB_EXIT_COLLISION;
+	r->particles[c.p1].lastcollision = r->t;
+	r->particles[c.p2].lastcollision = r->t;
+    return 0; // don't remove either particle
+}
 
 int reb_collision_resolve_merge(struct reb_simulation* const r, struct reb_collision c){
 	if (r->particles[c.p1].lastcollision==r->t || r->particles[c.p2].lastcollision==r->t) return 0;

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -457,6 +457,7 @@ enum REB_STATUS {
     REB_EXIT_ESCAPE = 4,        ///< The integration ends early because a particle escaped (see exit_max_distance)  
     REB_EXIT_USER = 5,          ///< User caused exit, simulation did not finish successfully.
     REB_EXIT_SIGINT = 6,        ///< SIGINT received. Simulation stopped.
+    REB_EXIT_COLLISION = 7,     ///< The integration ends early because two particles collided. 
 };
 
 
@@ -1102,6 +1103,11 @@ struct reb_particle* reb_get_particle_by_hash(struct reb_simulation* const r, ui
  * @param r The rebound simulation to be considered
  */
 void reb_run_heartbeat(struct reb_simulation* const r);
+
+/**
+ * @brief Resolve collision by simply halting the integration and setting r->status=REB_EXIT_COLLISION (Default)
+ */
+int reb_collision_resolve_halt(struct reb_simulation* const r, struct reb_collision c);
 
 /**
  * @brief Hardsphere collision resolving routine (default).


### PR DESCRIPTION
added reb_collision_resolve_halt as default when collisions are all. Simply sets r->status = REB_EXIT_COLLISION silently and halts the integration. In Python it will raise a Collision exception. Added to the end of CloseEncounters ipynb how to use it and set up a custom python function.

This changes the default from hardsphere, so I've gone through all the C examples and the SaturnsRings ipynb and set collision_resolve to hardsphere explicitly in ones where collision_resolve was not already set. I also changed shearing_sheet_2, which defines a custom resolve function in problem.c but I think was using the default hardsphere because it wasn't setting collision_resolve.

In doing that I realized that the C examples still mostly have tabs, so I went through and changed all tabs to spaces. It's a pain in the side by side viewer...I separated it out into a separate commit so you might view the other commits individually to see the changes that actually matter.

I also added -Wno-unused-result to Makefile.defs (only on Linux), because on gcc (e.g. in the travis build) we get a lot of obnoxious warnings (for each of the C examples) on not using the return values from fread. I think checking the return value for each fread would make the code really ugly, and I would think it's fine not to add them (famous last words!) given that we control how the binaries are written and have unit tests. 
