### PR TITLE
added manual snapshot append functions

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -480,7 +480,9 @@ class Simulation(Structure):
         if interval_walltime:
             self.simulationarchive_interval_walltime = interval_walltime
 
-    
+    def simulationarchive_append(self):
+        clibrebound.reb_simulationarchive_append(byref(self))
+
     def process_messages(self):
         clibrebound.reb_get_next_message.restype = c_int
         buf = create_string_buffer(c_int.in_dll(clibrebound, "reb_max_messages_length").value)

--- a/src/simulationarchive.c
+++ b/src/simulationarchive.c
@@ -399,6 +399,11 @@ static int reb_simulationarchive_snapshotsize(struct reb_simulation* const r){
 }
 
 void reb_simulationarchive_append(struct reb_simulation* r){
+    struct timeval time_now;
+    gettimeofday(&time_now,NULL);
+    r->simulationarchive_walltime += time_now.tv_sec-r->simulationarchive_time.tv_sec+(time_now.tv_usec-r->simulationarchive_time.tv_usec)/1e6;
+    r->simulationarchive_time = time_now;
+    
     if (r->simulationarchive_version<2){
         // Old version
         FILE* of = fopen(r->simulationarchive_filename,"r+");
@@ -562,11 +567,6 @@ void reb_simulationarchive_heartbeat(struct reb_simulation* const r){
         if (r->simulationarchive_interval){
             if (r->simulationarchive_next <= r->t){
                 r->simulationarchive_next += r->simulationarchive_interval;
-                
-                struct timeval time_now;
-                gettimeofday(&time_now,NULL);
-                r->simulationarchive_walltime += time_now.tv_sec-r->simulationarchive_time.tv_sec+(time_now.tv_usec-r->simulationarchive_time.tv_usec)/1e6;
-                r->simulationarchive_time = time_now;
                 reb_simulationarchive_append(r);
             }
         }
@@ -575,8 +575,6 @@ void reb_simulationarchive_heartbeat(struct reb_simulation* const r){
             gettimeofday(&time_now,NULL);
             double delta_walltime = time_now.tv_sec-r->simulationarchive_time.tv_sec+(time_now.tv_usec-r->simulationarchive_time.tv_usec)/1e6;
             if (delta_walltime >= r->simulationarchive_interval_walltime){
-                r->simulationarchive_walltime += delta_walltime;
-                r->simulationarchive_time = time_now;
                 reb_simulationarchive_append(r);
             }
         }


### PR DESCRIPTION
I moved the time information into reb_simulationarchive_append and added a python function that lets you manually append snapshots. I think it gives the intended behaviour. Here's an example that gives extra snapshots at 10500 and 20700 as expected. 

```
import rebound
import numpy as np

sim = rebound.Simulation()
sim.add(m=1.)
sim.add(m=1e-3, a=1.)
sim.add(m=1e-8, a=2.)
sim.move_to_com()
sim.dt = sim.particles[1].P*0.05  # timestep is 5% of orbital period
sim.integrator = "whfast"

sim.initSimulationArchive("satest.bin", interval=1.e3)
sim.integrate(1.05e4)
sim.remove(2)
sim.simulationarchive_append()
sim.integrate(2.07e4)
sim.simulationarchive_append()
sim.add(m=1.e-8, a=5.)
sim.integrate(3.e4)

sa = rebound.SimulationArchive("satest.bin")
for sim in sa:
    print(sim.t, sim.dt)
```