### PR TITLE
added close function to simulationarchive

### DIFF
--- a/rebound/simulationarchive.py
+++ b/rebound/simulationarchive.py
@@ -86,6 +86,10 @@ class SimulationArchive(Structure):
         self.tmin = self.t[0]
         self.tmax = self.t[self.nblobs-1]
 
+    def __del__(self):
+        if self._b_needsfree_ == 1: 
+            clibrebound.reb_free_simulationarchive_pointers(byref(self))
+
     def __str__(self):
         """
         Returns a string with details of this simulation archive.

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -658,55 +658,6 @@ struct reb_hash_pointer_pair{
 /** @} */
 
 /**
- * @brief Opens a SimulationArchive
- * @details This function opens a SimulationArchive file and creates an index to 
- * find snapshots within the file. This may take a few seconds if there are many 
- * snapshots in the file. Note that opening a file on a slow filesystem (for example
- * via a network) might be partiucularly slow. The file is kept open until 
- * the user calls reb_close_simulationarchive.
- * @param filename The path and filename of the SimulationArchive input file.
- * @return Returns a reb_simulationarchive struct.
- */
-struct reb_simulationarchive* reb_open_simulationarchive(const char* filename);
-
-/**
- * @brief Closes a SimulationArchive
- * @details This function closes a SimulationArchive that was previously opened
- * by the reb_open_simulationarchive function. It also destroys the index created
- * and frees the allocated memory. 
- * @param sa The SimulationArchive to be closed.
- */
-void reb_close_simulationarchive(struct reb_simulationarchive* sa);
-
-/**
- * @brief Appends a SimulationArchive snapshot to a file
- * @details This function can either be called manually or via one of the convenience methods
- * reb_simulationarchive_automate_interval and reb_simulationarchive_automate_walltime.
- * If the file does not exist, the function outputs a binary file. If a file exists,
- * it appends a SimulationArchive snapshot to that file. 
- * @param r The rebound simulation to be considered.
- * @param filename The path and filename of the SimulationArchive output file.
- */
-void reb_simulationarchive_snapshot(struct reb_simulation* r, const char* filename);
-
-/**
- * @brief Automatically create a SimulationArchive Snapshot at regular intervals
- * @param r The rebound simulation to be considered.
- * @param filename The path and filename of the SimulationArchive output file.
- * @param interval The interval between snapshots (in simulation time units).
- */
-void reb_simulationarchive_automate_interval(struct reb_simulation* const r, const char* filename, double interval);
-
-/**
- * @brief Automatically create a SimulationArchive Snapshot at regular walltime intervals
- * @param r The rebound simulation to be considered.
- * @param filename The path and filename of the SimulationArchive output file.
- * @param interval The walltime interval between snapshots (in seconds).
- */
-void reb_simulationarchive_automate_walltime(struct reb_simulation* const r, const char* filename, double walltime);
-
-
-/**
  * @defgroup MainRebStructs 
  * @details These are the main REBOUND structures
  * @{
@@ -1696,6 +1647,62 @@ struct reb_particle reb_particle_divide(struct reb_particle p1, double value);
  * @brief Allocates a simulation and sets it to a specific snapshot in a SimulationArchive file.
  */
 struct reb_simulation* reb_create_simulation_from_simulationarchive(struct reb_simulationarchive* sa, long snapshot);
+
+/**
+ * @brief Opens a SimulationArchive
+ * @details This function opens a SimulationArchive file and creates an index to 
+ * find snapshots within the file. This may take a few seconds if there are many 
+ * snapshots in the file. Note that opening a file on a slow filesystem (for example
+ * via a network) might be partiucularly slow. The file is kept open until 
+ * the user calls reb_close_simulationarchive.
+ * @param filename The path and filename of the SimulationArchive input file.
+ * @return Returns a reb_simulationarchive struct.
+ */
+struct reb_simulationarchive* reb_open_simulationarchive(const char* filename);
+
+/**
+ * @brief Closes a SimulationArchive
+ * @details This function closes a SimulationArchive that was previously opened
+ * by the reb_open_simulationarchive function. It also destroys the index created
+ * and frees the allocated memory. 
+ * @param sa The SimulationArchive to be closed.
+ */
+void reb_close_simulationarchive(struct reb_simulationarchive* sa);
+
+/**
+ * @brief Frees all the pointers in a SimulationArchive structure
+ * @param sa The SimulationArchive to be closed.
+ */
+void reb_free_simulationarchive_pointers(struct reb_simulationarchive* sa);
+
+/**
+ * @brief Appends a SimulationArchive snapshot to a file
+ * @details This function can either be called manually or via one of the convenience methods
+ * reb_simulationarchive_automate_interval and reb_simulationarchive_automate_walltime.
+ * If the file does not exist, the function outputs a binary file. If a file exists,
+ * it appends a SimulationArchive snapshot to that file. 
+ * @param r The rebound simulation to be considered.
+ * @param filename The path and filename of the SimulationArchive output file.
+ */
+void reb_simulationarchive_snapshot(struct reb_simulation* r, const char* filename);
+
+/**
+ * @brief Automatically create a SimulationArchive Snapshot at regular intervals
+ * @param r The rebound simulation to be considered.
+ * @param filename The path and filename of the SimulationArchive output file.
+ * @param interval The interval between snapshots (in simulation time units).
+ */
+void reb_simulationarchive_automate_interval(struct reb_simulation* const r, const char* filename, double interval);
+
+/**
+ * @brief Automatically create a SimulationArchive Snapshot at regular walltime intervals
+ * @param r The rebound simulation to be considered.
+ * @param filename The path and filename of the SimulationArchive output file.
+ * @param interval The walltime interval between snapshots (in seconds).
+ */
+void reb_simulationarchive_automate_walltime(struct reb_simulation* const r, const char* filename, double walltime);
+
+
 
 /** @} */
 

--- a/src/simulationarchive.c
+++ b/src/simulationarchive.c
@@ -368,6 +368,11 @@ struct reb_simulationarchive* reb_open_simulationarchive(const char* filename){
 }
 
 void reb_close_simulationarchive(struct reb_simulationarchive* sa){
+    reb_free_simulationarchive_pointers(sa);
+    free(sa);
+}
+
+void reb_free_simulationarchive_pointers(struct reb_simulationarchive* sa){
     if (sa==NULL) return;
     if (sa->inf){
         fclose(sa->inf);
@@ -375,9 +380,7 @@ void reb_close_simulationarchive(struct reb_simulationarchive* sa){
     free(sa->filename);
     free(sa->t);
     free(sa->offset);
-    free(sa);
 }
-
     
 static int reb_simulationarchive_snapshotsize(struct reb_simulation* const r){
     int size_snapshot = 0;


### PR DESCRIPTION
You can get an error for having too many files open in Jupyter, so I added a __del__ function following what we do for Simulation. I also moved the sim archive functions in rebound.h into the right doxygen section (they weren't getting picked up in the docs)