### PR TITLE
Clarified a Sim Archive warning.

### DIFF
--- a/ipython_examples/SimulationArchiveRestart.ipynb
+++ b/ipython_examples/SimulationArchiveRestart.ipynb
@@ -65,7 +65,7 @@
     "collapsed": true
    },
    "source": [
-    "Depending on how fast your computer is, the above command may take a couple of seconds. Once the simulation is done, we can delete it from memeory and load it back in from the SA. You could do this at a later time. Note that this will even work if the SA file was generated on a different computer with a different operating system and even a different version of REBOUND. See Rein & Tamayo (2017) for a full discussion on how machine independent code."
+    "Depending on how fast your computer is, the above command may take a couple of seconds. Once the simulation is done, we can delete it from memeory and load it back in from the SA. You could do this at a later time. Note that this will even work if the SA file was generated on a different computer with a different operating system and even a different version of REBOUND. See Rein & Tamayo (2017) for a full discussion on machine independent code."
    ]
   },
   {
@@ -159,7 +159,7 @@
    "metadata": {},
    "source": [
     "A few things to note when restarting a simulation from a SA: \n",
-    "- If you used any additional forces or post-timestep modifications in the original simulation, then those need to be restored after loading a simulation from a SA.\n",
+    "- If you used any additional forces or post-timestep modifications in the original simulation, then those need to be restored after loading a simulation from a SA. A RuntimeWarning may be given related to this indicating the need to reset function pointers after creating a reb_simulation struct with a binary file.\n",
     "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsychronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that.\n",
     "- For reproducibility, the SimulationArchive does not output snapshots at the *exact* intervals specified, but rather at the timestep in the integration directly following each interval. This means that if you load from a SimulationArchive and want to reproduce the state in a snapshot later on, you have to pass `exact_finish_time=0` in a call to `sim.integrate`."
    ]
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I came across a warning that was unclear to me. "/Users/rein/git/rebound/rebound/simulationarchive.py:127: RuntimeWarning: You have to reset function pointers after creating a reb_simulation struct with a binary file.
  warnings.warn(message, RuntimeWarning)"
Dan clarified that it was saying I needed to make sure I added the ReboundX effects to the simulations I retrieved from the archive before running them again, so I figured I'd add a sentence into the docs in case that isn't clear to someone else.
I also fixed a grammatical error.