### PR TITLE
negative M values

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -424,7 +424,7 @@ static double mod2pi(double f){
 }
 
 double reb_tools_M_to_E(double e, double M){
-    M = mod2pi(M); // avoid numerical artefacts for negative numbers
+    //M = mod2pi(M); // avoid numerical artefacts for negative numbers
 	double E;
 	if(e < 1.){
 		E = e < 0.8 ? M : M_PI;


### PR DESCRIPTION
Fix for issue #355 

I've narrowed down the issue is with initializing particles using negative M values. This pull request gives back the right orbit. Alternatively if you use the current master and try:

```
import rebound
sim = rebound.Simulation()
sim.add(m=1)
sim.add(m=1e-3,a=-2,e=1.4, M=-0.001)
sim.particles[1].x
```

you'll get a jump when you switch M from negative to positive. 

I'm just a bit leery that fix comes from commenting out a line that itself has a comment that it's there to avoid numerical artifacts for negative numbers!! Could you take a look @hannorein ?
