### PR TITLE
added bullet to simarchiverestart.ipynb

### DIFF
--- a/ipython_examples/SimulationArchiveRestart.ipynb
+++ b/ipython_examples/SimulationArchiveRestart.ipynb
@@ -159,6 +159,7 @@
     "A few things to note when restarting a simulation from a SA: \n",
     "- If you used any additional forces or post-timestep modifications in the original simulation, then those need to be restored after loading a simulation from a SA. A RuntimeWarning may be given related to this indicating the need to reset function pointers after creating a reb_simulation struct with a binary file.\n",
     "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsychronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that.\n",
+    "- If you use the symplectic WHFast integrator with the safe mode turned off in order to combine kepler steps (see the Advanced WHFast tutorial), but want to preserve bitwise reproducibility when integrating to different times in the simulation or to match SimulationArchive snapshots, you need to manually set sim.ri_whfast.keep_unsynchronized = 1. This ensures that the integration state does not change depending on if and when you generate outputs.\n",
     "- For reproducibility, the SimulationArchive does not output snapshots at the *exact* intervals specified, but rather at the timestep in the integration directly following each interval. This means that if you load from a SimulationArchive and want to reproduce the state in a snapshot later on, you have to pass `exact_finish_time=0` in a call to `sim.integrate`."
    ]
   },
@@ -188,7 +189,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I figured if I got tripped up by this, probably others will too at some point, so I added a bullet at the bottom of the example notebook that says

If you use the symplectic WHFast integrator with the safe mode turned off in order to combine kepler steps (see the Advanced WHFast tutorial), but want to preserve bitwise reproducibility when integrating to different times in the simulation or to match SimulationArchive snapshots, you need to manually set sim.ri_whfast.keep_unsynchronized = 1. This ensures that the integration state does not change depending on if and when you generate outputs.

Please correct if I got anything wrong! For my own edification (since I obviously did not understand this as well as I thought):

When (with safe_mode=0) I load a simarchive snapshot, I get ri_whfast.is_synchronized = 0, and in a case where I integrate through a list of times with ri_whfast.keep_unsynchronized=1, I also get ri_whfast.is_synchronized = 0. But I was confused that in the simarchive snapshot case sim.status() was giving me that unsynchronized state (and I needed to call integrator_synchronize) but in the case where I integrated through a list of times, sim.status() was giving me the synchronized state. I think this makes sense because I guess in the latter case sim.integrate synchronizes before giving you output...I think I was thinking incorrectly that is_synchronized was telling me something about what I'd get if I checked the simulation state right now. But do I have it right that this is not the case and the ri_whfast.is_synchronized flag only refers to the state of the INTERNAL integrator variables, i.e. the p_j for jacobi? 