### PR TITLE
Lyap

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1534,6 +1534,7 @@ class Simulation(Structure):
             self.exact_finish_time = c_int(exact_finish_time)
             ret_value = clibrebound.reb_integrate(byref(self), c_double(tmax))
             if ret_value == 1:
+                self.process_messages()
                 raise SimulationError("An error occured during the integration.")
             if ret_value == 2:
                 raise NoParticles("No more particles left in simulation.")
@@ -1550,6 +1551,12 @@ class Simulation(Structure):
         else:
             debug.integrate_other_package(tmax,exact_finish_time)
         self.process_messages()
+
+    def integrator_reset(self):
+        """
+        Call this function to reset temporary integrator variables
+        """
+        clibrebound.reb_integrator_reset(byref(self))
 
     def integrator_synchronize(self):
         """

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1055,7 +1055,7 @@ class Simulation(Structure):
         return s
         
 # MEGNO
-    def init_megno(self):
+    def init_megno(self, seed=None):
         """
         This function initialises the chaos indicator MEGNO particles and enables their integration.
 
@@ -1070,7 +1070,10 @@ class Simulation(Structure):
 
         For more information on MENGO see e.g. http://dx.doi.org/10.1051/0004-6361:20011189
         """
-        clibrebound.reb_tools_megno_init(byref(self))
+        if seed is None:
+            clibrebound.reb_tools_megno_init(byref(self))
+        else:
+            clibrebound.reb_tools_megno_init_seed(byref(self), c_uint(seed))
     
     def calculate_megno(self):
         """

--- a/src/integrator_whfast.c
+++ b/src/integrator_whfast.c
@@ -788,9 +788,11 @@ void reb_integrator_whfast_part2(struct reb_simulation* const r){
             struct reb_particle* const particles_var1 = particles + vc.index;
             const int index = vc.index;
             // Centre of mass
+            reb_transformations_inertial_to_jacobi_posvel(ri_whfast->p_jh+index, particles_var1, particles, N_real);
             ri_whfast->p_jh[index].x += r->dt/2.*ri_whfast->p_jh[index].vx;
             ri_whfast->p_jh[index].y += r->dt/2.*ri_whfast->p_jh[index].vy;
             ri_whfast->p_jh[index].z += r->dt/2.*ri_whfast->p_jh[index].vz;
+            reb_transformations_jacobi_to_inertial_posvel(particles_var1, ri_whfast->p_jh+index, particles, N_real);
             if (r->calculate_megno){
                 reb_calculate_acceleration_var(r);
                 const double dx = particles[0].x - particles[1].x;

--- a/src/integrator_whfast.c
+++ b/src/integrator_whfast.c
@@ -788,7 +788,9 @@ void reb_integrator_whfast_part2(struct reb_simulation* const r){
             struct reb_particle* const particles_var1 = particles + vc.index;
             const int index = vc.index;
             // Centre of mass
-            reb_transformations_inertial_to_jacobi_posvel(ri_whfast->p_jh+index, particles_var1, particles, N_real);
+            if (ri_whfast->keep_unsynchronized){ // unsync reverts p_j in synchronize(), so have to transform back
+                reb_transformations_inertial_to_jacobi_posvel(ri_whfast->p_jh+index, particles_var1, particles, N_real);
+            }
             ri_whfast->p_jh[index].x += r->dt/2.*ri_whfast->p_jh[index].vx;
             ri_whfast->p_jh[index].y += r->dt/2.*ri_whfast->p_jh[index].vy;
             ri_whfast->p_jh[index].z += r->dt/2.*ri_whfast->p_jh[index].vz;

--- a/src/integrator_whfast.c
+++ b/src/integrator_whfast.c
@@ -667,7 +667,6 @@ void reb_integrator_whfast_part1(struct reb_simulation* const r){
     struct reb_particle* restrict const particles = r->particles;
     const int N = r->N;
     const int N_real = N-r->N_var;
-    
     if (reb_integrator_whfast_init(r)){
         // Non recoverable error occured.
         return;
@@ -792,7 +791,6 @@ void reb_integrator_whfast_part2(struct reb_simulation* const r){
             ri_whfast->p_jh[index].x += r->dt/2.*ri_whfast->p_jh[index].vx;
             ri_whfast->p_jh[index].y += r->dt/2.*ri_whfast->p_jh[index].vy;
             ri_whfast->p_jh[index].z += r->dt/2.*ri_whfast->p_jh[index].vz;
-            reb_transformations_jacobi_to_inertial_posvel(particles_var1, ri_whfast->p_jh+index, particles, N_real);
             if (r->calculate_megno){
                 reb_calculate_acceleration_var(r);
                 const double dx = particles[0].x - particles[1].x;

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -572,6 +572,9 @@ int reb_check_exit(struct reb_simulation* const r, const double tmax, double* la
     }
     const double dtsign = copysign(1.,r->dt);   // Used to determine integration direction
     if (r->status>=0 || reb_error_message_waiting(r)){
+        if(r->status <= 0){
+            r->status = 1;
+        }
         // Exit now.
     }else if(tmax!=INFINITY){
         if(r->exact_finish_time==1){

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -571,10 +571,10 @@ int reb_check_exit(struct reb_simulation* const r, const double tmax, double* la
         usleep(1000);
     }
     const double dtsign = copysign(1.,r->dt);   // Used to determine integration direction
-    if (r->status>=0 || reb_error_message_waiting(r)){
-        if(r->status <= 0){
-            r->status = 1;
-        }
+    if (reb_error_message_waiting(r)){
+        r->status = REB_EXIT_ERROR;
+    }
+    if (r->status>=0){
         // Exit now.
     }else if(tmax!=INFINITY){
         if(r->exact_finish_time==1){

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1883,6 +1883,13 @@ int reb_add_var_2nd_order(struct reb_simulation* const r, int testparticle, int 
  */
 void reb_tools_megno_init(struct reb_simulation* const r);
 
+/** 
+ * @brief Init the MEGNO particles, enable MEGNO calculation, and specify a seed for the random number generation.
+ * @param r The rebound simulation to be considered
+ * @param seed The seed to use for the random number generator
+ */
+void reb_tools_megno_init_seed(struct reb_simulation* const r, unsigned int seed);
+
 /**
  * @brief Get the current MEGNO value
  * @param r The rebound simulation to be considered

--- a/src/tools.c
+++ b/src/tools.c
@@ -937,6 +937,11 @@ int reb_add_var_2nd_order(struct reb_simulation* const r, int testparticle, int 
     return index;
 }
 
+void reb_tools_megno_init_seed(struct reb_simulation* const r, unsigned int seed){
+    srand(seed);
+    reb_tools_megno_init(r);
+}
+
 void reb_tools_megno_init(struct reb_simulation* const r){
 	r->megno_Ys = 0.;
 	r->megno_Yss = 0.;


### PR DESCRIPTION
Couldn't figure out why the lyapunov times in the stability project integrations weren't making sense. After chasing down the wrong things for a while I now understand the MEGNO much better :) It turned out it was a bug with calculating the megno with WHFast with keep_unsynchronized = 1. synchronize() caches the p_j and at the end resets the p_j back, but at the end of part2, the variational particle calculation uses the p_j, which have been reset to mid-timestep values. I think the new line fixes the problem, but I also wondered whether it would make sense to have a dedicated p_j_cache array in the simulation structure so that we don't malloc and free one every timestep. In that case the new line I added wouldn't be necessary.

I also added a couple things I ran into while debugging:

- I would find it useful to be able to get exactly the same megno/lyapunov times every time for the stability stuff, so I added a seed option to megno_init(). If you don't like it you can just remove the last commit.

- I made integrator_reset() callable from Python

- This is more general...some errors can make the code hang. For example, 

```
sim = rebound.Simulation()
sim.integrator = "whfast"
sim.ri_whfast.coordinates="whds"
sim.add(m=1.)
sim.add(m=1.e-3, a=1.5, e=0.1, inc=0.1)
sim.init_megno()
sim.integrate(2)
```

In whfast_init it will reb_error because you can only use variational particles with jacobi coordinates. Then in integrate's reb_check_exit(), this condition passes ```if (r->status>=0 || reb_error_message_waiting(r))```, the function returns without updating the status, so whfast_part_1 gets called again, which does nothing because it reb_errors, and just loops forever. 

It seems to me like the different error statuses were from the time we needed them before you set up the error logging system. Maybe this is a naive solution, but I thought that one could raise reb_errors anywhere in the code and then have reb_check_exit catch them in the above condition and change the status to 1, and rather than have python translate the reb_status, it could just process messages. I'm probably missing all sorts of edge cases!