### PR TITLE
Newlyap

### DIFF
--- a/rebound/tests/test_megno.py
+++ b/rebound/tests/test_megno.py
@@ -13,7 +13,8 @@ class TestMegno(unittest.TestCase):
         self.sim.integrator = "ias15"
         self.sim.add(m=1)
         self.sim.add(m=1e-3,a=1.5,e=0.1,inc=0.1)
-        self.sim.init_megno()
+        self.sim.add(m=1.e-3, a=15., e=0.1, inc=0.1)
+        self.sim.init_megno(seed=0)
         self.sim.integrate(1000)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
@@ -22,12 +23,25 @@ class TestMegno(unittest.TestCase):
         self.sim.integrator = "whfast"
         self.sim.add(m=1)
         self.sim.add(m=1e-3,a=1.5,e=0.1,inc=0.1)
-        self.sim.init_megno()
+        self.sim.add(m=1.e-3, a=15., e=0.1, inc=0.1)
+        self.sim.init_megno(seed=0)
         self.sim.integrate(1000)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
 
-
-    
+    def test_whfast_close_regular(self):
+        self.sim = rebound.Simulation()
+        self.sim.integrator = "whfast"
+        self.sim.G = 4*math.pi**2
+        self.sim.add(m=1.0, x=-4.7298443749900997e-07, y=2.3452237398515157e-06, z=-2.8779986923394045e-08, vx=-9.994358883493113e-06, vy=-2.8416720717989476e-06, vz=1.5927607755978474e-07)
+        self.sim.add(m=4.544728982917554e-07, x=0.9818659845399763, y=0.19089291910956852, z=-0.011300485084842085, vx=-1.1951384526938573, vy=6.164295939653557, vz=0.16345519841419276)
+        self.sim.add(m=1.7367161546229798e-06, x=-0.07616371745657412, y=-1.2648949778387153, z=0.01873838700271951, vx=5.516651885197617, vy=-0.34889260830083374, vz=-0.13577609379397024)
+        self.sim.add(m=2.1454312223049496e-07, x=0.741238938912468, y=-1.0963570106709737, z=0.006397276680495443, vx=4.459049824337919, vy=3.011488098634852, vz=0.010452444973871466)
+        self.sim.init_megno(seed=0)
+        self.sim.dt = 0.034641008279678746
+        self.sim.integrate(1000)
+        self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
+        self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
+         
 if __name__ == "__main__":
     unittest.main()

--- a/rebound/tests/test_megno.py
+++ b/rebound/tests/test_megno.py
@@ -42,6 +42,27 @@ class TestMegno(unittest.TestCase):
         self.sim.integrate(1000)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
-         
+
+    def test_chaotic(self):
+        self.sim = rebound.Simulation()
+        self.sim.integrator = "ias15"
+        self.sim.add(m=1.)
+        self.sim.add(m=1.e-4, P=1.)
+        self.sim.add(m=1.e-4, P=1.17)
+        self.sim.init_megno(seed=0)
+        self.sim.move_to_com()
+        self.sim.integrate(1000)
+        self.megnoIAS = self.sim.calculate_megno()
+        self.sim = rebound.Simulation()
+        self.sim.integrator = "whfast"
+        self.sim.add(m=1.)
+        self.sim.add(m=1.e-4, P=1.)
+        self.sim.add(m=1.e-4, P=1.17)
+        self.sim.init_megno(seed=0)
+        self.sim.move_to_com()
+        self.sim.integrate(1000)
+        self.megnoWHFast = self.sim.calculate_megno()
+        self.assertAlmostEqual(abs((self.megnoIAS-self.megnoWHFast)/self.megnoIAS), 0., delta=0.2)
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/integrator_whfast.c
+++ b/src/integrator_whfast.c
@@ -779,18 +779,25 @@ void reb_integrator_whfast_part2(struct reb_simulation* const r){
     
     if (r->var_config_N){
         // Need to have x,v,a synchronized to calculate ddot/d for MEGNO. 
-        reb_integrator_whfast_synchronize(r);
-        // Add additional acceleration term for MEGNO calculation
         const int N_real = r->N-r->N_var;
+        struct reb_particle* sync_pj  = NULL;
+        if (ri_whfast->keep_unsynchronized){ // cache the p_j and set back at the end
+            sync_pj = malloc(sizeof(struct reb_particle)*r->N);
+            memcpy(sync_pj,r->ri_whfast.p_jh,r->N*sizeof(struct reb_particle));
+            ri_whfast->keep_unsynchronized=0; // synchronize will revert the p_j to midstep if keep_unsync=0. 
+            reb_integrator_whfast_synchronize(r);
+            ri_whfast->keep_unsynchronized=1; // Manually avoid synchronize reverting the p_j and do it ourselves when we're done
+        }
+        else{
+            reb_integrator_whfast_synchronize(r);
+        }
+        // Add additional acceleration term for MEGNO calculation
         struct reb_particle* restrict const particles = r->particles;
         for (int v=0;v<r->var_config_N;v++){
             struct reb_variational_configuration const vc = r->var_config[v];
             struct reb_particle* const particles_var1 = particles + vc.index;
             const int index = vc.index;
             // Centre of mass
-            if (ri_whfast->keep_unsynchronized){ // unsync reverts p_j in synchronize(), so have to transform back
-                reb_transformations_inertial_to_jacobi_posvel(ri_whfast->p_jh+index, particles_var1, particles, N_real);
-            }
             ri_whfast->p_jh[index].x += r->dt/2.*ri_whfast->p_jh[index].vx;
             ri_whfast->p_jh[index].y += r->dt/2.*ri_whfast->p_jh[index].vy;
             ri_whfast->p_jh[index].z += r->dt/2.*ri_whfast->p_jh[index].vz;
@@ -835,6 +842,11 @@ void reb_integrator_whfast_part2(struct reb_simulation* const r){
         if (r->calculate_megno){
             double dY = r->dt * 2. * r->t * reb_tools_megno_deltad_delta(r);
             reb_tools_megno_update(r, dY);
+        }
+        if (ri_whfast->keep_unsynchronized){
+            memcpy(r->ri_whfast.p_jh,sync_pj,r->N*sizeof(struct reb_particle));
+            free(sync_pj);
+            ri_whfast->is_synchronized=0;
         }
     }
 }


### PR DESCRIPTION
So I fooled myself into thinking the previous patch worked because the tests were all for a single planet. Looking at it for several planets, the patch didn't make sense. What we need when unsynchronized is to actually synchronize the p_j, so we have to do what synchronize() does, then update the megno, and only revert back at the end of that. This is a hacky way to do that, but it works. Probably the better one would be to have a separate unsynced_p_j array in the simulation structure that is always what gets used when restarting the integration, and the others are just for output. But I haven't got into the details of that, so I'm probably missing all sorts of complications in the logic that that might cause. I think this is a reasonable patch that only does extra work when keep_unsynchronized=1. 

I also updated test_megno.py to have multiple planets and have both closely packed regular cases and chaotic ones. Sorry for the mixup!