### PR TITLE
added -N_var to collision.c and edited col unit tests

### DIFF
--- a/rebound/tests/test_collisions.py
+++ b/rebound/tests/test_collisions.py
@@ -13,6 +13,8 @@ class TestLineCollisions(unittest.TestCase):
         sim.dt = 10
         sim.add(r=1,x=0)
         sim.add(r=1,x=3,vx=-1)
+        sim.init_megno()
+        sim.particles[-1].x = np.nan # test that collisions with variational particles not being checked
         sim.integrate(10)
     def test_line_find(self):
         # Should find the collision
@@ -22,6 +24,8 @@ class TestLineCollisions(unittest.TestCase):
         sim.dt = 10
         sim.add(r=1,x=0)
         sim.add(r=1,x=3,vx=-1)
+        sim.init_megno()
+        sim.particles[-1].x = np.nan
         with self.assertRaises(rebound.Collision) as context:
             sim.integrate(10)
     def test_line_miss_overlap(self):
@@ -32,6 +36,8 @@ class TestLineCollisions(unittest.TestCase):
         sim.dt = 10
         sim.add(r=1,x=0)
         sim.add(r=1,x=1,vx=-1)
+        sim.init_megno()
+        sim.particles[-1].x = np.nan
         sim.integrate(10)
     def test_line_find_overlap(self):
         # Should find the collision because not overlapping at t=0, only at end
@@ -41,6 +47,8 @@ class TestLineCollisions(unittest.TestCase):
         sim.dt = 10
         sim.add(r=1,x=0)
         sim.add(r=1,x=11,vx=-1)
+        sim.init_megno()
+        sim.particles[-1].x = np.nan
         with self.assertRaises(rebound.Collision) as context:
             sim.integrate(10)
 
@@ -133,7 +141,6 @@ class TestCollisions(unittest.TestCase):
         sim.integrate(sim.dt)
         sim.integrate(2.*sim.dt)
         self.assertLess(sim.N,25)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/collision.c
+++ b/src/collision.c
@@ -48,8 +48,8 @@
 static void reb_tree_get_nearest_neighbour_in_cell(struct reb_simulation* const r, int* collisions_N, struct reb_ghostbox gb, struct reb_ghostbox gbunmod, int ri, double p1_r,  double* nearest_r2, struct reb_collision* collision_nearest, struct reb_treecell* c);
 
 void reb_collision_search(struct reb_simulation* const r){
-	int N = r->N;
-	int Ninner = r->N;
+	int N = r->N - r->N_var;
+	int Ninner = N;
     int* mercurius_map = NULL;
     if (r->integrator==REB_INTEGRATOR_MERCURIUS){
         if (r->ri_mercurius.mode==0){
@@ -223,7 +223,7 @@ void reb_collision_search(struct reb_simulation* const r){
 			int nghostycol = (r->nghosty>1?1:r->nghosty);
 			int nghostzcol = (r->nghostz>1?1:r->nghostz);
 			const struct reb_particle* const particles = r->particles;
-			const int N = r->N;
+			const int N = r->N - r->N_var;
 			// Loop over all particles
 #pragma omp parallel for schedule(guided)
 			for (int i=0;i<N;i++){
@@ -292,7 +292,7 @@ void reb_collision_search(struct reb_simulation* const r){
             // Remove particles
             if (outcome & 1){
                 // Remove p1
-                if (c.p2==r->N-1 && !(r->tree_root)){
+                if (c.p2==r->N-r->N_var-1 && !(r->tree_root)){
                     // Particles swapped
                     c.p2 = c.p1;
                 }
@@ -305,10 +305,10 @@ void reb_collision_search(struct reb_simulation* const r){
                         r->collisions[j].p2 = -1;
                         // Will be skipped.
                     }
-                    if (cp.p1==r->N){
+                    if (cp.p1==r->N-r->N_var){
                         r->collisions[j].p1 = c.p1;
                     }
-                    if (cp.p2==r->N){
+                    if (cp.p2==r->N-r->N_var){
                         r->collisions[j].p2 = c.p1;
                     }
                 }
@@ -324,10 +324,10 @@ void reb_collision_search(struct reb_simulation* const r){
                         r->collisions[j].p2 = -1;
                         // Will be skipped.
                     }
-                    if (cp.p1==r->N){
+                    if (cp.p1==r->N-r->N_var){
                         r->collisions[j].p1 = c.p2;
                     }
-                    if (cp.p2==r->N){
+                    if (cp.p2==r->N-r->N_var){
                         r->collisions[j].p2 = c.p2;
                     }
                 }
@@ -594,7 +594,7 @@ int reb_collision_resolve_merge(struct reb_simulation* const r, struct reb_colli
 
             Ei += 0.5*pj->m*(vx*vx + vy*vy + vz*vz);
         }
-        const int N_active = ((r->N_active==-1)?r->N:r->N_active);
+        const int N_active = ((r->N_active==-1)?r->N-r->N_var:r->N_active);
         // No potential energy between test particles
         if (i<N_active || j<N_active){
             double x = pi->x - pj->x;


### PR DESCRIPTION
If you use variational particles and any values become nan (some of the chaotic stability integrations run long enough for this to happen), sim.collision="direct" will 'detect' collisions between particles and variational particles. 

I added this to the collision unit tests, and implemented what I think is a straightforward fix replacing all r->N with r->N-r->N_var. It passes travis, but could you please look at it quickly to make sure I'm not missing something important with mercurius of with gravity=tree that we're not testing?