### PR TITLE
made keep_unsync incompatible with safe_mode

### DIFF
--- a/rebound/tests/test_megno.py
+++ b/rebound/tests/test_megno.py
@@ -15,7 +15,7 @@ class TestMegno(unittest.TestCase):
         self.sim.add(m=1e-3,a=1.5,e=0.1,inc=0.1)
         self.sim.add(m=1.e-3, a=15., e=0.1, inc=0.1)
         self.sim.init_megno(seed=0)
-        self.sim.integrate(1000)
+        self.sim.integrate(10000.)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
 
@@ -25,7 +25,8 @@ class TestMegno(unittest.TestCase):
         self.sim.add(m=1e-3,a=1.5,e=0.1,inc=0.1)
         self.sim.add(m=1.e-3, a=15., e=0.1, inc=0.1)
         self.sim.init_megno(seed=0)
-        self.sim.integrate(1000)
+        self.sim.dt = self.sim.particles[1].P*0.07
+        self.sim.integrate(10000.)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
 
@@ -39,7 +40,7 @@ class TestMegno(unittest.TestCase):
         self.sim.add(m=2.1454312223049496e-07, x=0.741238938912468, y=-1.0963570106709737, z=0.006397276680495443, vx=4.459049824337919, vy=3.011488098634852, vz=0.010452444973871466)
         self.sim.init_megno(seed=0)
         self.sim.dt = 0.034641008279678746
-        self.sim.integrate(1000)
+        self.sim.integrate(10000.)
         self.assertAlmostEqual(self.sim.calculate_megno(),2.,delta=2e-1)
         self.assertAlmostEqual(self.sim.calculate_lyapunov(),0.,delta=1e-3)
 
@@ -51,7 +52,7 @@ class TestMegno(unittest.TestCase):
         self.sim.add(m=1.e-4, P=1.17)
         self.sim.init_megno(seed=0)
         self.sim.move_to_com()
-        self.sim.integrate(1000)
+        self.sim.integrate(1000.)
         self.megnoIAS = self.sim.calculate_megno()
         self.sim = rebound.Simulation()
         self.sim.integrator = "whfast"

--- a/src/integrator_whfast.c
+++ b/src/integrator_whfast.c
@@ -588,6 +588,9 @@ int reb_integrator_whfast_init(struct reb_simulation* const r){
         reb_error(r, "Symplectic correctors are only compatible with Jacobi coordinates.");
         return 1; // Error
     }
+    if (ri_whfast->keep_unsynchronized==1 && ri_whfast->safe_mode==1){
+        reb_error(r, "ri_whfast->keep_unsynchronized == 1 is not compatible with safe_mode. Must set ri_whfast->safe_mode = 0.");
+    }
     const int N = r->N;
     if (ri_whfast->coordinates==REB_WHFAST_COORDINATES_JACOBI){
         r->gravity_ignore_terms = 1;


### PR DESCRIPTION
Found another edge case...I don't think keep_unsynchronized should be compatible with safe_mode. There's a bug in the current version where safe_mode overwrites the p_jh when keep_unysynchronized=1 because it keeps seeing that is_synchronized==0. 

That could be fixed, but I think the better solution is to say you can't have both since they do opposite things. safe_mode wants to synchronize every timestep, keep_unsynchronized wants to avoid that. I thought that a better option than silently setting safe_mode to 0 when you set keep_unsynchronized=1 is to raise an error explicitly telling you you need to set safe_mode = 0 if you want to use the keep_unsynchronized flag, but maybe there's a better way. 

I also found out the hard way that the C rand() function is not machine independent (makes sense), which makes my earlier patch of being able to pass megno_init a seed less useful. Given how much effort we've put into reproducibility, would it make sense to try to fix this? I thought that one option might be to use the hash function we already have in there. Though I guess some of the randomization in REBOUND does want good RNG properties? Maybe not worth the effort? In any case, I had to increase the length of the megno test integrations, because for some RNG draws, the previous lengths didn't make it through the early transients to reach a values of 2.