### PR TITLE
added Nsteps option to sim.step

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1498,12 +1498,19 @@ class Simulation(Structure):
         clibrebound.reb_output_binary(byref(self), c_char_p(filename.encode("ascii")))
 
 # Integration
-    def step(self):
+    def step(self, Nsteps=None):
         """
-        Perform exactly one integration step with REBOUND. This function is rarely needed.
+        Perform discrete integration steps with REBOUND. By default, executes a single step.
+        If Nsteps is passed, it will integrate to that TOTAL number of Nsteps.
+        Follows the same convention as integrate, e.g., if 3 steps have already been done
+        and you call sim.step(5), it will integrate until the total number of steps is 5
+        (not for 5 additional steps to 8). This function is rarely needed.
         Instead, use integrate().
         """
-        clibrebound.reb_step(byref(self))
+        if Nsteps is None:
+            clibrebound.reb_step(byref(self))
+        else:
+            clibrebound.reb_steps(byref(self), c_int(Nsteps))
         self.process_messages()
 
     def integrate(self, tmax, exact_finish_time=1):

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -161,6 +161,12 @@ void reb_step(struct reb_simulation* const r){
     r->steps_done++; // This also counts failed IAS15 steps
 }
 
+void reb_steps(struct reb_simulation* const r, const int Nsteps){
+    while (r->steps_done < Nsteps){
+        reb_step(r);
+    }
+}
+
 void reb_exit(const char* const msg){
     // This function should also kill all children. 
     // Not implemented as pid is not easy to get to.

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -984,12 +984,21 @@ struct reb_simulation* reb_copy_simulation(struct reb_simulation* r);
 void reb_init_simulation(struct reb_simulation* r);
 
 /**
- * @brief Performon one integration step
+ * @brief Perform one integration step
  * @details You rarely want to call this function yourself.
  * Use reb_integrate instead.
  * @param r The rebound simulation to be integrated by one step.
  */
 void reb_step(struct reb_simulation* const r);
+
+/**
+ * @brief Perform many integration steps
+ * @details Follows same convention as reb_integrate: Integrate from the current state until the TOTAL number of steps reaches Nsteps. You rarely want to call this function yourself.
+ * Use reb_integrate instead.
+ * @param r The rebound simulation to be stepped.
+ * @param Nsteps The final number of steps to integrate to
+ */
+void reb_steps(struct reb_simulation* const r, const int Nsteps);
 
 /**
  * @brief Performs the actual integration


### PR DESCRIPTION
I want to get the times exactly right on a logarithmically spaced list of times. I think this is a useful option for these specialized cases...just lets you pass an integer number of steps to sim.step(). It follows the same convention as integrate in that Nsteps is the final number of steps you want to finish on (not how many steps to do). It reuses sim.steps_done to do that, so unless I'm missing logic where steps_done would not be correct, I think this should always work. I can now do things in a nice syntax like

```
times = np.logspace(0, np.log10(tmax), Nout)
Nsteps = np.int64(np.round(times/simWH.dt))
times = Nsteps*simWH.dt # corrected times

xWH, x = np.zeros(Nout), np.zeros(Nout)
for i, time in enumerate(times):
    sim.integrate(time)
    x[i] = sim.particles[1].x

for i, Nstep in enumerate(Nsteps):
    simWH.step(Nstep)
    xWH[i] = simWH.particles[1].x
```