### PR TITLE
reb_error instead of reb_exit

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -511,6 +511,7 @@ class Simulation(Structure):
 
         """
         clibrebound.reb_simulationarchive_snapshot(byref(self), c_char_p(filename.encode("ascii")))
+        self.process_messages()
 
     @property
     def simulationarchive_filename(self):

--- a/src/output.c
+++ b/src/output.c
@@ -186,7 +186,8 @@ void reb_output_ascii(struct reb_simulation* r, char* filename){
     FILE* of = fopen(filename,"a"); 
 #endif // MPI
     if (of==NULL){
-        reb_exit("Can not open file.");
+        reb_error(r, "Can not open file.");
+        return;
     }
     for (int i=0;i<N;i++){
         struct reb_particle p = r->particles[i];
@@ -205,7 +206,8 @@ void reb_output_orbits(struct reb_simulation* r, char* filename){
     FILE* of = fopen(filename,"a"); 
 #endif // MPI
     if (of==NULL){
-        reb_exit("Can not open file.");
+        reb_error(r, "Can not open file.");
+        return;
     }
     struct reb_particle com = r->particles[0];
     for (int i=1;i<N;i++){
@@ -432,7 +434,8 @@ void reb_output_binary(struct reb_simulation* r, const char* filename){
     FILE* of = fopen(filename,"wb"); 
 #endif // MPI
     if (of==NULL){
-        reb_exit("Can not open file.");
+        reb_error(r, "Can not open file.");
+        return;
     }
     char* bufp;
     size_t sizep;
@@ -452,7 +455,8 @@ void reb_output_binary_positions(struct reb_simulation* r, const char* filename)
     FILE* of = fopen(filename,"wb"); 
 #endif // MPI
     if (of==NULL){
-        reb_exit("Can not open file.");
+        reb_error(r, "Can not open file.");
+        return;
     }
     for (int i=0;i<N;i++){
         struct reb_vec3d v;
@@ -505,7 +509,8 @@ void reb_output_velocity_dispersion(struct reb_simulation* r, char* filename){
     Q_tot.z = sqrt(Q_tot.z/(double)N_tot);
     FILE* of = fopen(filename,"a"); 
     if (of==NULL){
-        reb_exit("Can not open file.");
+        reb_error(r, "Can not open file.");
+        return;
     }
     fprintf(of,"%e\t%e\t%e\t%e\t%e\t%e\t%e\n",r->t,A_tot.x,A_tot.y,A_tot.z,Q_tot.x,Q_tot.y,Q_tot.z);
     fclose(of);


### PR DESCRIPTION
```
sim = rebound.Simulation()
sim.simulationarchive_snapshot('path_doesnt_exist/file.bin')

```
would crash from python. Changed reb_exits to reb_errors in output.c. Also changed functions that might not get called from Python (not sure), but I didn't see a downside. 