### PR TITLE
Create a .gitattributes file to fix language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+examples/* linguist-documentation
+ipython_examples/* linguist-documentation
+python_examples/* linguist-documentation
+doc/* linguist-documentation


### PR DESCRIPTION
GitHub uses this file to decide which files to use and ignore when computing the language stats and this should correct for the fact that rebound is definitely not a `Jupyter Notebook` project. Feel free to ignore!