### PR TITLE
fix compile errors with MPI=1

### DIFF
--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -14,10 +14,10 @@ ifeq ($(OS), Darwin)
 endif
 
 ifeq ($(MPI), 1)
-	CC?=mpicc
+	CC=mpicc
 	PREDEF+= -DMPI
 else
-	CC?=cc
+	CC=cc
 endif
 
 ifeq ($(FFTW), 1)

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -14,10 +14,14 @@ ifeq ($(OS), Darwin)
 endif
 
 ifeq ($(MPI), 1)
-	CC=mpicc
+	ifeq ($(origin CC),default)
+		CC:=mpicc
+	else
+		CC?=mpicc
+	endif
 	PREDEF+= -DMPI
 else
-	CC=cc
+	CC?=cc
 endif
 
 ifeq ($(FFTW), 1)

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -732,11 +732,11 @@ static void* reb_integrate_raw(void* args){
     reb_sigint = 0;
     signal(SIGINT, reb_sigint_handler);
     struct reb_thread_info* thread_info = (struct reb_thread_info*)args;
+	struct reb_simulation* const r = thread_info->r;
 #ifdef MPI
     // Distribute particles
     reb_communication_mpi_distribute_particles(r);
 #endif // MPI
-    struct reb_simulation* const r = thread_info->r;
 
     double last_full_dt = r->dt; // need to store r->dt in case timestep gets artificially shrunk to meet exact_finish_time=1
     r->dt_last_done = 0.; // Reset in case first timestep attempt will fail


### PR DESCRIPTION
Compiling the **simplest** example code with MPI=1 didn't work for me. 

Here are two changes that fixed the issue for me:

The first change in Makefile.dev was necessary because in the examples/simplest/Makefile the variable **CC** was still set to **cc** instead of **mpicc** which caused an **mpi.h** not found error.

The second change is probably just some typo like error.

Let me know if this makes sense and if you have any comments

Cheers,
Thomas



For reference:
My system is Ubuntu 18.04  with the default openmpi packages installed via apt (libopenmpi-dev 2.1.1 and openmpi-bin 2.1.1).