### PR TITLE
make REB_GRAVITY_NONE reset accelerations

### DIFF
--- a/src/gravity.c
+++ b/src/gravity.c
@@ -69,6 +69,11 @@ void reb_calculate_acceleration(struct reb_simulation* r){
     const int _testparticle_type   = r->testparticle_type;
     switch (r->gravity){
         case REB_GRAVITY_NONE: // Do nothing.
+        for (int j=0; j<N; j++){
+            particles[j].ax = 0;  
+            particles[j].ay = 0;  
+            particles[j].az = 0;  
+        }  
         break;
         case REB_GRAVITY_JACOBI:
         {


### PR DESCRIPTION
I *think* this is the right place to put this. REBOUNDx doesn't know when update_acceleration is being called (for a whole timestep, at a subtimestep), so I think REBOUND should be responsible for resetting the accelerations each timestep like it does in the other gravity routines, even in the case where it's set to NONE. I had this issue when making custom splitting schemes for the REBOUNDx paper where I added an operator post timestep to reset the accelerations, but this seems cleaner to me.