### PR TITLE
Inconsistent archive behavior when deletefile=True

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -629,6 +629,11 @@ class Simulation(Structure):
             raise AttributeError("Need to specify either interval, walltime, or step")
         if deletefile and os.path.isfile(filename):
             os.remove(filename)
+            
+            # reset intervals so that automate functions C set sim->next consistently
+            self.simulationarchive_auto_interval=0
+            self.simulationarchive_auto_walltime=0
+            self.simulationarchive_auto_step=0
         if interval:
             clibrebound.reb_simulationarchive_automate_interval(byref(self), c_char_p(filename.encode("ascii")), c_double(interval))
         if walltime:


### PR DESCRIPTION
I noticed when using the SPOCK Nbody class (which always overwrites archives with deleteFile=True) that when you do overwrite an existing archive, you no longer save the initial snapshot like you normally do when writing a new one. It seems useful to always save the initial condition and to have consistent behavior when a file does and does not exist.

I now reset all the auto intervals when deleting the file, which causes the C automate functions to update r->next the same way regardless of whether or not the file already exists. 

I don't see any side effects and I've checked this passes all tests on Travis, but I might be missing something!