### PR TITLE
UniquelyIdentifyingParticlesWithHashes.ipynb cleanup

### DIFF
--- a/ipython_examples/UniquelyIdentifyingParticlesWithHashes.ipynb
+++ b/ipython_examples/UniquelyIdentifyingParticlesWithHashes.ipynb
@@ -8,19 +8,17 @@
     "\n",
     "In many cases, one can just identify particles by their position in the particle array, e.g. using ``sim.particles[5]``. However, in cases where particles might get reordered in the particle array finding a particle might be difficult. This is why we added a *hash* attribute to particles.\n",
     "\n",
-    "In REBOUND particles might get rearranged when a tree code is used for the gravity or collision routine, when particles merge, when a particle leaves the simulation box, or when you manually remove or add particles. In general, therefore, the user should not assume that particles stay at the same index or in the same location in memory.  The reliable way to access particles is to assign them hashes and to access particles through them. \n",
+    "In REBOUND particles might get rearranged when a tree code is used for the gravity or collision routine, when particles merge, when a particle leaves the simulation box, or when you manually remove or add particles. In general, therefore, the user should not assume that particles stay at the same index or in the same location in memory.  The reliable way to access particles is to assign them hashes and to access particles through them. Assigning hashes make ``sim.particles`` to behave like Python's `dict` while keeping list-like integer-based indexing at the same time.\n",
     "\n",
-    "**Note**: When you don't assign particles a hash, they automatically get set to 0.  The user is responsible for making sure hashes are unique, so if you set up particles without a hash and later set a particle's hash to 0, you don't know which one you'll get back when you access hash 0.  See Possible Pitfalls below.\n",
+    "**Note**: When you don't assign particles a hash, they automatically get set to 0.  The user is responsible for making sure hashes are unique, so if you set up particles without a hash and later set a particle's hash to 0, you don't know which one you'll get back when you access hash 0.  See [Possible Pitfalls](#Possible-Pitfalls) below.\n",
     "\n",
-    "In this example, we show the basic usage of the *hash* attribute, which is an unsigned integer."
+    "In this example, we show the basic usage of the *hash* attribute."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import rebound\n",
@@ -28,7 +26,8 @@
     "sim.add(m=1., hash=999)\n",
     "sim.add(a=0.4, hash=\"mercury\")\n",
     "sim.add(a=1., hash=\"earth\")\n",
-    "sim.add(a=5., hash=\"jupiter\")"
+    "sim.add(a=5., hash=\"jupiter\")\n",
+    "sim.add(a=7.)"
    ]
   },
   {
@@ -41,9 +40,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -70,9 +67,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -99,14 +94,12 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<rebound.Particle object, m=0.0 x=5.0 y=0.0 z=0.0 vx=0.0 vy=0.4472135954999579 vz=0.0>"
+       "<rebound.Particle object, m=0.0 x=7.0 y=0.0 z=0.0 vx=0.0 vy=0.3779644730092272 vz=0.0>"
       ]
      },
      "execution_count": 4,
@@ -122,27 +115,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Details**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also access particles through their hash directly.  However, to differentiate from passing an integer index, we have to first cast the hash to the underlying C datatype.  We can do this through the rebound.hash function:"
+    "We can also set hash after particle is added."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<rebound.Particle object, m=1.0 x=0.0 y=0.0 z=0.0 vx=0.0 vy=0.0 vz=0.0>"
+       "<rebound.Particle object, m=0.0 x=7.0 y=0.0 z=0.0 vx=0.0 vy=0.3779644730092272 vz=0.0>"
       ]
      },
      "execution_count": 5,
@@ -151,25 +135,28 @@
     }
    ],
    "source": [
-    "from rebound import hash as h\n",
-    "sim.particles[h(999)]"
+    "sim.particles[-1].hash = 'pluto'\n",
+    "sim.particles['pluto']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "which corresponds to `particles[0]` as it should.  `sim.particles[999]` would try to access index 999, which doesn't exist in the simulation, and REBOUND would raise an AttributeError.\n",
-    "\n",
-    "When we above set the hash to a string, REBOUND converted this to an unsigned integer using the same `rebound.hash` function:"
+    "### Details"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We usually use strings as hashes, however, under the hood hash is an unsigned integer (`c_uint`). There is a function `rebound.hash` that calculates actual hash of a string."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -183,20 +170,26 @@
     }
    ],
    "source": [
+    "from rebound import hash as h\n",
     "h(\"earth\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same function can be applied to integers. In this case it just casts the value to the underlying C datatype (`c_uint`)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "c_uint(1424801690)"
+       "c_uint(999)"
       ]
      },
      "execution_count": 7,
@@ -205,7 +198,112 @@
     }
    ],
    "source": [
-    "sim.particles[2].hash"
+    "h(999)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "c_uint(4294967294)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "h(-2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we above set the hash to some value, REBOUND converted this value to an unsigned integer using the same `rebound.hash` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "c_uint(999)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.particles[0].hash # particle was created with sim.add(m=1., hash=999)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "c_uint(1424801690)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.particles[2].hash \n",
+    "# particle was created with sim.add(a=1., hash=\"earth\")\n",
+    "# so the hash is the same as h(\"earth\") above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When we use string as an index to access particle, function `rebound.hash` is applied to the index and a particle with this hash is returned. On the other hand, if we use integer index, it is not treated as a hash, REBOUND just returns a particle with given position in array, i.e. `sim.particles[0]` is the first particle, etc.\n",
+    "\n",
+    "We can access particles through their hash directly. However, to differentiate from passing an integer index, we have to first cast the hash to the underlying C datatype by using `rebound.hash` manually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<rebound.Particle object, m=1.0 x=0.0 y=0.0 z=0.0 vx=0.0 vy=0.0 vz=0.0>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sim.particles[h(999)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "which corresponds to `particles[0]` as it should.  `sim.particles[999]` would try to access index 999, which doesn't exist in the simulation, and REBOUND would raise an AttributeError."
    ]
   },
   {
@@ -219,10 +317,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 12,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -230,7 +326,7 @@
        "<rebound.Particle object, m=0.0 x=1.0 y=0.0 z=0.0 vx=0.0 vy=1.0 vz=0.0>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,10 +344,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [],
    "source": [
     "for i in range(1,100):\n",
@@ -260,18 +354,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 14,
+   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "96.0"
+       "95.0"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,10 +374,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 15,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -293,7 +383,7 @@
        "98.99999999999999"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -306,17 +396,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Possible Pitfalls**",
-    "\n",
+    "### Possible Pitfalls\n",
     "The user is responsible for making sure the hashes are unique.  If two particles share the same hash, you could get either one when you access them using their hash (in most cases the first hit in the `particles` array).  Two random strings used for hashes have a $\\sim 10^{-9}$ chance of clashing.  The most common case is setting a hash to 0:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 16,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -324,7 +411,7 @@
        "<rebound.Particle object, m=0.0 x=5.0 y=0.0 z=0.0 vx=0.0 vy=0.4472135954999579 vz=0.0>"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -346,10 +433,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 17,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -357,7 +442,7 @@
        "<rebound.Particle object, m=1.0 x=0.0 y=0.0 z=0.0 vx=0.0 vy=0.0 vz=0.0>"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -379,10 +464,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 18,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -390,7 +473,7 @@
        "False"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -408,10 +491,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -419,7 +500,7 @@
        "True"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -432,15 +513,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See the docs for further information: https://docs.python.org/2/library/ctypes.html"
+    "See the docs for further information: https://docs.python.org/3/library/ctypes.html"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
@@ -461,9 +540,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.6.10"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
- added note that we can set up hash later (see #456);
- discussion of details is rearranged;
- link to Python docs is updated (2 → 3).