### PR TITLE
fix broken link to UniquelyIdentifyingParticles.ipynb

### DIFF
--- a/ipython_examples/EscapingParticles.ipynb
+++ b/ipython_examples/EscapingParticles.ipynb
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This doesn't look right.  The problem here is that when we removed `particles[1]` from the simulation, all the particles got shifted down in the `particles` array.  So following the removal, `xvenus` all of a sudden started getting populated by the values for Earth (the new `sim.particles[2]`).  A more robust way to access particles is using hashes (see [UniquelyIdentifyingParticles.ipynb](UniquelyIdentifyingParticles.ipynb))"
+    "This doesn't look right.  The problem here is that when we removed `particles[1]` from the simulation, all the particles got shifted down in the `particles` array.  So following the removal, `xvenus` all of a sudden started getting populated by the values for Earth (the new `sim.particles[2]`).  A more robust way to access particles is using hashes (see [UniquelyIdentifyingParticlesWithHashes.ipynb](UniquelyIdentifyingParticlesWithHashes.ipynb))"
    ]
   },
   {

--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -703,4 +703,4 @@ class Particle(Structure):
         elif isinstance(value, int_types):
             self._hash = value
         else:
-            raise AttributeError("Hash must be set to an integer, a ctypes.c_uint32 or a string. See UniquelyIdentifyingParticles.ipynb ipython_example.")
+            raise AttributeError("Hash must be set to an integer, a ctypes.c_uint32 or a string. See UniquelyIdentifyingParticlesWithHashes.ipynb ipython_example.")

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -2200,7 +2200,7 @@ class Particles(MutableMapping):
             if isinstance(key, string_types):
                 key = rebhash(key)
             elif not isinstance(key, hash_types):
-                raise AttributeError("Expecting string, integer or ctypes.c_uint32 as argument to sim.particles.  See UniquelyIdentifyingParticles.ipynb ipython_example.")
+                raise AttributeError("Expecting string, integer or ctypes.c_uint32 as argument to sim.particles.  See UniquelyIdentifyingParticlesWithHashes.ipynb ipython_example.")
 
             ptr = clibrebound.reb_get_particle_by_hash(byref(self.sim), key) 
             


### PR DESCRIPTION
There are two more broken links to `Exceptions.html` and `Installation.html`, but I am not sure where they should point instead.