### PR TITLE
add search field to sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -243,7 +243,7 @@ html_static_path = ['_static']
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}
 html_sidebars = {
-             '**': ['globaltoc.html',]
+             '**': ['globaltoc.html', 'searchbox.html']
                 }
 
 # Additional templates that should be rendered to pages, maps page names to


### PR DESCRIPTION
And one more while I'm on it:

I really like the sphinx search as it makes it really fast to find a specific page when you don't remember in which category it is left. But the overwritten sidebar template removes the default search field, so I readded it in this PR.
![image](https://user-images.githubusercontent.com/6266037/103659082-4fdedd00-4f6c-11eb-8ff6-f935550dfa55.png)

I can't promise that it works on ReadTheDocs as I think they use their own server-side search instead of the default sphinx search, but at least locally it works fine.