### PR TITLE
fix typos in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ The full documentation with many examples, changelogs and tutorials can be found
 
 http://rebound.readthedocs.org
 
-We're alway trying to improve REBOUND and extending the documention is high on our to-do list.
+We're always trying to improve REBOUND and extending the documention is high on our to-do list.
 If you have trouble installing or using REBOUND, please open an issue on github and we'll try to help as much as we can.
 
 There are also short YouTube videos describing various aspects of REBOUND available at https://www.youtube.com/channel/UC2wonKI0wWwGi5-JqJtMsYQ/videos.

--- a/changelog.rst
+++ b/changelog.rst
@@ -43,7 +43,7 @@ Version 3.12.0
 Version 3.11.1
 --------------
 * Added support for test particles and first-order variational particles to the Embedded Operator Splitting (EOS).
-* BASIC Gravity routine changed from O(N^2) to O(0.5 N^2). This should lead to a speed-up in most cases but will break bit-wise reproducibility from earlier versions as the ordering of floating point opperations has changed.
+* BASIC Gravity routine changed from O(N^2) to O(0.5 N^2). This should lead to a speed-up in most cases but will break bit-wise reproducibility from earlier versions as the ordering of floating point operations has changed.
 
 Version 3.11.0
 --------------
@@ -186,7 +186,7 @@ Version 3.5.1
 Version 3.5.0
 -------------
 * The WHFast integrator now supports Jacobi coordinates (default), democratic heliocentric coordinates and WHDS coordinates. The previously separate WHFastHelio integrator has been removed. The coordinate system can now be changed by simply setting the coordinates flag in the ri_whfast struct.
-* Included a experimental new integrator MERCURIUS. This is similar to the hybrid integrator in Mercury but uses WHFast and IAS15. Not ready for production yet.
+* Included an experimental new integrator MERCURIUS. This is similar to the hybrid integrator in Mercury but uses WHFast and IAS15. Not ready for production yet.
 
 Version 3.4.0
 -------------
@@ -278,11 +278,11 @@ Version 2.19.0
        warnings.simplefilter("always")
        # Execute a command which triggers a warning message.
        # The message will not show up.
-* Improvements regarding the WHFast logic for hyperbolic orbis. No changes should be noticable to users.
+* Improvements regarding the WHFast logic for hyperbolic orbis. No changes should be noticeable to users.
 
 Version 2.18.9
 --------------
-* Added the reb_serialize_particle_data function for fast access to particle data via numpy array. The full syntax is explain in the documentation. Here is a short example: 
+* Added the reb_serialize_particle_data function for fast access to particle data via numpy array. The full syntax is explained in the documentation. Here is a short example: 
 .. code:: python
    
    import numpy as np
@@ -294,7 +294,7 @@ Version 2.18.9
 Version 2.18.5
 --------------
 * When loading a simulation from a binary file, REBOUND now checks if the version of the binary file is the same as the current version. 
-* When saving a simulation to a binary file, all the auxiliary arrays for IAS15 are now stored. This allows for bit-by-bit reproducability in simulations that are making use of checkpoints.
+* When saving a simulation to a binary file, all the auxiliary arrays for IAS15 are now stored. This allows for bit-by-bit reproducibility in simulations that are making use of checkpoints.
 
 
 Version 2.18.0
@@ -327,8 +327,8 @@ Version 2.17.0
 Version 2.0.0
 -------------
 
-* We made many changes to the code. Most importanly, REBOUND is now thread-safe and does not use global variables anymore. All the variables that were previously global, are now contained in the ``reb_simulation`` structure. This has many advantages, for example, you can run separate simulations in parallel from within one process.
+* We made many changes to the code. Most importantly, REBOUND is now thread-safe and does not use global variables anymore. All the variables that were previously global, are now contained in the ``reb_simulation`` structure. This has many advantages, for example, you can run separate simulations in parallel from within one process.
 * We also made it possible to choose all modules at runtime (compared to the selection in the ``Makefile`` that was used before). This is much more in line with standard UNIX coding practice and does not severely impact performance (it might even help making REBOUND a tiny bit faster). This makes REBOUND a fully functional shared library. We added a prefix to all public functions and struct definitions: ``reb_``.
 * There are still some features that haven't been fully ported. Most importantly, the MPI parallelization and the SWEEP collision detection routine. 
-* The best way to get and idea of the changes we made is to look at some of the example problems and the new REBOUND documentation. If you have trouble using the new version or find a bug, please submit an issue or a pull request on github. 
+* The best way to get an idea of the changes we made is to look at some of the example problems and the new REBOUND documentation. If you have trouble using the new version or find a bug, please submit an issue or a pull request on github. 
 

--- a/doc/examples.rst
+++ b/doc/examples.rst
@@ -76,7 +76,7 @@ With the simulation archive you can run a simulation first, then think later abo
 Variational Equations and Chaos detectors
 -----------------------------------------
 REBOUND supports first and second order variational equations. 
-Varational equations have several advantages over shadow particles when calculating chaos indicators such as Lyapunov exponents. 
+Variational equations have several advantages over shadow particles when calculating chaos indicators such as Lyapunov exponents. 
 They can also be used in optimization problems. 
 For more details on variational equations and the math behind them, have a look at the paper `Rein and Tamayo 2016 <https://arxiv.org/abs/1603.03424>`_ and the following examples.
 
@@ -115,7 +115,7 @@ Granular Dynamics
 -----------------
 The examples in this section show how to use REBOUND for simulations in which particles are colliding with each other.
 Note that this is a different type of simulation than simulations of colliding planets.
-Here, particles collide often with each other. In the planet case, they collide with each other very rarely. 
+Here, particles often collide with each other. In the planet case, they collide with each other very rarely. 
 
 .. toctree::
    c_example_bouncing_balls
@@ -127,7 +127,7 @@ Here, particles collide often with each other. In the planet case, they collide 
 
 Tree code
 ---------
-REBOUND has a built in Barnes-Hut oct tree for collision detection and gravity. 
+REBOUND has a built-in Barnes-Hut oct tree for collision detection and gravity. 
 This allows you, for example, to simulate large gravitationally interacting systems.
 
 .. toctree::

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -92,7 +92,7 @@ There are several papers describing the functionality of REBOUND.
 
 7. Rein & Tamayo 2018 (Monthly Notices of the Royal Astronomical Society, Volume 473, Issue 3, p.3351–3357) describes the integer based JANUS integrator. https://ui.adsabs.harvard.edu/abs/2018MNRAS.473.3351R
 
-8. Rein, Hernandez, Tamayo, Brown, Eckels, Holmes, Lau, Leblanc & Silburt 2019 (Monthly Notices of the Royal Astronomical Society, Volume 485, Issue 4, p.5490-5497) describes the hyrbid symplectic intergator MERCURIUS. https://ui.adsabs.harvard.edu/abs/2019MNRAS.485.5490R
+8. Rein, Hernandez, Tamayo, Brown, Eckels, Holmes, Lau, Leblanc & Silburt 2019 (Monthly Notices of the Royal Astronomical Society, Volume 485, Issue 4, p.5490-5497) describes the hyrbid symplectic integrator MERCURIUS. https://ui.adsabs.harvard.edu/abs/2019MNRAS.485.5490R
 
 9. Rein, Tamayo & Brown 2019 (Monthly Notices of the Royal Astronomical Society, Volume 489, Issue 4, November 2019, Pages 4632-4640) describes the implementation of the high order symplectic intergators SABA, SABAC, SABACL, WHCKL, WHCKM, and WHCKC. https://ui.adsabs.harvard.edu/abs/2019MNRAS.489.4632R
 

--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -29,7 +29,7 @@ Module name               Description
 =======================  ============================================ 
 REB_COLLISION_NONE        No collision detection, default
 REB_COLLISION_DIRECT      Brute force collision search, O(N^2), checks for instantaneous overlaps only 
-REB_COLLISION_LINE        Brute force collision search, O(N^2), checks for overlaps that occured during the last timestep assuming particles travelled along straight lines
+REB_COLLISION_LINE        Brute force collision search, O(N^2), checks for overlaps that occurred during the last timestep assuming particles travelled along straight lines
 REB_COLLISION_TREE        Oct tree, O(N log(N))
 REB_COLLISION_SWEEP       (still work in progress) Plane sweep algorithm, ideal for low dimensional  problems, O(N) or O(N^1.5) depending on geometry 
 REB_COLLISION_LINETREE    Oct tree, O(N log(N)), in contrast to REB_COLLISION_TREE, this algorithm checks for overlapping trajectories, not overlapping particles.
@@ -43,7 +43,7 @@ Boundary conditions
 Module name               Description
 =======================  ============================================ 
 REB_BOUNDARY_NONE         Dummy. Particles are not affected by boundary conditions, default
-REB_BOUNDARY_OPEN         Particles are removed from the simulation if they leaves the box.
+REB_BOUNDARY_OPEN         Particles are removed from the simulation if they leave the box.
 REB_BOUNDARY_PERIODIC     Periodic boundary conditions. Particles are reinserted on the other side if they cross the box boundaries. You can use an arbitrary number of ghost-boxes with this module.
 REB_BOUNDARY_SHEAR        Shear periodic boundary conditions. Similar to periodic boundary conditions, but ghost-boxes are moving with constant speed, set by the shear.
 =======================  ============================================ 
@@ -55,7 +55,7 @@ Integrators
 ==========================  ============================================ 
 Module name                 Description
 ==========================  ============================================ 
-REB_INTEGRATOR_IAS15        IAS15 stands for Integrator with Adaptive Step-size control, 15th order. It is a vey high order, non-symplectic integrator which can handle arbitrary (velocity dependent) forces and is in most cases accurate down to machine precision. IAS15 can integrate variational equations. Rein & Spiegel 2015, Everhart 1985. This is the default integrator of REBOUND.
+REB_INTEGRATOR_IAS15        IAS15 stands for Integrator with Adaptive Step-size control, 15th order. It is a very high order, non-symplectic integrator which can handle arbitrary (velocity dependent) forces and is in most cases accurate down to machine precision. IAS15 can integrate variational equations. Rein & Spiegel 2015, Everhart 1985. This is the default integrator of REBOUND.
 REB_INTEGRATOR_WHFAST       WHFast is the integrator described in Rein & Tamayo 2015 and Rein, Tamayo & Brown 2019. It is an implementation of the symplectic Wisdom-Holman integrator. It supports first and second symplectic correctors as well as the kernel method of Wisdom et al. 1996 with various different kernels. It is very fast and accurate, uses Gauss f and g functions to solve the Kepler motion and can integrate variational equations. The user can choose between Jacobi and Democratic Heliocentric coordinates. 
 REB_INTEGRATOR_SABA         SABA are symplectic integrators developed by Laskar & Robutel 2001 and Blanes et al. 2013. This implementation support SABA1, SABA2, SABA3, and SABA4 as well as the corrected versions SABAC1, SABAC2, SABAC3, and SABAC4. Different correctors can be selected. Also supported are SABA(8,4,4), SABA(8,6,4), SABA(10,6,4). See Rein, Tamayo & Brown 2019 for details. 
 REB_INTEGRATOR_JANUS        Janus is a bit-wise time-reversible high-order symplectic integrator using a mix of floating point and integer arithmetic. This integrator is still in an experimental stage and will be discussed in an upcoming paper. 

--- a/doc/python_quickstart.rst
+++ b/doc/python_quickstart.rst
@@ -103,7 +103,7 @@ Then, import the rebound module::
 
     import rebound
 
-create a new simualtion::
+create a new simulation::
 
     sim = rebound.Simulation()
 

--- a/ipython_examples/AdvWHFast.ipynb
+++ b/ipython_examples/AdvWHFast.ipynb
@@ -16,7 +16,7 @@
     "As long as \n",
     "\n",
     "1. you don't add, remove or otherwise modify particles between timesteps\n",
-    "2. you get your outputs by passing a list of output times ahead of time and access the particles pointer between calls to `sim.integrate()` (see, e.g., the Visualization section of [WHFast.ipynb](WHFast.ipynb))\n",
+    "2. you get your outputs by passing a list of output times ahead of time and access the particle's pointer between calls to `sim.integrate()` (see, e.g., the Visualization section of [WHFast.ipynb](WHFast.ipynb))\n",
     "\n",
     "you can set `sim.ri_whfast.safe_mode = 0` to get a substantial performance boost.  Under the same stipulations, you can set `sim.ri_whfast.corrector = 11` to get much higher accuracy, at a nearly negligible loss of performance (as long as there are many timesteps between outputs).\n",
     "\n",
@@ -345,7 +345,7 @@
    "source": [
     "**Changing the internal coordinate system**\n",
     "\n",
-    "WHFast by default uses Jacobi coordinates internally. This works well for planetary systems which are stable and orbits are not crossing. However, in some cases a different coordinate system might perform better. WHFast also support so called democratic heliocentric coordinates and the so called WHDS coordinates. For mor information on these coordinates systems [see Hernandez and Dehnen (2016)](https://arxiv.org/abs/1612.05329). To select a different coordinate system, use the following syntax:"
+    "WHFast by default uses Jacobi coordinates internally. This works well for planetary systems which are stable and orbits are not crossing. However, in some cases a different coordinate system might perform better. WHFast also support so-called democratic heliocentric coordinates and the so called WHDS coordinates. For more information on these coordinates systems [see Hernandez and Dehnen (2016)](https://arxiv.org/abs/1612.05329). To select a different coordinate system, use the following syntax:"
    ]
   },
   {

--- a/ipython_examples/Cheartbeat.ipynb
+++ b/ipython_examples/Cheartbeat.ipynb
@@ -7,9 +7,9 @@
     "# Using a C Heartbeat function\n",
     "The heartbeat function of a REBOUND simulation gets called after every timestep. There are many different things you can do in a heartbeat function, for example creating outputs, adding particles, adjusting parameters that depend on time, etc. REBOUND supports heartbeat functions in both its C and python interface. \n",
     "\n",
-    "A python heartbeat function can sometimes become the bottleneck of a simulation because it gets called every single timestep. This tutotial shows you how to implement the heartbeat function in C, then link it to REBOUND using python. Note that alternatively you can of course always just use the C version of REBOUND directly and never bother with python at all.\n",
+    "A python heartbeat function can sometimes become the bottleneck of a simulation because it gets called every single timestep. This tutorial shows you how to implement the heartbeat function in C, then link it to REBOUND using python. Note that alternatively you can of course always just use the C version of REBOUND directly and never bother with python at all.\n",
     "\n",
-    "We start by creating a REBOUND simualtion which contains the planets of our Solar System as a test case."
+    "We start by creating a REBOUND simulation which contains the planets of our Solar System as a test case."
    ]
   },
   {
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let us first create a simple heartbeat function in python. It simply calculates the eccentricty of Mercury (you could do something with it, here we just calculate it and then ignore it)."
+    "Let us first create a simple heartbeat function in python. It simply calculates the eccentricity of Mercury (you could do something with it, here we just calculate it and then ignore it)."
    ]
   },
   {

--- a/ipython_examples/Checkpoints.ipynb
+++ b/ipython_examples/Checkpoints.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Checkpoints\n",
-    "You can easily save and load a REBOUND simulation to a binary file. The binary file includes all information about the particles (mass, position, velocity, etc), as well as the current simulation settings such as time, integrator choise, etc.\n",
+    "You can easily save and load a REBOUND simulation to a binary file. The binary file includes all information about the particles (mass, position, velocity, etc), as well as the current simulation settings such as time, integrator choice, etc.\n",
     "\n",
     "Let's add three particles to REBOUND and save them to a file."
    ]

--- a/ipython_examples/Churyumov-Gerasimenko.ipynb
+++ b/ipython_examples/Churyumov-Gerasimenko.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# The comet 67P/Churyumov–Gerasimenko\n",
     "\n",
-    "This tutorial teaches you how to use the IAS15 integator (Rein and Spiegel, 2015) to simulate the orbit of 67P/Churyumov–Gerasimenko. We will download the data from NASA Horizons and visualize the orbit using matplotlib.\n",
+    "This tutorial teaches you how to use the IAS15 integrator (Rein and Spiegel, 2015) to simulate the orbit of 67P/Churyumov–Gerasimenko. We will download the data from NASA Horizons and visualize the orbit using matplotlib.\n",
     "\n",
     "This tutorial assumes that you have already installed REBOUND."
    ]
@@ -73,7 +73,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Although there are three bodies, the `calculate_orbits()` function only returns two objects as the orbit for the Sun would be a little boring. The function returns the orbits in Jacobi coordinates. Since we didn't specify a falue for $G$, REBOUND assumes that $G=1$. The unit of length is one astronomical unit, the unit of time is one year/$2\\pi$.\n",
+    "Although there are three bodies, the `calculate_orbits()` function only returns two objects as the orbit for the Sun would be a little boring. The function returns the orbits in Jacobi coordinates. Since we didn't specify a value for $G$, REBOUND assumes that $G=1$. The unit of length is one astronomical unit, the unit of time is one year/$2\\pi$.\n",
     "\n",
     "Let's add something more interesting to our simulation: the comet 67P/Churyumov-Gerasimenko. "
    ]
@@ -107,13 +107,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When searching for a body by name, REBOUND takes the first dataset that Horizons offers. In this case, it's a set of parameters from 1962. You probably want to go to the Horizons website and check that the values you are using are up-to-date and appropriate for what you want to do. You can also use more complicted Horizons queries, for example, to get the most recent apparition solution for the comet, use\n",
+    "When searching for a body by name, REBOUND takes the first dataset that Horizons offers. In this case, it's a set of parameters from 1962. You probably want to go to the Horizons website and check that the values you are using are up-to-date and appropriate for what you want to do. You can also use more complicated Horizons queries, for example, to get the most recent apparition solution for the comet, use\n",
     "\n",
     "    sim.add(\"NAME=Churyumov-Gerasimenko; CAP\")\n",
     "\n",
     "You can also use the IAU asteroid number for numbered asteroids, or the database record numbers from Horizons for objects not yet numbered by the IAU (but note that database record numbers can change as the database gets rearranged with new discoveries, see http://ssd.jpl.nasa.gov/?horizons_doc#sb for details). In our case the current database record number is 900647, so you could use `sim.add(\"900647\")` to get the newest set of orbital parameters for Churyumov-Gerasimenko.\n",
     "\n",
-    "NASA Horizons doesn't have masses for all bodies. If REBOUND doesn't find a mass, you get a warning message (see above). In our case, we don't need the mass of the comet (it's really smal). However, it you want, you can add it manually using the syntax `sim.add(\"Churyumov-Gerasimenko\", m=5.03e-18)`.\n",
+    "NASA Horizons doesn't have masses for all bodies. If REBOUND doesn't find a mass, you get a warning message (see above). In our case, we don't need the mass of the comet (it's really small). However, it you want, you can add it manually using the syntax `sim.add(\"Churyumov-Gerasimenko\", m=5.03e-18)`.\n",
     "\n",
     "Before we integrate the orbits, let's plot the instantaneous orbits using the built-in REBOUND function `OrbitPlot`."
    ]
@@ -251,7 +251,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see in the above image, the comet 67P had a rather strong encounter with Jupiter a few years ago. Of course, if you wanted to do a realistic simulation of that encounter, you'd need to include all the other planets and maybe even some non-gravitational effects for the comet. However, let's stick with our simplistic model and try to find out when exactly the two bodies had a close encouter. We already stored the data, so we can just plot their distance as a function of time."
+    "As you can see in the above image, the comet 67P had a rather strong encounter with Jupiter a few years ago. Of course, if you wanted to do a realistic simulation of that encounter, you'd need to include all the other planets and maybe even some non-gravitational effects for the comet. However, let's stick with our simplistic model and try to find out when exactly the two bodies had a close encounter. We already stored the data, so we can just plot their distance as a function of time."
    ]
   },
   {
@@ -263,7 +263,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Minimum distance (0.050965 AU) occured at time: -61.501150 years.\n"
+      "Minimum distance (0.050965 AU) occurred at time: -61.501150 years.\n"
      ]
     },
     {
@@ -323,7 +323,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you check [wikipedia](http://en.wikipedia.org/wiki/67P/Churyumov–Gerasimenko) or [JPL](https://ssd.jpl.nasa.gov/sbdb.cgi?sstr=67P;old=0;orb=0;cov=0;log=0;cad=1#cad), the encounter happened on 1959-Feb-04 06:24, so we are off by a few days.  It turns out that's because of jets from the comet!"
+    "If you check [Wikipedia](http://en.wikipedia.org/wiki/67P/Churyumov–Gerasimenko) or [JPL](https://ssd.jpl.nasa.gov/sbdb.cgi?sstr=67P;old=0;orb=0;cov=0;log=0;cad=1#cad), the encounter happened on 1959-Feb-04 06:24, so we are off by a few days.  It turns out that's because of jets from the comet!"
    ]
   }
  ],

--- a/ipython_examples/CloseEncounters.ipynb
+++ b/ipython_examples/CloseEncounters.ipynb
@@ -117,7 +117,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `Encounter` does currently not tell you wich particles had a close encounter. But you can easily search for the pair yourself (see below). \n",
+    "The `Encounter` does currently not tell you which particles had a close encounter. But you can easily search for the pair yourself (see below). \n",
     "\n",
     "Here, we already know which bodies had a close encounter (the two planets) and we can plot their separation as a function of time."
    ]
@@ -156,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We did indeed find the close enounter correctly. We can now search for the two particles that collided and, for this example, merge them. To do that we'll first calculate our new merged planet coordinates, then remove the two particles that collided from REBOUND and finally add the new particle."
+    "We did indeed find the close encounter correctly. We can now search for the two particles that collided and, for this example, merge them. To do that we'll first calculate our new merged planet coordinates, then remove the two particles that collided from REBOUND and finally add the new particle."
    ]
   },
   {

--- a/ipython_examples/EccentricComets.ipynb
+++ b/ipython_examples/EccentricComets.ipynb
@@ -7,7 +7,7 @@
     "# Integrating eccentric Comets with MERCURIUS\n",
     "In this example, we study highly eccentric comets which interact with a Neptune mass planet.\n",
     "\n",
-    "MERCURIUS ia a hybrid integration scheme which combines the WHFAST and IAS15 algorithms. It smoothly transitions between the two integrators, similar to what the hybrid integrator in the MERCURY package is doing. "
+    "MERCURIUS is a hybrid integration scheme which combines the WHFAST and IAS15 algorithms. It smoothly transitions between the two integrators, similar to what the hybrid integrator in the MERCURY package is doing. "
    ]
   },
   {
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We need to move to the COM frame to avoid drifting out of our simulation box. Also it is always good practice to monitor the change in energy over the course of a simulation, which requires us to calculate it before and after the simulation."
+    "We need to move to the COM frame to avoid drifting out of our simulation box. Also, it is always good practice to monitor the change in energy over the course of a simulation, which requires us to calculate it before and after the simulation."
    ]
   },
   {

--- a/ipython_examples/Forces.ipynb
+++ b/ipython_examples/Forces.ipynb
@@ -37,7 +37,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We could integrate this system, and the planet would go around the star at a fixed orbit with $a=1$ forever. Let's add an additional constant force that acts on the planet and points in one direction $F_x = m\\cdot c$, where $m$ is the planet's mass and $c$ a constant. This is called the Stark problem. In python we can describe this with the following function"
+    "We could integrate this system, and the planet would go around the star at a fixed orbit with $a=1$ forever. Let's add an additional constant force that acts on the planet and points in one direction $F_x = m\\cdot c$, where $m$ is the planet's mass and $c$ a constant. This is called the Stark problem. In python, we can describe this with the following function"
    ]
   },
   {
@@ -147,7 +147,7 @@
    "source": [
     "You can see that the eccentricity is oscillating between 0 and almost 1. \n",
     "\n",
-    "Note that the function `starkForce(reb_sim)` above receives the argument `reb_sim` when it is called. This is a pointer to the simulation structure. Instead of using the global `ps` variable to access particle data, one could also use `reb_sim.contents.particles`. This could be useful when one is running multiple simulations in parallel or when the particles get added and removed (in those cases `particles` might change). The `contents` has the same meaning a `->` in C, i.e. follow the memory address. To find out more about pointers, check out the [ctypes documentation](https://docs.python.org/3/library/ctypes.html#pointers).\n",
+    "Note that the function `starkForce(reb_sim)` above receives the argument `reb_sim` when it is called. This is a pointer to the simulation structure. Instead of using the global `ps` variable to access particle data, one could also use `reb_sim.contents.particles`. This could be useful when one is running multiple simulations in parallel or when the particles get added and removed (in those cases `particles` might change). The `contents` has the same meaning as a `->` in C, i.e. follow the memory address. To find out more about pointers, check out the [ctypes documentation](https://docs.python.org/3/library/ctypes.html#pointers).\n",
     "\n",
     "\n",
     "**Non-conservative forces**\n",
@@ -269,7 +269,7 @@
    "source": [
     "The semi-major axis decays exponentially on a timescale `tau`.\n",
     "\n",
-    "In the above example, REBOUND is calling a python function at every timestep. This can be slow. Note that you can also set `rebound.additional_forces` to a c function pointer. This let's you speed up the simulation significantly. However, you need to write you own c function/library that knows how to calculate the forces. Or, you use Dan Tamayo's new migration library (in preparation)."
+    "In the above example, REBOUND is calling a python function at every timestep. This can be slow. Note that you can also set `rebound.additional_forces` to a c function pointer. This let's you speed up the simulation significantly. However, you need to write your own c function/library that knows how to calculate the forces. Or, you use Dan Tamayo's new migration library (in preparation)."
    ]
   }
  ],

--- a/ipython_examples/FourierSpectrum.ipynb
+++ b/ipython_examples/FourierSpectrum.ipynb
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's try to analyze the periodicities in this signal.  Here we have a uniformly spaced time series, so we could run a Fast Fourier Transform, but as an example of the wider array of tools available through scipy, let's run a Lomb-Scargle periodogram (which allows for non-uniform time series). This could also be used when storing outputs at each timestep using the integrator IAS15 (which uses adaptive and therefore nonuniform timesteps).\n",
+    "Now let's try to analyze the periodicities in this signal.  Here we have a uniformly spaced time series, so we could run a Fast Fourier Transform, but as an example of the wider array of tools available through scipy, let's run a Lomb-Scargle periodogram (which allows for non-uniform time series). This could also be used when storing outputs at each timestep using the integrator IAS15 (which uses adaptive and therefore non-uniform timesteps).\n",
     "\n",
     "Let's check for periodicities with periods logarithmically spaced between 10 and $10^5$ yrs.  From the documentation, we find that the lombscargle function requires a list of corresponding angular frequencies (ws), and we obtain the appropriate normalization for the plot.  To avoid conversions to orbital elements, we analyze the time series of Jupiter's x-position."
    ]
@@ -197,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We pick out the obvious signal in the eccentricity plot with a period of $\\approx 45000$ yrs, which is due to secular interactions between the two planets.  There is quite a bit of power aliased into neighboring frequencies due to the short integration duration, with contributions from the second secular timescale, which is out at $\\sim 2\\times10^5$ yrs and causes a slower, low-amplitude modulation of the eccentricity signal plotted above (we limited the time of integration so that the example runs in a few seconds).  \n",
+    "We pick out the obvious signal in the eccentricity plot with a period of $\\approx 45000$ yrs, which is due to secular interactions between the two planets.  There is quite a bit of power aliased into neighbouring frequencies due to the short integration duration, with contributions from the second secular timescale, which is out at $\\sim 2\\times10^5$ yrs and causes a slower, low-amplitude modulation of the eccentricity signal plotted above (we limited the time of integration so that the example runs in a few seconds).  \n",
     "\n",
     "Additionally, though it was invisible on the scale of the eccentricity plot above, we clearly see a strong signal at Jupiter's orbital period of about 12 years.  \n",
     "\n",

--- a/ipython_examples/HighOrderSymplectic.ipynb
+++ b/ipython_examples/HighOrderSymplectic.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# High Order Symplectic Integrators\n",
     "\n",
-    "This notebooks show how to use the high order symplectic integrators of Wisdom et al. (1996) and Laskar & Robutel (2001) with REBOUND. See  Rein, Tamayo & Brown (2019) for an overview of these integrators. \n",
+    "These notebooks show how to use the high order symplectic integrators of Wisdom et al. (1996) and Laskar & Robutel (2001) with REBOUND. See  Rein, Tamayo & Brown (2019) for an overview of these integrators. \n",
     "\n",
     "Let us start by importing REBOUND, as well as numpy and matplotlib."
    ]

--- a/ipython_examples/Horizons.ipynb
+++ b/ipython_examples/Horizons.ipynb
@@ -12,7 +12,7 @@
     "\n",
     "When we add particles by passing a string, REBOUND queries the HORIZONS database and takes the first dataset HORIZONS offers.  For the Sun, moons, and small bodies, this will typically return the body itself.  For planets, it will return the barycenter of the system (for moonless planets like Venus it will say barycenter but there is no distinction).  If you want the planet specifically, you have to use, e.g., \"NAME=Pluto\" rather than \"Pluto\".  In all cases, REBOUND will print out the name of the HORIZONS entry it's using.\n",
     "\n",
-    "You can also add bodies using their integer NAIF IDs:  [NAIF IDs](http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/MATLAB/req/naif_ids.html).  Note that because of the number of small bodies (asteroids etc.) we have discovered, this convention only works for large objetcts.  For small bodies, instead use \"NAME=name\" (see the SMALL BODIES section in the [HORIZONS Documentation](http://ssd.jpl.nasa.gov/?horizons_doc))."
+    "You can also add bodies using their integer NAIF IDs:  [NAIF IDs](http://naif.jpl.nasa.gov/pub/naif/toolkit_docs/MATLAB/req/naif_ids.html).  Note that because of the number of small bodies (asteroids etc.) we have discovered, this convention only works for large objects.  For small bodies, instead use \"NAME=name\" (see the SMALL BODIES section in the [HORIZONS Documentation](http://ssd.jpl.nasa.gov/?horizons_doc))."
    ]
   },
   {
@@ -217,7 +217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The reference plane is the ecliptic (Earth's orbital plane) of J2000 (Jan. 1st 2000 12:00 GMT), with the x axis along the ascending node of the ecliptic and the Earth's mean equator (also at J2000).  "
+    "The reference plane is the ecliptic (Earth's orbital plane) of J2000 (Jan. 1st 2000 12:00 GMT), with the x-axis along the ascending node of the ecliptic and the Earth's mean equator (also at J2000).  "
    ]
   }
  ],

--- a/ipython_examples/HybridIntegrationsWithMercurius.ipynb
+++ b/ipython_examples/HybridIntegrationsWithMercurius.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Hybrid integrations with MERCURIUS\n",
-    "REBOUND comes with several integrators, each of which has its own advantages and disadvantages. MERCURIUS is a hybrid integrastor that is very similar to the hybrid integrator in John Chambers' Mercury code (J. E. Chambers 1999). It uses a symplectic Wisdom-Holman integrator when particles are far apart from each other and switches over to a high order integrator during close encounters. Specifically, MERCURIUS uses the efficient WHFast and IAS15 integrators internally."
+    "REBOUND comes with several integrators, each of which has its own advantages and disadvantages. MERCURIUS is a hybrid integrator that is very similar to the hybrid integrator in John Chambers' Mercury code (J. E. Chambers 1999). It uses a symplectic Wisdom-Holman integrator when particles are far apart from each other and switches over to a high order integrator during close encounters. Specifically, MERCURIUS uses the efficient WHFast and IAS15 integrators internally."
    ]
   },
   {
@@ -110,7 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see MERCURIUS is able to integrate this system with much better accuracy. When a close encounter occurs, it automatically (and smoothly!) switches to the IAS15 integrator. When there is not close encounter, you still get all the benefits in terms of speed an accuracy from a symplectic integrator."
+    "As you can see, MERCURIUS is able to integrate this system with much better accuracy. When a close encounter occurs, it automatically (and smoothly!) switches to the IAS15 integrator. When there is no close encounter, you still get all the benefits in terms of speed an accuracy from a symplectic integrator."
    ]
   },
   {

--- a/ipython_examples/HyperbolicOrbits.ipynb
+++ b/ipython_examples/HyperbolicOrbits.ipynb
@@ -34,7 +34,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We  want to add these comits to a REBOUND simulation(s).  The first thing to do is set the units, which have to be consistent throughout.  Here we have a table in AU and days, so we'll use the gaussian gravitational constant (AU, days, solar masses).  "
+    "We  want to add these comets to a REBOUND simulation(s).  The first thing to do is set the units, which have to be consistent throughout.  Here we have a table in AU and days, so we'll use the gaussian gravitational constant (AU, days, solar masses).  "
    ]
   },
   {
@@ -113,7 +113,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, REBOUND adds and outputs particles in Jacobi orbital elements.  Typically orbital elements for comets are heliocentric.  Mixing the two will give you relative errors in elements, positions etc. of order the mass ratio of Jupiter to the Sun ($\\sim 0.001$) which is why we pass the additional `primary=sim.particles[0]` argument to the `add()` function.  If this level of accuracy doesn't matters to you, you can ignore the `primary` argument.\n",
+    "By default, REBOUND adds and outputs particles in Jacobi orbital elements.  Typically, orbital elements for comets are heliocentric.  Mixing the two will give you relative errors in elements, positions etc. of order the mass ratio of Jupiter to the Sun ($\\sim 0.001$) which is why we pass the additional `primary=sim.particles[0]` argument to the `add()` function.  If this level of accuracy doesn't matter to you, you can ignore the `primary` argument.\n",
     "\n"
    ]
   },
@@ -186,7 +186,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For fun, let's add all the coments to a simulation:"
+    "For fun, let's add all the comets to a simulation:"
    ]
   },
   {

--- a/ipython_examples/Megno.ipynb
+++ b/ipython_examples/Megno.ipynb
@@ -102,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "On my laptop (dual core CPU), this takes only 3 seconds!\n",
+    "On my laptop (dual-core CPU), this takes only 3 seconds!\n",
     "\n",
     "Let's plot it!"
    ]

--- a/ipython_examples/OrbitPlot.ipynb
+++ b/ipython_examples/OrbitPlot.ipynb
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To get an idea of the three dimensional distribution of orbits, use the `slices` option. This will plot the orbits three times, from different perspectives. You can size of the `z` direction by changing the value of `slices`. For example, `slices=0.5` corresponds to plots half the size of the main plot."
+    "To get an idea of the three-dimensional distribution of orbits, use the `slices` option. This will plot the orbits three times, from different perspectives. You can size of the `z` direction by changing the value of `slices`. For example, `slices=0.5` corresponds to plots half the size of the main plot."
    ]
   },
   {
@@ -239,7 +239,7 @@
    "source": [
     "Circumbinary Planet ABb is plotted correctly in orbit around the center of mass of A and B, but Bb's Jacobi orbit is also around the center of mass of the interior particles, which corresponds to a hyperbolic orbit. It's important to note that while the plot looks incorrect, IAS15 would correctly integrate their motions.\n",
     "\n",
-    "There's no way to generically assign specific primaries to particular particles, since this concept becomes ill defined near the boundaries of different bodies' Hill spheres bodies and particles could for example switch primaries in a given simulation. But it's straightforward to make custom plots since version 3.5.10:"
+    "There's no way to generically assign specific primaries to particular particles, since this concept becomes ill-defined near the boundaries of different bodies' Hill spheres bodies and particles could for example switch primaries in a given simulation. But it's straightforward to make custom plots since version 3.5.10:"
    ]
   },
   {

--- a/ipython_examples/OrbitalElements.ipynb
+++ b/ipython_examples/OrbitalElements.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "**Reference bodies**\n",
     "\n",
-    "As a reminder, there is a one-to-one mapping between (x,y,z,vx,vy,vz) and orbital elements, and one should always specify what the orbital elements are referenced against (e.g., the central star, the system's barycenter, etc.).  The differences betwen orbital elements referenced to these centers differ by $\\sim$ the mass ratio of the largest body to the central mass.  By default, REBOUND always uses Jacobi elements, which for each particle are always referenced to the center of mass of all particles with lower index in the simulation. \n",
+    "As a reminder, there is a one-to-one mapping between (x,y,z,vx,vy,vz) and orbital elements, and one should always specify what the orbital elements are referenced against (e.g., the central star, the system's barycenter, etc.).  The differences between orbital elements referenced to these centers differ by $\\sim$ the mass ratio of the largest body to the central mass.  By default, REBOUND always uses Jacobi elements, which for each particle are always referenced to the center of mass of all particles with lower index in the simulation. \n",
     "\n",
     "For the painstaking user: When separating out the center of mass degree of freedom and reducing the N body problem to N-1 Kepler problems and interaction terms, there are a number of possible Hamiltonian splittings (see e.g., Hernandez & Dehnen 2017), and different possible choices for the primary mass in each of the separate Kepler problems. REBOUND takes this primary mass to be the total mass of all the particles in the simulation. If particles are added from the inside out, this gives logical behavior in the limit of a hierarchical system, even for large masses (one can think of it as setting up our new particle in a 2-body orbit around all the interior mass concentrated at the interior particles' center of mass). \n",
     "\n",
@@ -163,7 +163,7 @@
     "\n",
     "**Edge cases and orbital element sets**\n",
     "\n",
-    "Different orbital elements lose meaning in various limits, e.g., a planar orbit and a circular orbit.  REBOUND therefore allows initialization with several different types of variables that are appropriate in different cases.  It's important to keep in mind that the procedure to initialize particles from orbital elements is not exactly invertible, so one can expect discrepant results for elements that become ill defined.  For example, "
+    "Different orbital elements lose meaning in various limits, e.g., a planar orbit and a circular orbit.  REBOUND therefore allows initialization with several different types of variables that are appropriate in different cases.  It's important to keep in mind that the procedure to initialize particles from orbital elements is not exactly invertible, so one can expect discrepant results for elements that become ill-defined.  For example, "
    ]
   },
   {
@@ -190,7 +190,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The problem here is that $\\omega$ (the angle from the ascending node to pericenter) is ill-defined for a circular orbit, so it's not clear what we mean when we pass it, and we get spurious results for both $\\omega$ and $f$, since the latter is also undefined as the angle from pericenter to the particle's position.  However, the true longitude $\\theta$, the broken angle from the $x$ axis to the ascending node = $\\Omega + \\omega + f$, and then to the particle's position, is always well defined:  "
+    "The problem here is that $\\omega$ (the angle from the ascending node to pericenter) is ill-defined for a circular orbit, so it's not clear what we mean when we pass it, and we get spurious results for both $\\omega$ and $f$, since the latter is also undefined as the angle from pericenter to the particle's position.  However, the true longitude $\\theta$, the broken angle from the $x$ axis to the ascending node = $\\Omega + \\omega + f$, and then to the particle's position, is always well-defined:  "
    ]
   },
   {
@@ -262,7 +262,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we have a planar orbit, in which case the line of nodes becomes ill defined, so $\\Omega$ is not a good variable, but we pass it anyway!  In this case, $\\omega$ is also undefined since it is referenced to the ascending node.  Here we get that now these two ill-defined variables get flipped.  The appropriate variable is pomega ($\\varpi = \\Omega + \\omega$), which is the angle from the $x$ axis to pericenter:"
+    "Here we have a planar orbit, in which case the line of nodes becomes ill-defined, so $\\Omega$ is not a good variable, but we pass it anyway!  In this case, $\\omega$ is also undefined since it is referenced to the ascending node.  Here we get that now these two ill-defined variables get flipped.  The appropriate variable is pomega ($\\varpi = \\Omega + \\omega$), which is the angle from the $x$ axis to pericenter:"
    ]
   },
   {
@@ -403,7 +403,7 @@
    "source": [
     "**Accuracy**\n",
     "\n",
-    "As a test of accuracy and demonstration of issues related to the last section, let's test the numerical stability by intializing particles with small eccentricities and true anomalies, computing their orbital elements back, and comparing the relative error.  We choose the inclination and node longitude randomly:"
+    "As a test of accuracy and demonstration of issues related to the last section, let's test the numerical stability by initializing particles with small eccentricities and true anomalies, computing their orbital elements back, and comparing the relative error.  We choose the inclination and node longitude randomly:"
    ]
   },
   {
@@ -663,7 +663,7 @@
     "\n",
     "**Jacobi masses**\n",
     "\n",
-    "There is a classical Hamiltonian splitting for the N-body problem (see e.g., Wisdom & Holman 1991) that when expanded to first order in the planet/star mass ratio, gives an interaction Hamiltonian with the same form as the disturbing function for an exterior perturber. This makes it particularly attractive for analytic or semi-analytic studies. In this splitting, the masses of the primaries for each planet take on a particular form. One can add particles using these jacobi masses with the `jacobi_masses` flag. By default this flag is false and the primary mass is the total mass of all particles in the simulation (see the top of this ipynb)."
+    "There is a classical Hamiltonian splitting for the N-body problem (see e.g., Wisdom & Holman 1991) that when expanded to first order in the planet/star mass ratio, gives an interaction Hamiltonian with the same form as the disturbing function for an exterior perturber. This makes it particularly attractive for analytic or semi-analytic studies. In this splitting, the masses of the primaries for each planet take on a particular form. One can add particles using these jacobi masses with the `jacobi_masses` flag. By default, this flag is false and the primary mass is the total mass of all particles in the simulation (see the top of this ipynb)."
    ]
   },
   {

--- a/ipython_examples/PoincareMap.ipynb
+++ b/ipython_examples/PoincareMap.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Poincare Map\n",
-    "This example shows how to calculate a simple Poincare Map with REBOUND. A Poincare Map (or sometimes calles Poincare Section) can be helpful to understand dynamical systems."
+    "This example shows how to calculate a simple Poincare Map with REBOUND. A Poincare Map (or sometimes called Poincare Section) can be helpful to understand dynamical systems."
    ]
   },
   {

--- a/ipython_examples/RemovingParticlesFromSimulation.ipynb
+++ b/ipython_examples/RemovingParticlesFromSimulation.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Removing particles from the simulation\n",
     "\n",
-    "This tutorial shows the differnet ways to remove particles from a REBOUND simulation. Let us start by setting up a simple simulation with 10 bodies, and assign them unique hashes so we can keep track of them (see [UniquelyIdentifyingParticlesWithHashes.ipynb](UniquelyIdentifyingParticlesWithHashes.ipynb))."
+    "This tutorial shows the different ways to remove particles from a REBOUND simulation. Let us start by setting up a simple simulation with 10 bodies, and assign them unique hashes, so we can keep track of them (see [UniquelyIdentifyingParticlesWithHashes.ipynb](UniquelyIdentifyingParticlesWithHashes.ipynb))."
    ]
   },
   {
@@ -246,7 +246,7 @@
     "collapsed": true
    },
    "source": [
-    "If you try to remove a particle with an invalid index or hash, an exception is thrown, which might be catch using the standard python syntax:"
+    "If you try to remove a particle with an invalid index or hash, an exception is thrown, which might be caught using the standard python syntax:"
    ]
   },
   {

--- a/ipython_examples/Resonances_of_Jupiters_moons.ipynb
+++ b/ipython_examples/Resonances_of_Jupiters_moons.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Resonances of Jupiter's moons, Io, Europa, and Ganymede\n",
     "\n",
-    "Example provided by Deborah Lokhorst. In this example, the four Galilean moons of Jupiter are downloaded from HORIZONS and their orbits are integrated forwards in time. This is a well-known example of a 1:2:4 resonance (also called Laplace resonance) in orbiting bodies. We calculate the resonant arguments see them oscillate with time. We also perform an Fast Fourier Transform (FFT) on the x-position of Io, to look for the period of oscillations caused by the 2:1 resonance between Io and Europa."
+    "Example provided by Deborah Lokhorst. In this example, the four Galilean moons of Jupiter are downloaded from HORIZONS and their orbits are integrated forwards in time. This is a well-known example of a 1:2:4 resonance (also called Laplace resonance) in orbiting bodies. We calculate the resonant arguments see them oscillate with time. We also perform a Fast Fourier Transform (FFT) on the x-position of Io, to look for the period of oscillations caused by the 2:1 resonance between Io and Europa."
    ]
   },
   {

--- a/ipython_examples/SaturnsRings.ipynb
+++ b/ipython_examples/SaturnsRings.ipynb
@@ -109,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We enable gravitational softening to smear out any potential numerical artefacts at very small scales."
+    "We enable gravitational softening to smear out any potential numerical artifacts at very small scales."
    ]
   },
   {
@@ -125,7 +125,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next up, we configure the simulation box. By default REBOUND used no boundary conditions, but here we have shear periodic boundaries and a finite simulation domain, so we need to let REBOUND know about the simulation boxsize (note that it is significantly smaller than $a$, so our local approximation is very good. In this example we'll work in SI units."
+    "Next up, we configure the simulation box. By default, REBOUND used no boundary conditions, but here we have shear periodic boundaries and a finite simulation domain, so we need to let REBOUND know about the simulation boxsize (note that it is significantly smaller than $a$, so our local approximation is very good. In this example we'll work in SI units."
    ]
   },
   {
@@ -142,7 +142,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because we have shear-periodic boundary conditions, we use ghost boxes to simulate the gravity of neighbouring ring patches. The more ghostboxes we use, the smoother the gravitational force accross the boundary. Here, two layers of ghost boxes in the x and y direction are enough (this is a total of 24 ghost boxes). We don't need ghost boxes in the z direction because a rings is a two dimensional system."
+    "Because we have shear-periodic boundary conditions, we use ghost boxes to simulate the gravity of neighbouring ring patches. The more ghostboxes we use, the smoother the gravitational force across the boundary. Here, two layers of ghost boxes in the x and y direction are enough (this is a total of 24 ghost boxes). We don't need ghost boxes in the z direction because a ring is a two-dimensional system."
    ]
   },
   {
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When two ring particles collide, they loose energy during their the bounce. We here use a velocity dependent Bridges et. al. coefficient of restitution. It is implemented as a python function (a C implementation would be faster!). We let REBOUND know which function we want to use by setting the `coefficient_of_restitution` function pointer in the simulation instance. "
+    "When two ring particles collide, they loose energy during their bounce. We here use a velocity dependent Bridges et al. coefficient of restitution. It is implemented as a python function (a C implementation would be faster!). We let REBOUND know which function we want to use by setting the `coefficient_of_restitution` function pointer in the simulation instance. "
    ]
   },
   {
@@ -221,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can finally add particles to REBOUND. Note that we initialize particles so that they have initially no velovity relative to the mean shear flow."
+    "Now we can finally add particles to REBOUND. Note that we initialize particles so that they have initially no velocity relative to the mean shear flow."
    ]
   },
   {
@@ -340,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Within just one orbital period, one can already see structure appearing on a scale close to the the Toomre critical wavelength. The simulation will eventually settle down in a turbulent state where clumps constantly form, but then get destroyed again after a short time. Permanent clumping cannot occur because particles are inside the Roche limit."
+    "Within just one orbital period, one can already see structure appearing on a scale close to the Toomre critical wavelength. The simulation will eventually settle down in a turbulent state where clumps constantly form, but then get destroyed again after a short time. Permanent clumping cannot occur because particles are inside the Roche limit."
    ]
   }
  ],

--- a/ipython_examples/ScreenshotsAndMoviesWithWebGL.ipynb
+++ b/ipython_examples/ScreenshotsAndMoviesWithWebGL.ipynb
@@ -7,11 +7,11 @@
     "# Screenshots and Movies with WebGL\n",
     "\n",
     "\n",
-    "One can use the REBOUND WebGL ipython widget to capture screenshots of a simualtion. These screenshots can then be easily compiled into a movie.\n",
+    "One can use the REBOUND WebGL ipython widget to capture screenshots of a simulation. These screenshots can then be easily compiled into a movie.\n",
     "\n",
     "The widget is using the ipywidgets package which needs to be installed and enabled. More information on this can be found in the ipywidgets documentation at https://ipywidgets.readthedocs.io/en/latest/user_install.html. You also need a browser and a graphics card that supports WebGL.\n",
     "\n",
-    "Note that this is a new feature and might not work an all systems. We've tested it on python 3.5.2."
+    "Note that this is a new feature and might not work on all systems. We've tested it on python 3.5.2."
    ]
   },
   {
@@ -82,7 +82,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This will not produce the desired outcome (in fact it will through an expection). The reason is complex. In short, `ipywidgets` provides no blocking calls to wait for updates of a widget because the widget updates make use of the ipython event loop which does not get run during an execution of a cell.\n",
+    "This will not produce the desired outcome (in fact it will through an exception). The reason is complex. In short, `ipywidgets` provides no blocking calls to wait for updates of a widget because the widget updates make use of the ipython event loop which does not get run during an execution of a cell.\n",
     "\n",
     "Thus, to capture multiple screenshots at different times, one either needs to take one screenshot per cell, or use the following more convenient way:"
    ]

--- a/ipython_examples/SimulationArchive.ipynb
+++ b/ipython_examples/SimulationArchive.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Simulation Archive\n",
-    "A Simulation Archive (Rein & Tamayo 2017) is useful when one runs long simulations. With the Simulation Archive, one can easily take snapshots of the simulation, and then later restart and analyize it. Since Spring 2018, the default Simulation Archive version is 2. Version 2 works with all integrators and very few restrictions that apply (you need to be careful when using function pointers)."
+    "A Simulation Archive (Rein & Tamayo 2017) is useful when one runs long simulations. With the Simulation Archive, one can easily take snapshots of the simulation, and then later restart and analyze it. Since Spring 2018, the default Simulation Archive version is 2. Version 2 works with all integrators and very few restrictions that apply (you need to be careful when using function pointers)."
    ]
   },
   {
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's first print the number of snapshots and the time of the first and last snaphot in the archive:"
+    "Let's first print the number of snapshots and the time of the first and last snapshot in the archive:"
    ]
   },
   {
@@ -216,7 +216,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above code, REBOUND looks up a nearby snaphot and then integrates the simulation forward in time to get close to the request time. As one can see, with `mode=\"close\"`, one gets a simulation very close to the request time, but it is still slightly off. This is because `WHFast` uses a fixed timestep. If we want to reach the requested time eactly, we have to change the timestep. Changing a timestep in a symplectic integrator can cause problems, but if one really wants to get a simulation object at the exact time (for example to match observations), then the `mode=\"exact\"` flag does that."
+    "In the above code, REBOUND looks up a nearby snapshot and then integrates the simulation forward in time to get close to the request time. As one can see, with `mode=\"close\"`, one gets a simulation very close to the request time, but it is still slightly off. This is because `WHFast` uses a fixed timestep. If we want to reach the requested time exactly, we have to change the timestep. Changing a timestep in a symplectic integrator can cause problems, but if one really wants to get a simulation object at the exact time (for example to match observations), then the `mode=\"exact\"` flag does that."
    ]
   },
   {
@@ -241,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Requesting a simulation at any time between `tmin` and `tmax` only takes a few seconds at most (keep in mind, REBOUND integrates the simulation from the nearest snaphot to the requested time). To analyze a large simulation, you might want to do this in parallel. We can easily do that by using REBOUND's `InterruptiblePool`. In the following example, we calculate the distance between the two planets at 432 times in the interval $[t_{min},t_{max}]$."
+    "Requesting a simulation at any time between `tmin` and `tmax` only takes a few seconds at most (keep in mind, REBOUND integrates the simulation from the nearest snapshot to the requested time). To analyze a large simulation, you might want to do this in parallel. We can easily do that by using REBOUND's `InterruptiblePool`. In the following example, we calculate the distance between the two planets at 432 times in the interval $[t_{min},t_{max}]$."
    ]
   },
   {

--- a/ipython_examples/SimulationArchiveRestart.ipynb
+++ b/ipython_examples/SimulationArchiveRestart.ipynb
@@ -89,7 +89,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to integrate the simulation further in time and append snapshots to the same SA, then we need to call the `automateSimulationArchive` method again (this is fail safe mechanism to avoid accidentally modifying a SA file). Note that we set the `deletefile` flag to `False`. Otherwise we would create a new empty SA file. This outputs a warning because the file already exists (which is ok since we want to append that file)."
+    "If we want to integrate the simulation further in time and append snapshots to the same SA, then we need to call the `automateSimulationArchive` method again (this is a fail-safe mechanism to avoid accidentally modifying a SA file). Note that we set the `deletefile` flag to `False`. Otherwise, we would create a new empty SA file. This outputs a warning because the file already exists (which is ok since we want to append that file)."
    ]
   },
   {
@@ -158,7 +158,7 @@
    "source": [
     "A few things to note when restarting a simulation from a SA: \n",
     "- If you used any additional forces or post-timestep modifications in the original simulation, then those need to be restored after loading a simulation from a SA. A RuntimeWarning may be given related to this indicating the need to reset function pointers after creating a reb_simulation struct with a binary file.\n",
-    "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsychronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that.\n",
+    "- If you use the symplectic WHFast integrator with the safe mode turned off, then the simulation will be in an unsynchronized state after reloading it. If you want to generate an output, then the simulation needs to be synchronized beforehand. See the WHFast tutorial on how to do that.\n",
     "- If you use the symplectic WHFast integrator with the safe mode turned off in order to combine kepler steps (see the Advanced WHFast tutorial), but want to preserve bitwise reproducibility when integrating to different times in the simulation or to match SimulationArchive snapshots, you need to manually set sim.ri_whfast.keep_unsynchronized = 1. This ensures that the integration state does not change depending on if and when you generate outputs.\n",
     "- For reproducibility, the SimulationArchive does not output snapshots at the *exact* intervals specified, but rather at the timestep in the integration directly following each interval. This means that if you load from a SimulationArchive and want to reproduce the state in a snapshot later on, you have to pass `exact_finish_time=0` in a call to `sim.integrate`."
    ]

--- a/ipython_examples/TransitTimingVariations.ipynb
+++ b/ipython_examples/TransitTimingVariations.ipynb
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We're now going to integrate the system forward in time. We assume the observer of the system is in the direction of the positive x-axis. We want to meassure the time when the inner planet transits. In this geometry, this happens when the y coordinate of the planet changes sign. Whenever we detect a change in sign between two steps, we try to find the transit time, which must lie somewhere within the last step, by bisection. "
+    "We're now going to integrate the system forward in time. We assume the observer of the system is in the direction of the positive x-axis. We want to measure the time when the inner planet transits. In this geometry, this happens when the y coordinate of the planet changes sign. Whenever we detect a change in sign between two steps, we try to find the transit time, which must lie somewhere within the last step, by bisection. "
    ]
   },
   {

--- a/ipython_examples/VariationalEquations.ipynb
+++ b/ipython_examples/VariationalEquations.ipynb
@@ -81,9 +81,9 @@
    "source": [
     "Running a simulation with variational equations is very easy. We start by creating a simulation and add the three particles (the star and two planets) just as before. Note that the `vary` convenience function we use below only accepts heliocentric coordinates, so we explicitly tell REBOUND that the star is the primary when adding particles to the simulation. \n",
     "\n",
-    "We then add variational particles to the simulation. We vary one paramter ($a$) and thus need only one set of first order variational equaitions. The second order variational equations depend on the first order ones. Thus, when initializing them, one has to pass the set of first order variational equations using the 'first_order' parameter.\n",
+    "We then add variational particles to the simulation. We vary one parameter ($a$) and thus need only one set of first order variational equations. The second order variational equations depend on the first order ones. Thus, when initializing them, one has to pass the set of first order variational equations using the 'first_order' parameter.\n",
     "\n",
-    "After adding a variation, one must always initialize it.  We do this below with REBOUND's `vary()` convenience function, which makes varying orbital parameters particularly easy. Alternatively, one can also initialize the variational particles directly, e.g. using  `var_da.particles[1].x = 1`. Note that variations are implemented as particles, but you they really represent derivatives of a particle's corrdinates with respect to some initial parameter. For more details, see Rein and Tamayo (2016).\n",
+    "After adding a variation, one must always initialize it.  We do this below with REBOUND's `vary()` convenience function, which makes varying orbital parameters particularly easy. Alternatively, one can also initialize the variational particles directly, e.g. using  `var_da.particles[1].x = 1`. Note that variations are implemented as particles, but you they really represent derivatives of a particle's coordinates with respect to some initial parameter. For more details, see Rein and Tamayo (2016).\n",
     "\n",
     "The function below does all that and returns the final position of the inner planet, as well as the first and second derivatives of the position with respect to $a$. "
    ]

--- a/ipython_examples/VariationalEquationsWithChainRule.ipynb
+++ b/ipython_examples/VariationalEquationsWithChainRule.ipynb
@@ -105,14 +105,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We could now run many different simulations to map out the parameter space. This is a very simple examlpe of a typical use case: the fitting of a radial velocity datapoint. "
+    "We could now run many different simulations to map out the parameter space. This is a very simple example of a typical use case: the fitting of a radial velocity datapoint. "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, we can be smarter than simple running an almost identical simulation over and over again by using variational equations. These will allow us to calculate the *derivate* of the stellar velocity at the end of the simulation. We can take derivative with respect to any of the initial conditions, i.e. a particles's mass, semi-major axis, x-coordinate, etc. Here, we want to take the derivative with respect to the semi-major axis of the outer planet. The following function does exactly that:"
+    "However, we can be smarter than simple running an almost identical simulation over and over again by using variational equations. These will allow us to calculate the *derivate* of the stellar velocity at the end of the simulation. We can take derivative with respect to any of the initial conditions, i.e. a particle's mass, semi-major axis, x-coordinate, etc. Here, we want to take the derivative with respect to the semi-major axis of the outer planet. The following function does exactly that:"
    ]
   },
   {
@@ -257,7 +257,7 @@
     "collapsed": true
    },
    "source": [
-    "Now that we know how to calculate first and second order derivates of positions and velocities of particles, we can simply use the chain rule to calculate more complicated derivates. For example, instead of the velocity $v_x$, you might be interested in the quanity $w\\equiv(v_x - c)^2$ where $c$ is a constant. This is something that typically appears in a $\\chi^2$ fit. The chain rule gives us:\n",
+    "Now that we know how to calculate first and second order derivates of positions and velocities of particles, we can simply use the chain rule to calculate more complicated derivates. For example, instead of the velocity $v_x$, you might be interested in the quantity $w\\equiv(v_x - c)^2$ where $c$ is a constant. This is something that typically appears in a $\\chi^2$ fit. The chain rule gives us:\n",
     "$$ \\frac{\\partial w}{\\partial a} = 2 \\cdot (v_x-c)\\cdot \\frac{\\partial v_x}{\\partial a}$$\n",
     "The variational equations provide the $\\frac{\\partial v_x}{\\partial a}$ part, the *ordinary* particles provide $v_x$."
    ]

--- a/ipython_examples/WHFast.ipynb
+++ b/ipython_examples/WHFast.ipynb
@@ -19,7 +19,7 @@
     "\n",
     "You can enter all the commands below into a file and execute it all at once, or open an interactive shell).\n",
     "\n",
-    "First, we need to import the REBOUND module (make sure have have enabled the virtual environment if you used it to install REBOUND)."
+    "First, we need to import the REBOUND module (make sure you have enabled the virtual environment if you used it to install REBOUND)."
    ]
   },
   {
@@ -394,7 +394,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Oops! This doesn't look like what we expected to see (small perturbations to an almost circluar orbit). What you see here is the barycenter slowly drifting. Some integration packages require that the simulation be carried out in a particular frame, but WHFast provides extra flexibility by working in any inertial frame.  If you recall how we added the particles, the Sun was at the origin and at rest, and then we added the planets.  This means that the center of mass, or barycenter, will have a small velocity, which results in the observed drift.  There are multiple ways we can get the plot we want to.\n",
+    "Oops! This doesn't look like what we expected to see (small perturbations to an almost circular orbit). What you see here is the barycenter slowly drifting. Some integration packages require that the simulation be carried out in a particular frame, but WHFast provides extra flexibility by working in any inertial frame.  If you recall how we added the particles, the Sun was at the origin and at rest, and then we added the planets.  This means that the center of mass, or barycenter, will have a small velocity, which results in the observed drift.  There are multiple ways we can get the plot we want to.\n",
     "1. We can calculate only relative positions.\n",
     "2. We can add the particles in the barycentric frame.\n",
     "3. We can let REBOUND transform the particle coordinates to the barycentric frame for us.\n",

--- a/ipython_examples/WebGLVisualization.ipynb
+++ b/ipython_examples/WebGLVisualization.ipynb
@@ -475,7 +475,7 @@
    "source": [
     "Drag the widget with your mouse or touchpad to look at the simulation from different angles. Keep the shift key pressed while you drag to zoom in or out.\n",
     "\n",
-    "Next, we will try to integrate the orbits forward in time. Because the planets are very massive and on close to each other, the system will go unstable very quickly. By default REBOUND is using the IAS15 integrator which can resolve close encounter. During each close encounter the instantaneous orbits of the planets show in the widget will change rapidly.  "
+    "Next, we will try to integrate the orbits forward in time. Because the planets are very massive and on close to each other, the system will go unstable very quickly. By default, REBOUND is using the IAS15 integrator which can resolve close encounter. During each close encounter the instantaneous orbits of the planets show in the widget will change rapidly.  "
    ]
   },
   {
@@ -513,7 +513,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "One can also preset the scale and the orientation of the view, which can be useful for constructing multple widgets at the same time that allows us to view the system from different angles."
+    "One can also preset the scale and the orientation of the view, which can be useful for constructing multiple widgets at the same time that allows us to view the system from different angles."
    ]
   },
   {
@@ -535,7 +535,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In case you're wondering, the orientation parameter above expects the x, y, z, and w components of a quaternion. If we now integrate the system a little further, all widgets will be updated at the same time, giving you an instantaneous idea of the three dimensional evolution of the system."
+    "In case you're wondering, the orientation parameter above expects the x, y, z, and w components of a quaternion. If we now integrate the system a little further, all widgets will be updated at the same time, giving you an instantaneous idea of the three-dimensional evolution of the system."
    ]
   },
   {

--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -70,7 +70,7 @@ class Particle(Structure):
         Whenever initializing a particle from orbital elements, one must 
         specify either the semimajor axis or the period of the orbit.
         
-        For classical orbital paramerers, one can specify the longitude 
+        For classical orbital parameters, one can specify the longitude 
         of the ascending node by passing Omega, to specify the pericenter 
         one can pass either omega or pomega (not both), and for the 
         longitude/anomaly one can pass one of f, M, l or theta.  

--- a/rebound/plotting.py
+++ b/rebound/plotting.py
@@ -26,7 +26,7 @@ def OrbitPlot(sim, figsize=None, fancy=False, slices=0, xlim=None, ylim=None, un
     periastron  : bool, optional            
         Draw a marker at periastron (default: False)
     orbit_type       : str, optional
-        This argument determines the type of orbit show. By default it shows the orbit as a trailing and fading line ("trail"). Other object are: "solid", None.
+        This argument determines the type of orbit show. By default, it shows the orbit as a trailing and fading line ("trail"). Other object are: "solid", None.
     lw              : float, optional           
         Linewidth used in plots (default: 1.)
     plotparticles   : list, optional

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -113,9 +113,9 @@ class reb_simulation_integrator_sei(Structure):
     :ivar float OMEGA:          
         The epicyclic frequency OMEGA. For simulations making use of shearing 
         sheet boundary conditions, REBOUND needs to know the epicyclic frequency. 
-        By default OMEGA is 1. For more details read Rein and Tremaine 2011.
+        By default, OMEGA is 1. For more details read Rein and Tremaine 2011.
     :ivar float OMEGAZ:          
-        The z component of the epicyclic frequency OMEGA. By default it is assuming
+        The z component of the epicyclic frequency OMEGA. By default, it is assuming
         OMEGAZ is the same as OMEGA.
     """
     _fields_ = [("OMEGA", c_double),
@@ -249,12 +249,12 @@ class reb_simulation_integrator_whfast(Structure):
     
     :ivar int corrector:      
         The order of the symplectic corrector in the WHFast integrator.
-        By default the symplectic correctors are turned off (=0). For high
+        By default, the symplectic correctors are turned off (=0). For high
         accuracy simulation set this value to 11 or 17. For more details read 
         Rein and Tamayo (2015).
     :ivar int corrector2:      
         Second correctors (C2 of Wisdom et al 1996).
-        By default the second symplectic correctors are turned off (=0). 
+        By default, the second symplectic correctors are turned off (=0). 
         Set to 1 to turn them on.
     :ivar int/string kernel:      
         Kernel option. Set to 0 for the default WH kernel (standard kick step).
@@ -264,7 +264,7 @@ class reb_simulation_integrator_whfast(Structure):
         Setting this flag to 1 (default 0) triggers the WHFast integrator
         to recalculate Jacobi/heliocenctric coordinates. This is needed 
         if the user changes the particle position, velocity or mass 
-        inbetween timesteps.  After every timestep the flag is set back 
+        in-between timesteps.  After every timestep the flag is set back 
         to 0, so if you continuously update the particles manually, 
         you need to set this flag to 1 after every timestep.
     :ivar string coordinates:
@@ -429,7 +429,7 @@ class Simulation(Structure):
 
     This object encapsulated an entire REBOUND simulation. 
     It is an abstraction of the C struct reb_simulation.
-    You can create mutiple REBOUND simulations (the c library is thread safe). 
+    You can create multiple REBOUND simulations (the c library is thread safe). 
 
     Examples
     --------
@@ -510,7 +510,7 @@ class Simulation(Structure):
 
     @classmethod
     def from_file(cls, filename):
-        """ rebound.Simulation.from_file(filename) is deprecated and will be removed in the futute. Use rebound.Simulation(filename) instead """
+        """ rebound.Simulation.from_file(filename) is deprecated and will be removed in the future. Use rebound.Simulation(filename) instead """
         warnings.warn( "rebound.Simulation.from_file(filename) is deprecated and will be removed in the future. Use rebound.Simulation(filename) instead", FutureWarning)
         return cls(filename=filename)
     
@@ -552,7 +552,7 @@ class Simulation(Structure):
         """
         Wrapper function that returns a new widget attached to this simulation.
 
-        Widgets provide real-time 3D visualizations from within an Jupyter notebook.
+        Widgets provide real-time 3D visualizations from within a Jupyter notebook.
         See the Widget class for more details on the possible arguments.
         
         
@@ -607,7 +607,7 @@ class Simulation(Structure):
 # Simulation Archive tools
     def automateSimulationArchive(self, filename, interval=None, walltime=None, step=None, deletefile=False):
         """
-        This function automates taking snapshots during a simulationusing the Simulation Archive.
+        This function automates taking snapshots during a simulation using the Simulation Archive.
         Instead of using this function, one can also call simulationarchive_snapshot() manually
         to create snapshots.
 
@@ -838,7 +838,7 @@ class Simulation(Structure):
         The argument can be a python function or something that can 
         be cast to a C function of type CFUNCTYPE(None,POINTER(Simulaton)). 
         If the forces are velocity dependent, the flag 
-        force_is_velocity_dependent needs to be set to 1. Otherwise
+        force_is_velocity_dependent needs to be set to 1. Otherwise,
         the particle structures might contain incorrect velocity 
         values.
         """
@@ -931,7 +931,7 @@ class Simulation(Structure):
         Possible options for setting:
           1) Function pointer
           2) "merge": two colliding particles will merge) 
-          3) "hardsphere": two colliding particles will bounce of using a set coefficient of restitution
+          3) "hardsphere": two colliding particles will bounce off using a set coefficient of restitution
         """
         raise AttributeError("You can only set C function pointers from python.")
     @collision_resolve.setter
@@ -968,7 +968,7 @@ class Simulation(Structure):
     @property
     def integrator(self):
         """
-        Get or set the intergrator module.
+        Get or set the integrator module.
 
         Available integrators include:
 
@@ -1186,11 +1186,11 @@ class Simulation(Structure):
     def convert_particle_units(self, *args): 
         """
         Will convert the units for the simulation (i.e. convert G) as well as the particles' cartesian elements.
-        Must have set sim.units ahead of calling this function so REBOUND knows what units to convert from.
+        Must have set sim.units ahead of calling this function, so REBOUND knows what units to convert from.
 
         Parameters
         ----------
-        3 strings corresponding to units of time, length and mass.  Can be in any order and aren't case sensitive.        You can add new units to rebound/rebound/units.py
+        3 strings corresponding to units of time, length and mass.  Can be in any order and aren't case-sensitive.        You can add new units to rebound/rebound/units.py
         """
         if self.python_unit_l == 0 or self.python_unit_m == 0 or self.python_unit_t == 0:
             raise AttributeError("Must set sim.units before calling convert_particle_units in order to know what units to convert from.")
@@ -1214,12 +1214,12 @@ class Simulation(Structure):
         Parameters
         ----------
         order : integer, optional
-            By default the function adds a set of first order variational particles to the simulation. Set this flag to 2 for second order.
+            By default, the function adds a set of first order variational particles to the simulation. Set this flag to 2 for second order.
         first_order : Variation, optional
             Second order variational equations depend on their corresponding first order variational equations. 
             This parameter expects the Variation object corresponding to the first order variational equations. 
         first_order_2 : Variation, optional
-            Same as first_order. But allows to set two different indicies to calculate off-diagonal elements. 
+            Same as first_order. But allows to set two different indicies to calculated off-diagonal elements. 
             If omitted, then first_order will be used for both first order equations.
         testparticle : int, optional
             If set to a value >= 0, then only one variational particle will be added and be treated as a test particle.
@@ -1423,8 +1423,8 @@ class Simulation(Structure):
 # Orbit calculation
     def calculate_orbits(self, primary=None, jacobi_masses=False, heliocentric=None, barycentric=None):
         """ 
-        Calculate orbital parameters for all partices in the simulation.
-        By default this functions returns the orbits in Jacobi coordinates. 
+        Calculate orbital parameters for all particles in the simulation.
+        By default, this functions returns the orbits in Jacobi coordinates. 
 
         If MEGNO is enabled, variational particles will be ignored.
 
@@ -1529,7 +1529,7 @@ class Simulation(Structure):
         Note that this routine is only intended for special use cases
         where speed is an issue. For normal use, it is recommended to
         access particle data via the `sim.particles` array. Be aware of
-        potential issues that arrise by directly accesing the memory of
+        potential issues that arise by directly accesing the memory of
         numpy arrays (see numpy documentation for more details).
 
         Examples
@@ -1622,7 +1622,7 @@ class Simulation(Structure):
         """
         This function moves all particles in the simulation to the heliocentric frame.
         Note that the simulation will not stay in the heliocentric frame during integrations
-        as the heliocentric frame is not an innertial frame.
+        as the heliocentric frame is not an inertial frame.
         """
         clibrebound.reb_move_to_hel(byref(self))
     
@@ -1631,7 +1631,7 @@ class Simulation(Structure):
         This function moves all particles in the simulation to a center of momentum frame.
         In that frame, the center of mass is at the origin and does not move.
         It makes sense to call this function at the beginning of the integration, especially 
-        for the high accuray integrators IAS15 and WHFast.
+        for the high accuracy integrators IAS15 and WHFast.
         """
         clibrebound.reb_move_to_com(byref(self))
     
@@ -1664,7 +1664,7 @@ class Simulation(Structure):
         root_nx, root_ny, root_nz : int, optional
             The number of root boxes in each direction. The total size of the simulation box
             will be ``root_nx * boxsize``, ``root_ny * boxsize`` and ``root_nz * boxsize``.
-            By default there will be exactly one root box in each direction.
+            By default, there will be exactly one root box in each direction.
         """
         clibrebound.reb_configure_box(byref(self), c_double(boxsize), c_int(root_nx), c_int(root_ny), c_int(root_nz))
         return
@@ -1758,7 +1758,7 @@ class Simulation(Structure):
 
     def integrator_synchronize(self):
         """
-        Call this function if safe-mode is disabled and you need synchronize particle positions and velocities between timesteps.
+        Call this function if safe-mode is disabled and you need to synchronize particle positions and velocities between timesteps.
         """
         clibrebound.reb_integrator_synchronize(byref(self))
     
@@ -1783,7 +1783,7 @@ class Variation(Structure):
     variational equations.
 
     Note that variations are only encoded as particles for convenience.  
-    A variational particle's position and velocity should be interpreted as a derivative, i.e. how much that position orvelocity varies with respect to the first or second-order variation.  
+    A variational particle's position and velocity should be interpreted as a derivative, i.e. how much that position or velocity varies with respect to the first or second-order variation.  
     See ipython_examples/VariationalEquations.ipynb and Rein and Tamayo (2016) for details.
 
     Examples
@@ -1846,7 +1846,7 @@ class Variation(Structure):
         variation2: string, optional
             This is only used for second order variations which can depend on two varying parameters. If omitted, then it is assumed that the parameter variation is variation2.
         primary: Particle, optional
-            By default variational particles are created in the Heliocentric frame. 
+            By default, variational particles are created in the Heliocentric frame. 
             Set this parameter to use any other particles as a primary (e.g. the center of mass).
         """
         if self.order==2 and variation2 is None:
@@ -1918,7 +1918,7 @@ class reb_simulation_integrator_eos(Structure):
     :ivar int n     
         Sets the number of substeps taken by Phi_1
     :ivar int safe_mode  
-        By default safe_mode is on (1). Set to 0 (off) to combine
+        By default, safe_mode is on (1). Set to 0 (off) to combine
         drift step at the beginning and end of the Phi0 integrator steps.
 
     Example usage:

--- a/rebound/simulationarchive.py
+++ b/rebound/simulationarchive.py
@@ -18,13 +18,13 @@ class SimulationArchive(Structure):
     (down to the last bit). The SimulationArchive allows you to add
     an arbitrary number of snapshots. Simulations can be reconstructed
     from these snapshots. Since version 2 of the SimulationArchive
-    (Spring 2018), you can change anything inbetween snapshots,
-    icluding settings like the integrator, the timestep, the number of
+    (Spring 2018), you can change anything in-between snapshots,
+    including settings like the integrator, the timestep, the number of
     particles. The file format is efficient in that only data
     that changed is stored in the SimulationArchive file. This is all
     done automatically. All the user has to do is call the function
     to create a snapshot.
-    The SimulationArchive thus allows for fast access to any long running 
+    The SimulationArchive thus allows for fast access to any long-running 
     simulations. For a full discussion of the functionality see the paper 
     by Rein & Tamayo 2017.
 
@@ -260,9 +260,9 @@ class SimulationArchive(Structure):
         This function returns array that can be used as a Cubic Bezier
         Path in matplotlib. 
         The function returns two arrays, the first one contains
-        the verticies for each particles and has the shape
-        (Nvert, Nparticles, 2) where Nvert is the number of verticies.
-        The second array returned describes the type of verticies to be
+        the vertices for each particle and has the shape
+        (Nvert, Nparticles, 2) where Nvert is the number of vertices.
+        The second array returned describes the type of vertices to be
         used with matplotlib's Patch class.
 
         Arguments
@@ -278,7 +278,7 @@ class SimulationArchive(Structure):
         Examples
         --------
         The following example reads in a SimulationArchive and plots
-        the trajectories as Cubic Bezier Curves. It also plots the 
+        the trajectories as Cubic Bézier Curves. It also plots the 
         actual datapoints stored in the SimulationArchive. 
         Note that the SimulationArchive needs to have enough
         datapoints to allow for smooth and reasonable orbits.

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -171,7 +171,7 @@ struct reb_simulation_integrator_ias15 {
      * @brief This parameter controls the order of operations.
      * @details The order of floating point operations can affect the long term energy error. In the original version of IAS15, 
      * the order of floating point operations leads to a linear energy error growth when a fixed timestep is used (Hernandez + Holman 2019).
-     * By default this parameter is now set to 1 which uses a different order and thus avoids this issue. Note that using IAS15 as a 
+     * By default, this parameter is now set to 1 which uses a different order and thus avoids this issue. Note that using IAS15 as a 
      * non-adaptive integrator is rarely beneficial. This flag only exists to allow for backwards compatibility. All new simulations should 
      * use neworder=1.
      **/
@@ -232,8 +232,8 @@ struct reb_simulation_integrator_mercurius {
     
     /** 
      * @brief Switching distance in units of the Hill radius 
-     * @brief The switching distances for particles are calculated automastically
-     * based on multiple criteria. One criteria calculates the Hill radius of 
+     * @brief The switching distances for particles are calculated automatically
+     * based on multiple criteria. One criterion calculates the Hill radius of 
      * particles and then multiplies it with the hillfac variable. 
      */ 
     double hillfac;        
@@ -249,9 +249,9 @@ struct reb_simulation_integrator_mercurius {
 
     /** 
      * @brief Setting this flag to one will recalculate the critical switchover 
-     * distances dcrit at the the beginning of the next timestep. 
+     * distances dcrit at the beginning of the next timestep. 
      * @details After one timestep, the flag gets set back to 0. 
-     * If you want to recalculate dcrit at every every timestep, you 
+     * If you want to recalculate dcrit at every timestep, you 
      * also need to set this flag to 1 before every timestep.
      * Default is 0.
      */ 
@@ -337,7 +337,7 @@ struct reb_simulation_integrator_saba {
     unsigned int safe_mode;       ///< Safe_mode has the same functionality as in WHFast.
     unsigned int is_synchronized; ///< Flag to determine if current particle structure is synchronized
     /**
-     * @brief Flaf that determines if the inertial coordinates generated are discared in subsequent timesteps (Jacobi coordinates are used instead).
+     * @brief Flaf that determines if the inertial coordinates generated are discarded in subsequent timesteps (Jacobi coordinates are used instead).
      * @details Danger zone! Only use this flag if you are absolutely sure
      * what you are doing. This is intended for
      * simulation which have to be reproducible on a bit by bit basis.
@@ -454,7 +454,7 @@ struct reb_simulation_integrator_whfast {
 };
 
 /**
- * @brief Available opperator splitting methods for phi0 and phi1 in EOS integrators.
+ * @brief Available operator splitting methods for phi0 and phi1 in EOS integrators.
  */
 enum REB_EOS_TYPE {
     REB_EOS_LF = 0x00,      // 2nd order, standard leap-frog
@@ -472,8 +472,8 @@ enum REB_EOS_TYPE {
  * @brief This structure contains variables used by the EOS integrator family.
  */
 struct reb_simulation_integrator_eos {
-    enum REB_EOS_TYPE phi0;         ///< Outer opperator splitting scheme
-    enum REB_EOS_TYPE phi1;         ///< Inner opperator splitting scheme
+    enum REB_EOS_TYPE phi0;         ///< Outer operator splitting scheme
+    enum REB_EOS_TYPE phi1;         ///< Inner operator splitting scheme
     unsigned int n;                 ///
 
     unsigned int safe_mode;         ///< If set to 0, always combine drift steps at the beginning and end of phi0. If set to 1, n needs to be bigger than 1.
@@ -557,10 +557,10 @@ struct reb_collision{
  */
 enum REB_STATUS {
     REB_RUNNING_PAUSED = -3,    ///< Simulation is paused by visualization.
-    REB_RUNNING_LAST_STEP = -2, ///< Current timestep is the last one. Needed to ensures that t=tmax exactly.
-    REB_RUNNING = -1,           ///< Simulation is current running, no error occured.
+    REB_RUNNING_LAST_STEP = -2, ///< Current timestep is the last one. Needed to ensure that t=tmax exactly.
+    REB_RUNNING = -1,           ///< Simulation is current running, no error occurred.
     REB_EXIT_SUCCESS = 0,       ///< Integration finished successfully.
-    REB_EXIT_ERROR = 1,         ///< A generic error occured and the integration was not successfull.
+    REB_EXIT_ERROR = 1,         ///< A generic error occurred and the integration was not successful.
     REB_EXIT_NOPARTICLES = 2,   ///< The integration ends early because no particles are left in the simulation.
     REB_EXIT_ENCOUNTER = 3,     ///< The integration ends early because two particles had a close encounter (see exit_min_distance)
     REB_EXIT_ESCAPE = 4,        ///< The integration ends early because a particle escaped (see exit_max_distance)  
@@ -585,8 +585,8 @@ struct reb_variational_configuration{
     int order;                  ///< Order of the variational equation. 1 or 2. 
     int index;                  ///< Index of the first variational particle in the particles array.
     int testparticle;           ///< Is this variational configuration describe a test particle? -1 if not.
-    int index_1st_order_a;      ///< Used for 2nd order variational particles only: Index of the first first order variational particle in the particles array.
-    int index_1st_order_b;      ///< Used for 2nd order variational particles only: Index of the first first order variational particle in the particles array.
+    int index_1st_order_a;      ///< Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
+    int index_1st_order_b;      ///< Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
 };
 
 /**
@@ -1050,13 +1050,13 @@ struct reb_simulation {
      */
     void (*display_heartbeat) (struct reb_simulation* r);
     /**
-     * @brief Return the coefficient of restitution. By default it is NULL, assuming a coefficient of 1.
+     * @brief Return the coefficient of restitution. By default, it is NULL, assuming a coefficient of 1.
      * @details The velocity of the collision is given to allow for velocity dependent coefficients
      * of restitution.
      */
     double (*coefficient_of_restitution) (const struct reb_simulation* const r, double v); 
     /**
-     * @brief Resolve collision within this function. By default it is NULL, assuming hard sphere model.
+     * @brief Resolve collision within this function. By default, it is NULL, assuming hard sphere model.
      * @details A return value of 0 indicates that both particles remain in the simulation. A return value of 1 (2) indicates that particle 1 (2) should be removed from the simulation. A return value of 3 indicates that both particles should be removed from the simulation. 
      */
     int (*collision_resolve) (struct reb_simulation* const r, struct reb_collision);
@@ -1092,7 +1092,7 @@ struct reb_simulation {
 /**
  * @brief Creates and initialises a REBOUND simulation
  * @details Allocate memory for one reb_simulation structure, initialise all variables 
- * and returni the pointer to the reb_simulation sructure. This function must be called 
+ * and return the pointer to the reb_simulation structure. This function must be called 
  * before any particles are added.
  */
 struct reb_simulation* reb_create_simulation(void);
@@ -1124,7 +1124,7 @@ int reb_diff_simulations(struct reb_simulation* r1, struct reb_simulation* r2, i
 void reb_init_simulation(struct reb_simulation* r);
 
 /**
- * @brief Performon one integration step
+ * @brief Perform one integration step
  * @details You rarely want to call this function yourself.
  * Use reb_integrate instead.
  * @param r The rebound simulation to be integrated by one step.
@@ -1163,9 +1163,9 @@ void reb_integrator_reset(struct reb_simulation* r);
  * Call this function when using open, periodic or shear periodic boundary conditions.
  * @param r The rebound simulation to be considered
  * @param boxsize The size of the root box
- * @param root_nx The numbe rof root boxes in the x direction.
- * @param root_ny The numbe rof root boxes in the y direction.
- * @param root_nz The numbe rof root boxes in the z direction.
+ * @param root_nx The number of root boxes in the x direction.
+ * @param root_ny The number of root boxes in the y direction.
+ * @param root_nz The number of root boxes in the z direction.
  */
 void reb_configure_box(struct reb_simulation* const r, const double boxsize, const int root_nx, const int root_ny, const int root_nz);
 
@@ -1388,12 +1388,12 @@ struct reb_particle reb_get_com_of_pair(struct reb_particle p1, struct reb_parti
  * @details This function can be used to quickly access particle data in a serialized form.
  * NULL pointers will not be set.
  * @param r The rebound simulation to be considered
- * @param hash 1D array to to hold particle hashes
- * @param mass 1D array to to hold particle masses
- * @param radius 1D array to to hold particle radii
- * @param xyz 3D array to to hold particle positions
- * @param vxvyvz 3D array to to hold particle velocities
- * @param xyzvxvyvz 3D array to to hold particle positions and velocities
+ * @param hash 1D array to hold particle hashes
+ * @param mass 1D array to hold particle masses
+ * @param radius 1D array to hold particle radii
+ * @param xyz 3D array to hold particle positions
+ * @param vxvyvz 3D array to hold particle velocities
+ * @param xyzvxvyvz 3D array to hold particle positions and velocities
 */
 void reb_serialize_particle_data(struct reb_simulation* r, uint32_t* hash, double* m, double* radius, double (*xyz)[3], double (*vxvyvz)[3], double (*xyzvxvyvz)[6]);
 
@@ -1402,12 +1402,12 @@ void reb_serialize_particle_data(struct reb_simulation* r, uint32_t* hash, doubl
  * @details This function can be used to quickly set particle data in a serialized form.
  * NULL pointers will not be accessed.
  * @param r The rebound simulation to be considered
- * @param hash 1D array to to hold particle hashes
- * @param mass 1D array to to hold particle masses
- * @param radius 1D array to to hold particle radii
- * @param xyz 3D array to to hold particle positions
- * @param vxvyvz 3D array to to hold particle velocities
- * @param xyzvxvyvz 3D array to to hold particle positions and velocities
+ * @param hash 1D array to hold particle hashes
+ * @param mass 1D array to hold particle masses
+ * @param radius 1D array to hold particle radii
+ * @param xyz 3D array to hold particle positions
+ * @param vxvyvz 3D array to hold particle velocities
+ * @param xyzvxvyvz 3D array to hold particle positions and velocities
 */
 void reb_set_serialized_particle_data(struct reb_simulation* r, uint32_t* hash, double* m, double* radius, double (*xyz)[3], double (*vxvyvz)[3], double (*xyzvxvyvz)[6]);
 
@@ -1573,7 +1573,7 @@ struct reb_particle reb_tools_orbit2d_to_particle(double G, struct reb_particle 
  * @param Omega Longitude of the ascending node of the particle.
  * @param omega argument of pericenter of the particle.
  * @param f true anomaly of the particle.
- * @param err Pointer to error code that wil be set by this function. Used for checking why particle was set to nans.
+ * @param err Pointer to error code that will be set by this function. Used for checking why particle was set to nans.
  * @return Returns a particle structure with the given orbital parameters. 
  */
 struct reb_particle reb_tools_orbit_to_particle_err(double G, struct reb_particle primary, double m, double a, double e, double i, double Omega, double omega, double f, int* err);
@@ -1634,7 +1634,7 @@ struct reb_particle reb_tools_pal_to_particle(double G, struct reb_particle prim
 /**
  * @brief Reads a binary file.
  * @details Also initialises the particles array with data form the binary file.
- * This can be used to restart a simualtion.
+ * This can be used to restart a simulation.
  * @param filename Filename to be read.
  * @return Returns a pointer to a REBOUND simulation.
  */
@@ -1711,7 +1711,7 @@ int reb_read_int(int argc, char** argv, const char* argument, int _default);
  * @return The derivative as a particle structre. Each structure element is a derivative.
  * @param G The gravitational constant
  * @param primary The primary of the Keplerian orbit
- * @param po The original partical for which the derivative is to be calculated.
+ * @param po The original particle for which the derivative is to be calculated.
  */
 struct reb_particle reb_derivatives_lambda(double G, struct reb_particle primary, struct reb_particle po);
 struct reb_particle reb_derivatives_h(double G, struct reb_particle primary, struct reb_particle po);
@@ -1842,7 +1842,7 @@ void reb_create_simulation_from_simulationarchive_with_messages(struct reb_simul
  * @details This function opens a SimulationArchive file and creates an index to 
  * find snapshots within the file. This may take a few seconds if there are many 
  * snapshots in the file. Note that opening a file on a slow filesystem (for example
- * via a network) might be partiucularly slow. The file is kept open until 
+ * via a network) might be particularly slow. The file is kept open until 
  * the user calls reb_close_simulationarchive.
  * @param filename The path and filename of the SimulationArchive input file.
  * @return Returns a reb_simulationarchive struct.

--- a/style.txt
+++ b/style.txt
@@ -1,7 +1,7 @@
 Style Guide
 ===========
 
-This is a short source code style guide for REBOUND. It is not enforced in any way an only itended to be a suggestion.
+This is a short source code style guide for REBOUND. It is not enforced in any way and only intended to be a suggestion.
 
 Functions (c)
 -------------
@@ -16,7 +16,7 @@ Variables (c)
 -------------
 
 * The function naming convention rules apply.
-* The only public variables are in structs. Therefore they do not have the reb_ prefix.
+* The only public variables are in structs. Therefore, they do not have the reb_ prefix.
 * As an exception to the lower case rule: the number of particle N is capitalized.
 * Variables beginning with an underscore are not intended for general use.
 


### PR DESCRIPTION
I found some typos when reading through the docs, so I decided to quickly check all of them using [languagetool](https://languagetool.org/) (or rather [pylanguagetool](https://pylanguagetool.lw1.at/) which supports rst and ipynb files directly).