### PR TITLE
modification to mercurius so massless test-particle encounters don't affect planet evolution

### DIFF
--- a/src/integrator_mercurius.c
+++ b/src/integrator_mercurius.c
@@ -160,7 +160,7 @@ static void reb_mercurius_encounter_predict(struct reb_simulation* const r){
     rim->encounterN = 1;
     rim->encounter_map[0] = 1;
     rim->tponly_encounter = 1;
-	 for (int i=1; i<N; i++){
+    for (int i=1; i<N; i++){
         rim->encounter_map[i] = 0;
     }
     for (int i=0; i<N_active; i++){

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -271,11 +271,13 @@ struct reb_simulation_integrator_mercurius {
     unsigned int mode;              ///< Internal. 0 if WH is operating, 1 if IAS15 is operating.
     unsigned int encounterN;        ///< Number of particles currently having an encounter
     unsigned int encounterNactive;  ///< Number of particles currently having an encounter
+    unsigned int tponly_encounter; ///< Flag to determine if any of the encounters are between two massive bodies (0) or only involve test particles (1)
     unsigned int allocatedN;        ///< Current size of allocated internal arrays
     unsigned int allocatedN_additionalforces;        ///< Current size of allocated internal particles_backup_additionalforces array
     unsigned int dcrit_allocatedN;  ///< Current size of dcrit arrays
     double* dcrit;                  ///< Switching radii for particles
-    struct reb_particle* REBOUND_RESTRICT particles_backup;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
+    struct reb_particle* REBOUND_RESTRICT particles_post;     ///< Internal array, contains coordinates after Kepler step for encounter prediction
+	 struct reb_particle* REBOUND_RESTRICT particles_backup;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
     struct reb_particle* REBOUND_RESTRICT particles_backup_additionalforces;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
     int* encounter_map;             ///< Map to represent which particles are integrated with ias15
     struct reb_vec3d com_pos;       ///< Used internally to keep track of the centre of mass during the timestep

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -277,7 +277,7 @@ struct reb_simulation_integrator_mercurius {
     unsigned int dcrit_allocatedN;  ///< Current size of dcrit arrays
     double* dcrit;                  ///< Switching radii for particles
     struct reb_particle* REBOUND_RESTRICT particles_post;     ///< Internal array, contains coordinates after Kepler step for encounter prediction
-	 struct reb_particle* REBOUND_RESTRICT particles_backup;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
+    struct reb_particle* REBOUND_RESTRICT particles_backup;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
     struct reb_particle* REBOUND_RESTRICT particles_backup_additionalforces;     ///< Internal array, contains coordinates before Kepler step for encounter prediction
     int* encounter_map;             ///< Map to represent which particles are integrated with ias15
     struct reb_vec3d com_pos;       ///< Used internally to keep track of the centre of mass during the timestep


### PR DESCRIPTION
A common use-case for hybrid integrators is integrating large sets of massless test particles with a system of massive bodies. It is useful for the evolution of the planets starting from a single set of initial conditions to remain identical even when different sets of test particles are evolved (for example, when you want to integrate thousands of test particles by spitting them across many rebound instances on a cluster). However, the fact that the test particles can trigger the close-encounter routine means that they do change the planet evolution even when they are massless (example plot of changes in Jupiter's mean anomaly attached). This can cause small problems (e.g., the planet phases between different instances are different, so you have to be careful when calculating phase-dependent properties like resonant angles to not combine data across different runs) or large problems (e.g., you're trying to study how planet migration affects the Kuiper belt using artificially induced migration plus test particles; a set of initial conditions and migration parameters that ends with acceptable giant planet orbits with one set of test particles could end with ejected ice giants for a different set of particles because a small phase-shift led to an unfavorable resonance crossing between the giant planets).

I have made some small changes to mercurius to prevent the test particles from affecting the planets by reverting the planet states at the end of a close-encounter step to the already-calculated post-kepler step states if there are no close encounters between bodies with mass (if the test particles have mass, or the encounters involve two planets, then the planet evolution from the close-encounter routine is kept!). This fixes the problems described above. (Though I have not yet tested this implementation with additional forces to make sure it doesn't change how those behave).


![delta-ma](https://user-images.githubusercontent.com/18192573/107443015-401b6100-6af5-11eb-9c1d-2cfd5a47ba56.png)

  