### PR TITLE
use immutable default arguments

### DIFF
--- a/rebound/plotting.py
+++ b/rebound/plotting.py
@@ -3,7 +3,7 @@ import math
 from .particle import Particle
 from itertools import cycle
 
-def OrbitPlot(sim, figsize=None, fancy=False, slices=0, xlim=None, ylim=None, unitlabel=None, color=False, periastron=False, orbit_type="trail", lw=1., plotparticles=[], primary=None, Narc=128):
+def OrbitPlot(sim, figsize=None, fancy=False, slices=0, xlim=None, ylim=None, unitlabel=None, color=False, periastron=False, orbit_type="trail", lw=1., plotparticles=None, primary=None, Narc=128):
     """
     Convenience function for plotting instantaneous orbits.
 
@@ -60,6 +60,8 @@ def OrbitPlot(sim, figsize=None, fancy=False, slices=0, xlim=None, ylim=None, un
         import numpy as np
     except:
         raise ImportError("Error importing matplotlib and/or numpy. Plotting functions not available. If running from within a jupyter notebook, try calling '%matplotlib inline' beforehand.")
+    if not plotparticles:
+        plotparticles = []
     if unitlabel is not None:
         unitlabel = " " + unitlabel
     else:
@@ -199,12 +201,14 @@ def fading_line(x, y, color='black', alpha=1, fading=True, fancy=False, **kwargs
     lc = LineCollection(segments, color=colors, **kwargs)
     return lc
 
-def OrbitPlotOneSlice(sim, ax, Narc=128, color=False, periastron=False, orbit_type="trial", lw=1., axes="xy", plotparticles=[], primary=None, fancy=False, xlim=None, ylim=None):
+def OrbitPlotOneSlice(sim, ax, Narc=128, color=False, periastron=False, orbit_type="trial", lw=1., axes="xy", plotparticles=None, primary=None, fancy=False, xlim=None, ylim=None):
     import matplotlib.pyplot as plt
     from matplotlib.collections import LineCollection
     import numpy as np
     import random
 
+    if not plotparticles:
+        plotparticles = []
     #ax.set_aspect("equal")
     p_orb_pairs = []
     if not plotparticles:


### PR DESCRIPTION
This is a fun issue I only recently learned about:
https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

If you have a function and you specify a mutable value as a default argument only one such object (here a list) is created when the function is defined and if the function would e.g. append to this list, every call of the function would append to the same list.

As the variable is only overridden and not modified it should not have mattered, but just in case someone changes the code in the future.