### PR TITLE
Corrupt

### DIFF
--- a/rebound/tests/test_simulationarchive.py
+++ b/rebound/tests/test_simulationarchive.py
@@ -546,7 +546,7 @@ class TestSimulationArchiveMercurius(unittest.TestCase):
         sim.integrate(3001)
         with open('simulationarchive.bin', 'r+b') as f:
             f.seek(15900)
-            f.write(bytes("Overwriting binary file with a bunch of garbage. Overwriting binary file with a bunch of garbage. Overwriting binary file with a bunch of garbage.", 'utf-8'))
+            f.write(bytes(72)) # binary should be 15972 bytes, overwrite last 72 bytes with all zeros
         sa = rebound.SimulationArchive("simulationarchive.bin")
         sim = sa[-1]
         sim.automateSimulationArchive("simulationarchive.bin", interval=1000)

--- a/rebound/tests/test_simulationarchive.py
+++ b/rebound/tests/test_simulationarchive.py
@@ -535,9 +535,24 @@ class TestSimulationArchiveMercurius(unittest.TestCase):
         x0 = sim.particles[1].x
 
         self.assertEqual(x0,x1)
+
+    def test_append_to_corrupt_snapshot(self):
+        sim = rebound.Simulation()
+        sim.add(m=1.)
+        sim.add(m=1e-3,a=1.)
+        sim.add(m=5e-3,a=2.25)
     
-    
-    
+        sim.automateSimulationArchive("simulationarchive.bin", interval=1000,deletefile=True) 
+        sim.integrate(3001)
+        with open('simulationarchive.bin', 'r+b') as f:
+            f.seek(15900)
+            f.write(bytes("Overwriting binary file with a bunch of garbage. Overwriting binary file with a bunch of garbage. Overwriting binary file with a bunch of garbage.", 'utf-8'))
+        sa = rebound.SimulationArchive("simulationarchive.bin")
+        sim = sa[-1]
+        sim.automateSimulationArchive("simulationarchive.bin", interval=1000)
+        sim.integrate(7001)
+        sa = rebound.SimulationArchive("simulationarchive.bin")
+        self.assertEqual(sa.nblobs, 8)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A possible failure mode when interrupting a large number of simulations storing simulation archives is that a small subset might interrupt while writing a binary snapshot, corrupting them. The latest version allows you to read in such corrupted simulation archives but can't resume and continue appending from an archive that's corrupted in this way. This pull request changes things so that instead of appending to the end of the file, it appends snapshots to the last valid snapshot. 

Thanks for your help @hannorein . Took a little longer than I had hoped to figure out that when I truncated a valid archive to make a corrupted archive test case, the rest of the archive still stayed in contiguous memory so the code would read it anyway  😅 