### PR TITLE
Fixing the dual code displays

### DIFF
--- a/docs/simulationarchive.md
+++ b/docs/simulationarchive.md
@@ -29,7 +29,7 @@ Instead of manually outputting each snapshot, you can also automate this process
 
 ### Regular time intervals
 The following code automatically creates a Simulation Archive snapshot at regular intervals.
-== "C"
+=== "C"
     ```c
     struct reb_simulation* r = reb_create_simulation();
     // ... work on simulation ...
@@ -45,7 +45,7 @@ The following code automatically creates a Simulation Archive snapshot at regula
 
 ### Regular number of timesteps
 The following code automatically creates a Simulation Archive snapshot after a fixed number of timesteps.
-== "C"
+=== "C"
     ```c
     struct reb_simulation* r = reb_create_simulation();
     // ... work on simulation ...
@@ -69,7 +69,7 @@ The following code automatically creates a Simulation Archive snapshot after a f
 The following code automatically creates a Simulation Archive snapshot after a fixed wall-time.
 This is particularly useful for creating restart files when running long simulations.
 The wall-time is given in seconds.
-== "C"
+=== "C"
     ```c
     struct reb_simulation* r = reb_create_simulation();
     // ... work on simulation ...


### PR DESCRIPTION
Not sure how to explain the problem but here goes. On most pages, any inline code is displayed for C and python in the same box, you just click "C" or "python" to view one or the other. On this 'Simulation Archive' page, the code for C and python were being displayed separately, and I think it was because there was a missing "=" before the "C" condition? That's my basic understanding at least.