### PR TITLE
fix fetching minor bodies from Horizons

### DIFF
--- a/rebound/horizons.py
+++ b/rebound/horizons.py
@@ -111,6 +111,20 @@ def getParticle(particle=None, m=None, x=None, y=None, z=None, vx=None, vy=None,
 
         made_choice = True
         body = api_request(idn, datestart, dateend, plane)
+    elif "Matching small-bodies" in body:
+        for line in body.split("\n"):
+            try:
+                first_word = line.split()[0]
+            except IndexError:
+                continue
+            print(first_word)
+            if first_word.isdecimal():
+                idn = first_word
+                break
+        if not idn:
+            raise Exception("Error while trying to find object.")
+        body = api_request(idn, datestart, dateend, plane)
+
     lines = body.split("$$SOE")[-1].split("\n")
     p = Particle()
 


### PR DESCRIPTION
for whatever weird reason the output of Horizon is completely different when there are multiple minor bodies found, so I wrote an equivalent few lines to also handle this case:
https://ssd.jpl.nasa.gov/api/horizons.api?format=text&COMMAND=%27Churyumov-Gerasimenko%27&START_TIME=%272021-11-08+11%3A38%3A17%27&STOP_TIME=%272021-11-08+11%3A39%27&MAKE_EPHEM=%27YES%27&EPHEM_TYPE=%27VECTORS%27&CENTER=%27%400%27&REF_PLANE=%27ecliptic%27&STEP_SIZE=%272%27&REF_SYSTEM=%27J2000%27&VEC_CORR=%27NONE%27&OUT_UNITS=%27KM-S%27&CSV_FORMAT=%27NO%27&VEC_DELTA_T=%27NO%27&VEC_TABLE=%273%27&VEC_LABELS=%27NO%27


Now 
```python
sim.add("Churyumov-Gerasimenko")
```
should work correctly.


Thinking about it, I'm not sure anymore if picking the first from the list is actually the best result.

`sim.add("NAME=Churyumov-Gerasimenko; CAP")` as mentioned in https://rebound.readthedocs.io/en/latest/ipython_examples/Churyumov-Gerasimenko/ already works without that change as only one dataset is returned.