### PR TITLE
fix(readme): change relative img path to absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 # Welcome to REBOUND
 
-![REBOUND Examples](docs/img/reboundbanner.png)
+![REBOUND Examples](https://github.com/hannorein/rebound/raw/main/docs/img/reboundbanner.png)
 
 REBOUND is an N-body integrator, i.e. a software package that can integrate the motion of particles under the influence of gravity. The particles can represent stars, planets, moons, ring or dust particles. REBOUND is very flexible and can be customized to accurately and efficiently solve many problems in astrophysics.  
 


### PR DESCRIPTION
Hi @hannorein your welcome!!

I just check you updated the PyPI release and the description got better (with the badges and with the code example).
Even though, it is not perfect yet, I just realized this is because you use a relative path in the example image.

With this new change you use the absolute path of GitHub and this way it would be found from PyPi, GitHub, or any other server.