### PR TITLE
added edge case test to to_new_axes and added failing unit test

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -204,6 +204,9 @@ class Rotation(Structure):
         if not newx: # newx not specified, newx will point along z cross newz (line of nodes)
             clibrebound.reb_vec3d_cross.restype = Vec3d
             newx = clibrebound.reb_vec3d_cross(Vec3d(0,0,1), Vec3d(newz))
+            mag = (newx.x**2 + newx.y**2 + newx.z**2)**(0.5)
+            if mag < 1e-15: # z and newz point in the same direction, so line of nodes undefined, don't rotate x
+                newx.x, newx.y, newx.z = 1,0,0
         clibrebound.reb_rotation_init_to_new_axes.restype = cls
         q = clibrebound.reb_rotation_init_to_new_axes(Vec3d(newz), Vec3d(newx))
         return q

--- a/rebound/tests/test_rotations.py
+++ b/rebound/tests/test_rotations.py
@@ -26,7 +26,14 @@ class TestRotations(unittest.TestCase):
         self.assertAlmostEqual(res[0], tov[0], delta=1e-15)
         self.assertAlmostEqual(res[1], tov[1], delta=1e-15)
         self.assertAlmostEqual(res[2], tov[2], delta=1e-15)
-    
+
+    def test_from_to_edge(self):
+        q = rebound.Rotation.from_to([1,0,0], [-1,0,0])
+        res = q*[1,0,0] 
+        self.assertAlmostEqual(res[0], -1, delta=1e-15)
+        self.assertAlmostEqual(res[1], 0, delta=1e-15)
+        self.assertAlmostEqual(res[2], 0, delta=1e-15)
+
     def test_to_orbit(self):
         sim = rebound.Simulation()
         a, e, inc, Omega, omega = 1, 0.1, 0.2, 0.3, 0.4


### PR DESCRIPTION
Not really a patch...I added a failing unit test for an edge case in from_to that I think will come up a lot (when trying to rotate to the invariable plane when you're already aligned with it, so the line of nodes is undefined).

`rebound.Rotation.from_to([1,0,0], [-1,0,0])`

yields

<rebound.simulation.Rotation object at 0x1057a9240, ix=nan, iy=nan, iz=nan, r=nan>

I also added testing for that edge case in Rotation.to_new_axes in python