### PR TITLE
acos2 is now static

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -933,7 +933,10 @@ struct reb_orbit reb_orbit_nan(void){
 // will return 0 or pi appropriately if num is larger than denom by machine precision
 // and will return 0 if denom is exactly 0.
 
-double acos2(double num, double denom, double disambiguator){
+
+
+// Calculates right quadrant for acos(num/denom) using a disambiguator that is < 0 when acos in the range (0, -pi)
+static double acos2(double num, double denom, double disambiguator){
 	double val;
 	double cosine = num/denom;
 	if(cosine > -1. && cosine < 1.){

--- a/src/tools.h
+++ b/src/tools.h
@@ -78,10 +78,4 @@ void reb_tools_particle_to_pal(double G, struct reb_particle p, struct reb_parti
  * @brief internal function to handle outputs for the Fast Simulation Restarter.
  */
 void reb_fsr_heartbeat(struct reb_simulation* const r);
-
-/**
- * @brief Calculates right quadrant for acos(num/denom) using a disambiguator that is < 0 when acos in the range (0, -pi)
- */
-double acos2(double num, double denom, double disambiguator);
-
 #endif 	// TOOLS_H


### PR DESCRIPTION
@dtamayo I noticed that the acos2 function did not have the `reb_` prefix but was part of the shared library. That could lead to issues when there is another library implementing the same function. It looks like we never use the function outside of `tools.c` so I have made it static. It looks like you also don't use it in reboundx. But maybe I'm missing something. Asking you because you implemented it. If not, I'll merge this in. 