### PR TITLE
Properly free tree cells in reb_tree_delete_cell

### DIFF
--- a/src/tree.c
+++ b/src/tree.c
@@ -309,6 +309,7 @@ static void reb_tree_delete_cell(struct reb_treecell* node){
 	for (int o=0; o<8; o++) {
 		reb_tree_delete_cell(node->oct[o]);
 	}
+	free(node);
 }
 
 void reb_tree_delete(struct reb_simulation* const r){


### PR DESCRIPTION
I think there was a missing call to `free()` here (the function does... nothing at the moment)

Fixes a small memory leak reported in valgrind.