### PR TITLE
Multiple heartbeat listeners called at automatic intervals

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1276,14 +1276,16 @@ class Simulation(Structure):
             object as its argument.
 
             Use the AFF or rebound.tools.deref_arg function to convert a Python
-            function to a C function (or use the interval_heartbeat decorator
+            function to a C function (or use the register_heartbeat decorator
             that converts and adds a Python function automatically).
         interval: float
             The time in simulated time or multiples of dt to wait before
             calling the function again. Internally uses reb_output_check.
         phase: float
             The phase, as a value from from 0.0 to 1.0, within an interval
-            to call the function at. Supplied to reb_output_check.
+            to call the function at. Subtracts from interval, so with interval
+            1.0 and phase 0.2, the function will be called just after 0.8, 1.8,
+            2.8, 3.8, etc. Supplied to reb_output_check_phase.
         is_dt_multiple: bool
             Whether the interval represents a float of time or a multiple
             of the current Simulation.dt.

--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1253,6 +1253,10 @@ class Simulation(Structure):
         self._hb = AFF(func)
         self._heartbeat = self._hb
 
+    def add_heartbeat(self, func, interval, is_dt_multiple=False):
+        clibrebound.reb_add_heartbeat.restype = HeartbeatUnit
+        return clibrebound.reb_add_heartbeat(byref(self), AFF(func), interval, is_dt_multiple)
+
     @property 
     def coefficient_of_restitution(self):
         """
@@ -2553,6 +2557,15 @@ class reb_display_data(Structure):
                 # ignoring other data (never used)
                 ]
 
+class HeartbeatUnit(Structure):
+    """
+    Object representing a heartbeat function and the metadata to run it automatically
+    using the heartbeat set code. Returned from Simulation.add_heartbeat, should not be
+    created manually.
+    """
+    _fields_ = [("heartbeat", CFUNCTYPE(None, POINTER(Simulation))),
+                ("interval", c_double),
+                ("is_dt_multiple", c_int)]
 
 # Setting up fields after class definition (because of self-reference)
 Simulation._fields_ = [
@@ -2652,6 +2665,9 @@ Simulation._fields_ = [
                 ("_odes_N", c_int),
                 ("_odes_allocatedN", c_int),
                 ("_odes_warnings", c_int),
+                ("_heartbeat_set", POINTER(POINTER(HeartbeatUnit))),
+                ("_heartbeat_set_N", c_int),
+                ("_heartbeat_set_allocatedN", c_int),
                 ("_additional_forces", CFUNCTYPE(None,POINTER(Simulation))),
                 ("_pre_timestep_modifications", CFUNCTYPE(None,POINTER(Simulation))),
                 ("_post_timestep_modifications", CFUNCTYPE(None,POINTER(Simulation))),

--- a/src/output.c
+++ b/src/output.c
@@ -66,6 +66,8 @@ void reb_output_stream_write(char** bufp, size_t* allocatedsize, size_t* sizep, 
  */
 int reb_output_check_phase(struct reb_simulation* r, double interval,double phase){
     double shift = r->t+interval*phase;
+    // Can output multiple times within the first timestemp 
+    // Consider adding shift >= r->dt condition? 
     if (floor(shift/interval)!=floor((shift-r->dt)/interval)){
         return 1;
     }

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -733,6 +733,13 @@ struct reb_hash_pointer_pair{
     int index;
 };
 
+// Structure holding a heartbeat function and the interval to call it
+struct reb_heartbeat_unit {
+    void (*heartbeat)(struct reb_simulation* r);
+    double interval;
+    int is_dt_multiple; // Determines if interval is in time units or is a multiple of reb_simulation->dt
+};
+
 // Main REBOUND Simulation structure
 struct reb_simulation {
     double  t;
@@ -900,6 +907,11 @@ struct reb_simulation {
     int odes_allocatedN;   // number of ode sets allocated
     int ode_warnings;
 
+    // Multiple Heartbeat
+    struct reb_heartbeat_unit** heartbeat_set;
+    int heartbeat_set_N; // number of heartbeat functions
+    int heartbeat_set_allocatedN; // number of heartbeat functions allocated
+
      // Callback functions
     void (*additional_forces) (struct reb_simulation* const r);
     void (*pre_timestep_modifications) (struct reb_simulation* const r);    // used by REBOUNDx
@@ -1031,6 +1043,9 @@ enum reb_input_binary_messages {
 // ODE functions
 struct reb_ode* reb_create_ode(struct reb_simulation* r, unsigned int length);
 void reb_free_ode(struct reb_ode* ode);
+
+// Function to add one of multiple heartbeats
+struct reb_heartbeat_unit* reb_add_heartbeat(struct reb_simulation* r, void (*heartbeat)(struct reb_simulation* r), double interval, int is_dt_multiple);
 
 // Miscellaneous functions
 uint32_t reb_hash(const char* str);
@@ -1377,7 +1392,6 @@ struct reb_display_data {
     unsigned int orbit_shader_particle_vao;
     unsigned int orbit_shader_vertex_count;
 };
-
 
 // Temporary. Function declarations needed by REBOUNDx 
 void reb_integrator_ias15_reset(struct reb_simulation* r);         ///< Internal function used to call a specific integrator

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -737,6 +737,7 @@ struct reb_hash_pointer_pair{
 struct reb_heartbeat_unit {
     void (*heartbeat)(struct reb_simulation* r);
     double interval;
+    double phase;
     int is_dt_multiple; // Determines if interval is in time units or is a multiple of reb_simulation->dt
 };
 
@@ -1045,7 +1046,9 @@ struct reb_ode* reb_create_ode(struct reb_simulation* r, unsigned int length);
 void reb_free_ode(struct reb_ode* ode);
 
 // Function to add one of multiple heartbeats
-struct reb_heartbeat_unit* reb_add_heartbeat(struct reb_simulation* r, void (*heartbeat)(struct reb_simulation* r), double interval, int is_dt_multiple);
+struct reb_heartbeat_unit* reb_add_heartbeat(struct reb_simulation* r, void (*heartbeat)(struct reb_simulation* r));
+struct reb_heartbeat_unit* reb_add_heartbeat_interval(struct reb_simulation* r, void (*heartbeat)(struct reb_simulation* r), double interval, int is_dt_multiple);
+struct reb_heartbeat_unit* reb_add_heartbeat_interval_phase(struct reb_simulation* r, void (*heartbeat)(struct reb_simulation* r), double interval, double phase, int is_dt_multiple);
 
 // Miscellaneous functions
 uint32_t reb_hash(const char* str);

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1008,6 +1008,7 @@ void reb_serialize_particle_data(struct reb_simulation* r, uint32_t* hash, doubl
 void reb_set_serialized_particle_data(struct reb_simulation* r, uint32_t* hash, double* m, double* radius, double (*xyz)[3], double (*vxvyvz)[3], double (*xyzvxvyvz)[6]); // Null pointers will be ignored.
 
 // Output functions
+int reb_output_check_phase(struct reb_simulation* r, double interval, double phase);
 int reb_output_check(struct reb_simulation* r, double interval);
 void reb_output_timing(struct reb_simulation* r, const double tmax);
 void reb_output_orbits(struct reb_simulation* r, char* filename);


### PR DESCRIPTION
Current, rebound only accepts a single function pointer as a heartbeat callback. The current interface makes simulations using Python heartbeats very slow since they incur significant overhead on every timestep.

Most heartbeat functions are called either on every timestep, after a certain interval (using `reb_output_check`), or after a certain multiple of the simulation dt. In the latter, I think Python heartbeat callbacks should be accepted.

The solution is allowing multiple heartbeat listeners functions to be added and calling them automatically inside a `reb_output_check` on a specified interval. This avoids incurring Python call overhead on every timestep, and also creates what I think to be a nicer modular interface for heartbeats.

TODO: create examples and docs

