### PR TITLE
Support for SimulationArchvies > 4GB

### DIFF
--- a/rebound/simulationarchive.py
+++ b/rebound/simulationarchive.py
@@ -54,7 +54,7 @@ class SimulationArchive(Structure):
                 ("auto_walltime", c_double), 
                 ("auto_step", c_ulonglong), 
                 ("nblobs", c_long), 
-                ("offset", POINTER(c_uint32)), 
+                ("offset64", POINTER(c_uint64)), 
                 ("t", POINTER(c_double)) 
                 ]
     def __repr__(self):

--- a/rebound/simulationarchive.py
+++ b/rebound/simulationarchive.py
@@ -1,4 +1,4 @@
-from ctypes import Structure, c_double, POINTER, c_float, c_int, c_uint, c_uint32, c_int64, c_long, c_ulong, c_ulonglong, c_void_p, c_char_p, CFUNCTYPE, byref, create_string_buffer, addressof, pointer, cast
+from ctypes import Structure, c_double, POINTER, c_float, c_int, c_uint, c_uint32, c_int64, c_uint64, c_long, c_ulong, c_ulonglong, c_void_p, c_char_p, CFUNCTYPE, byref, create_string_buffer, addressof, pointer, cast
 from .simulation import Simulation, BINARY_WARNINGS
 from . import clibrebound 
 import os

--- a/src/binarydiff.c
+++ b/src/binarydiff.c
@@ -75,7 +75,7 @@ int reb_binary_diff_with_options(char* buf1, size_t size1, char* buf2, size_t si
     size_t allocatedsize = 0;
 
     // Header.
-    if(memcmp(buf1,buf2,64)!=0){
+    if(memcmp(buf1,buf2,64)!=0 && output_option==1){
         printf("Header in binary files are different.\n");
     }
 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1239,7 +1239,7 @@ struct reb_simulationarchive{
     double auto_walltime;        // Walltime setting used to create SA (if used)
     unsigned long long auto_step;// Steps in-between SA snapshots (if used)
     long nblobs;                 // Total number of snapshots (including initial binary)
-    uint32_t* offset;            // Index of offsets in file (length nblobs)
+    uint64_t* offset64;            // Index of offsets in file (length nblobs)
     double* t;                   // Index of simulation times in file (length nblobs)
 };
 struct reb_simulation* reb_create_simulation_from_simulationarchive(struct reb_simulationarchive* sa, long snapshot);

--- a/src/simulationarchive.c
+++ b/src/simulationarchive.c
@@ -392,7 +392,7 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     }
                     if (i>0){
                         // Checking the offsets. Acts like a checksum.
-                        if (blob.offset_prev + sizeof(struct reb_simulationarchive_blob16) != ftell(sa->inf) - sa->offset[i] ){
+                        if (((long)blob.offset_prev) + ((long)sizeof(struct reb_simulationarchive_blob16)) != ftell(sa->inf) - ((long)sa->offset[i]) ){
                             // Offsets don't work. Next snapshot is definitly corrupted. Assume current one as well.
                             if (debug) printf("SA Error. Offset mismatch: %lu != %ld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob16), ftell(sa->inf) - sa->offset[i] );
                             read_error = 1;
@@ -421,7 +421,7 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     }
                     if (i>0){
                         // Checking the offsets. Acts like a checksum.
-                        if (blob.offset_prev + sizeof(struct reb_simulationarchive_blob) != ftell(sa->inf) - sa->offset[i] ){
+                        if (((long)blob.offset_prev )+ ((long)sizeof(struct reb_simulationarchive_blob)) != ftell(sa->inf) - ((long)sa->offset[i]) ){
                             // Offsets don't work. Next snapshot is definitly corrupted. Assume current one as well.
                             if (debug) printf("SA Error. Offset mismatch: %lu != %ld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob), ftell(sa->inf) - sa->offset[i] );
                             read_error = 1;

--- a/src/simulationarchive.c
+++ b/src/simulationarchive.c
@@ -70,7 +70,7 @@ void reb_create_simulation_from_simulationarchive_with_messages(struct reb_simul
     if (snapshot==0) return;
 
     // Read SA snapshot
-    if(fseek(inf, sa->offset[snapshot], SEEK_SET)){
+    if(fseek(inf, sa->offset64[snapshot], SEEK_SET)){
         *warnings |= REB_INPUT_BINARY_ERROR_SEEK;
         reb_free_simulation(r);
         return;
@@ -233,7 +233,7 @@ struct reb_simulation* reb_create_simulation_from_simulationarchive(struct reb_s
 }
 
 void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, const char* filename,  struct reb_simulationarchive* sa_index, enum reb_input_binary_messages* warnings){
-    const int debug = 0;
+    const int debug = 1;
     sa->inf = fopen(filename,"r");
     if (sa->inf==NULL){
         *warnings |= REB_INPUT_BINARY_ERROR_NOFILE;
@@ -310,14 +310,14 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
         fseek(sa->inf, 0, SEEK_END);  
         sa->nblobs = (ftell(sa->inf)-sa->size_first)/sa->size_snapshot+1; // +1 accounts for first binary 
         sa->t = malloc(sizeof(double)*sa->nblobs);
-        sa->offset = malloc(sizeof(uint32_t)*sa->nblobs);
+        sa->offset64 = malloc(sizeof(uint64_t)*sa->nblobs);
         sa->t[0] = t0;
-        sa->offset[0] = 0;
+        sa->offset64[0] = 0;
         for(long i=1;i<sa->nblobs;i++){
             double offset = sa->size_first+(i-1)*sa->size_snapshot;
             fseek(sa->inf, offset, SEEK_SET);  
             fread(&(sa->t[i]),sizeof(double), 1, sa->inf);
-            sa->offset[i] = offset;
+            sa->offset64[i] = offset;
         }
     }else{
         // New version
@@ -326,13 +326,13 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
         if (sa_index == NULL){ // Need to construct offset index from file.
             long nblobsmax = 1024;
             sa->t = malloc(sizeof(double)*nblobsmax);
-            sa->offset = malloc(sizeof(uint32_t)*nblobsmax);
+            sa->offset64 = malloc(sizeof(uint64_t)*nblobsmax);
             fseek(sa->inf, 0, SEEK_SET);  
             sa->nblobs = 0;
             int read_error = 0;
             for(long i=0;i<nblobsmax;i++){
                 struct reb_binary_field field = {0};
-                sa->offset[i] = ftell(sa->inf);
+                sa->offset64[i] = ftell(sa->inf);
                 int blob_finished = 0;
                 do{
                     size_t r1 = fread(&field,sizeof(struct reb_binary_field),1,sa->inf);
@@ -392,9 +392,9 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     }
                     if (i>0){
                         // Checking the offsets. Acts like a checksum.
-                        if (((long)blob.offset_prev) + ((long)sizeof(struct reb_simulationarchive_blob16)) != ftell(sa->inf) - ((long)sa->offset[i]) ){
+                        if (((long)blob.offset_prev) + ((long)sizeof(struct reb_simulationarchive_blob16)) != ftell(sa->inf) - ((long)sa->offset64[i]) ){
                             // Offsets don't work. Next snapshot is definitly corrupted. Assume current one as well.
-                            if (debug) printf("SA Error. Offset mismatch: %lu != %ld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob16), ftell(sa->inf) - sa->offset[i] );
+                            if (debug) printf("SA Error. Offset mismatch: %lu != %lld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob16), ftell(sa->inf) - sa->offset64[i] );
                             read_error = 1;
                             break;
                         }
@@ -409,7 +409,7 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     if (i==nblobsmax-1){ // Increase 
                         nblobsmax += 1024;
                         sa->t = realloc(sa->t,sizeof(double)*nblobsmax);
-                        sa->offset = realloc(sa->offset,sizeof(uint32_t)*nblobsmax);
+                        sa->offset64 = realloc(sa->offset64,sizeof(uint64_t)*nblobsmax);
                     }
                 }else{
                     struct reb_simulationarchive_blob blob = {0};
@@ -421,9 +421,9 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     }
                     if (i>0){
                         // Checking the offsets. Acts like a checksum.
-                        if (((long)blob.offset_prev )+ ((long)sizeof(struct reb_simulationarchive_blob)) != ftell(sa->inf) - ((long)sa->offset[i]) ){
+                        if (((long)blob.offset_prev )+ ((long)sizeof(struct reb_simulationarchive_blob)) != ftell(sa->inf) - ((long)sa->offset64[i]) ){
                             // Offsets don't work. Next snapshot is definitly corrupted. Assume current one as well.
-                            if (debug) printf("SA Error. Offset mismatch: %lu != %ld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob), ftell(sa->inf) - sa->offset[i] );
+                            if (debug) printf("SA Error. Offset mismatch: %lu != %lld.\n",blob.offset_prev + sizeof(struct reb_simulationarchive_blob), ftell(sa->inf) - sa->offset64[i] );
                             read_error = 1;
                             break;
                         }
@@ -438,7 +438,7 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     if (i==nblobsmax-1){ // Increase 
                         nblobsmax += 1024;
                         sa->t = realloc(sa->t,sizeof(double)*nblobsmax);
-                        sa->offset = realloc(sa->offset,sizeof(uint32_t)*nblobsmax);
+                        sa->offset64 = realloc(sa->offset64,sizeof(uint64_t)*nblobsmax);
                     }
                 }
             }
@@ -449,7 +449,7 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
                     fclose(sa->inf);
                     free(sa->filename);
                     free(sa->t);
-                    free(sa->offset);
+                    free(sa->offset64);
                     free(sa);
                     *warnings |= REB_INPUT_BINARY_ERROR_SEEK;
                     return;
@@ -462,10 +462,10 @@ void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, 
             // Unexpected behaviour if the shape is not the same.
             sa->nblobs = sa_index->nblobs;
             sa->t = malloc(sizeof(double)*sa->nblobs);
-            sa->offset = malloc(sizeof(uint32_t)*sa->nblobs);
+            sa->offset64 = malloc(sizeof(uint64_t)*sa->nblobs);
             fseek(sa->inf, 0, SEEK_SET);
             // No need to read the large file, just copying the index.
-            memcpy(sa->offset, sa_index->offset, sizeof(uint32_t)*sa->nblobs);
+            memcpy(sa->offset64, sa_index->offset64, sizeof(uint64_t)*sa->nblobs);
             memcpy(sa->t, sa_index->t, sizeof(double)*sa->nblobs);
         }
     }
@@ -497,7 +497,7 @@ void reb_free_simulationarchive_pointers(struct reb_simulationarchive* sa){
     }
     free(sa->filename);
     free(sa->t);
-    free(sa->offset);
+    free(sa->offset64);
 }
     
 static int reb_simulationarchive_snapshotsize(struct reb_simulation* const r){

--- a/src/simulationarchive.c
+++ b/src/simulationarchive.c
@@ -233,7 +233,7 @@ struct reb_simulation* reb_create_simulation_from_simulationarchive(struct reb_s
 }
 
 void reb_read_simulationarchive_with_messages(struct reb_simulationarchive* sa, const char* filename,  struct reb_simulationarchive* sa_index, enum reb_input_binary_messages* warnings){
-    const int debug = 1;
+    const int debug = 0;
     sa->inf = fopen(filename,"r");
     if (sa->inf==NULL){
         *warnings |= REB_INPUT_BINARY_ERROR_NOFILE;


### PR DESCRIPTION
This adds support for large SimulationArchives >4GB (which is the limit for 32 bit addresses). This should not break any backwards compatibility. Closes #666 