### PR TITLE
Remove Python 2.7 dependency from workflow

### DIFF
--- a/.github/workflows/ipynb.yml
+++ b/.github/workflows/ipynb.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
As of June 19, GitHub workflow no longer supports Python 2.7 by setup-python (https://github.com/actions/setup-python/issues/672). This pull request removes 2.7 dependency from the workflow.

Note: there is still a Python 2.7 ipynb dependency. Not sure how to work around this as it is there to test python 2.7 exclusively.