### PR TITLE
clang-docify a few things in rebound.h

### DIFF
--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1100,19 +1100,27 @@ void reb_free_ode(struct reb_ode* ode);
 // Miscellaneous functions
 uint32_t reb_hash(const char* str);
 double reb_tools_mod2pi(double f);
-double reb_tools_M_to_f(double e, double M); // True anomaly for a given eccentricity and mean anomaly
-double reb_tools_E_to_f(double e, double M); // True anomaly for a given eccentricity and eccentric anomaly
-double reb_tools_M_to_E(double e, double M); // Eccentric anomaly for a given eccentricity and mean anomaly
-void reb_tools_init_plummer(struct reb_simulation* r, int _N, double M, double R); // This function sets up a Plummer sphere, N=number of particles, M=total mass, R=characteristic radius
-void reb_run_heartbeat(struct reb_simulation* const r);  // used internally
+/// True anomaly for a given eccentricity and mean anomaly
+double reb_tools_M_to_f(double e, double M);
+/// True anomaly for a given eccentricity and eccentric anomaly
+double reb_tools_E_to_f(double e, double M);
+/// Eccentric anomaly for a given eccentricity and mean anomaly
+double reb_tools_M_to_E(double e, double M);
 
-// transformations to/from vec3d
+/// This function sets up a Plummer sphere, N=number of particles, M=total mass, R=characteristic radius
+void reb_tools_init_plummer(struct reb_simulation* r, int _N, double M, double R);
+
+/// used internally
+void reb_run_heartbeat(struct reb_simulation* const r);
+
+/// transformations to/from vec3d
 struct reb_vec3d reb_tools_spherical_to_xyz(const double mag, const double theta, const double phi);
 void reb_tools_xyz_to_spherical(struct reb_vec3d const xyz, double* mag, double* theta, double* phi);
 
 
 // Functions to add and initialize particles
-struct reb_particle reb_particle_nan(void); // Returns a reb_particle structure with fields/hash/ptrs initialized to nan/0/NULL. 
+/// Returns a reb_particle structure with fields/hash/ptrs initialized to nan/0/NULL.
+struct reb_particle reb_particle_nan(void);
 void reb_add(struct reb_simulation* const r, struct reb_particle pt);
 void reb_add_fmt(struct reb_simulation* r, const char* fmt, ...);
 struct reb_particle reb_particle_new(struct reb_simulation* r, const char* fmt, ...);    // Same as reb_add_fmt() but returns the particle instead of adding it to the simualtion.

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1149,45 +1149,57 @@ double reb_tools_calculate_lyapunov(struct reb_simulation* r);
 
 // Variational equations
 
-// Struct describing the properties of a set of variational equations.
-// If testparticle is set to -1, then it is assumed that all particles are massive
-// and all particles influence all other particles. If testparticle is >=0 then 
-// the particle with that index is assumed to be a testparticle, i.e. it does not 
-// influence other particles. For second order variational equation, index_1st_order_a/b 
-// is the index in the particle array that corresponds to the 1st order variational 
-// equations.
+/** Struct describing the properties of a set of variational equations.
+ *
+ * If testparticle is set to -1, then it is assumed that all particles are massive
+ * and all particles influence all other particles. If testparticle is >=0 then
+ * the particle with that index is assumed to be a testparticle, i.e. it does not
+ * influence other particles. For second order variational equation, index_1st_order_a/b
+ * is the index in the particle array that corresponds to the 1st order variational
+ * equations.
+ */
 struct reb_variational_configuration{
-    struct reb_simulation* sim; // Reference to the simulation.
-    int order;                  // Order of the variational equation. 1 or 2. 
-    int index;                  // Index of the first variational particle in the particles array.
-    int testparticle;           // Is this variational configuration describe a test particle? -1 if not.
-    int index_1st_order_a;      // Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
-    int index_1st_order_b;      // Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
-    double lrescale;             // Accumulates the logarithm of rescalings
+    struct reb_simulation* sim; /// Reference to the simulation.
+    int order;                  /// Order of the variational equation. 1 or 2.
+    int index;                  /// Index of the first variational particle in the particles array.
+    int testparticle;           /// Is this variational configuration describe a test particle? -1 if not.
+    int index_1st_order_a;      /// Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
+    int index_1st_order_b;      /// Used for 2nd order variational particles only: Index of the first order variational particle in the particles array.
+    double lrescale;            /// Accumulates the logarithm of rescalings
 };
 
-// Add and initialize a set of first order variational particles
-// If testparticle is >= 0, then only one variational particle (the test particle) will be added.
-// If testparticle is -1, one variational particle for each real particle will be added.
-// Returns the index of the first variational particle added
+/** Add and initialize a set of first order variational particles
+ *
+ * If testparticle is >= 0, then only one variational particle (the test particle) will be added.
+ * If testparticle is -1, one variational particle for each real particle will be added.
+ *
+ * Returns the index of the first variational particle added
+ */
 int reb_add_var_1st_order(struct reb_simulation* const r, int testparticle);
 
-// Add and initialize a set of second order variational particles
-// Note: a set of second order variational particles requires two sets of first order variational equations.
-// If testparticle is >= 0, then only one variational particle (the test particle) will be added.
-// If testparticle is -1, one variational particle for each real particle will be added.
-// index_1st_order_a is the index of the corresponding first variational particles.
-// index_1st_order_b is the index of the corresponding first variational particles.
-// Returns the index of the first variational particle added
+/** Add and initialize a set of second order variational particles
+ *
+ * Note: a set of second order variational particles requires two sets of first order variational equations.
+ *
+ * If testparticle is >= 0, then only one variational particle (the test particle) will be added.
+ * If testparticle is -1, one variational particle for each real particle will be added.
+ *
+ * index_1st_order_a is the index of the corresponding first variational particles.
+ * index_1st_order_b is the index of the corresponding first variational particles.
+ *
+ * Returns the index of the first variational particle added
+ */
 int reb_add_var_2nd_order(struct reb_simulation* const r, int testparticle, int index_1st_order_a, int index_1st_order_b);
 
-// Rescale all sets of variational particles if their size gets too large (>1e100).
-// This can prevent an overflow in floating point numbers. The logarithm of the rescaling
-// factor is stored in the reb_variational_configuration's lrescale variable. 
-// This function is called automatically every timestep. To avoid automatic rescaling,
-// set the reb_variational_configuration's lrescale variable to -1.
-// For this function to work, the positions and velocities needs to be synchronized. 
-// A warning is presented if the integrator is not synchronized. 
+/** Rescale all sets of variational particles if their size gets too large (>1e100).
+ *
+ * This can prevent an overflow in floating point numbers. The logarithm of the rescaling
+ * factor is stored in the reb_variational_configuration's lrescale variable.
+ * This function is called automatically every timestep. To avoid automatic rescaling,
+ * set the reb_variational_configuration's lrescale variable to -1.
+ * For this function to work, the positions and velocities needs to be synchronized.
+ * A warning is presented if the integrator is not synchronized.
+ */
 void reb_var_rescale(struct reb_simulation* const r);
 
 // These functions calculates the first/second derivative of a Keplerian orbit. 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -520,19 +520,40 @@ struct reb_collision{
     int ri;
 };
 
-// Possible return values of of rebound_integrate
+/// Possible return values of of rebound_integrate
 enum REB_STATUS {
-    REB_RUNNING_PAUSED = -3,    // Simulation is paused by visualization.
-    REB_RUNNING_LAST_STEP = -2, // Current timestep is the last one. Needed to ensure that t=tmax exactly.
-    REB_RUNNING = -1,           // Simulation is current running, no error occurred.
-    REB_EXIT_SUCCESS = 0,       // Integration finished successfully.
-    REB_EXIT_ERROR = 1,         // A generic error occurred and the integration was not successful.
-    REB_EXIT_NOPARTICLES = 2,   // The integration ends early because no particles are left in the simulation.
-    REB_EXIT_ENCOUNTER = 3,     // The integration ends early because two particles had a close encounter (see exit_min_distance)
-    REB_EXIT_ESCAPE = 4,        // The integration ends early because a particle escaped (see exit_max_distance)  
-    REB_EXIT_USER = 5,          // User caused exit, simulation did not finish successfully.
-    REB_EXIT_SIGINT = 6,        // SIGINT received. Simulation stopped.
-    REB_EXIT_COLLISION = 7,     // The integration ends early because two particles collided. 
+    /// Simulation is paused by visualization.
+    REB_RUNNING_PAUSED = -3,
+
+    /// Current timestep is the last one. Needed to ensure that t=tmax exactly.
+    REB_RUNNING_LAST_STEP = -2,
+
+    /// Simulation is current running, no error occurred.
+    REB_RUNNING = -1,
+
+    /// Integration finished successfully.
+    REB_EXIT_SUCCESS = 0,
+
+    /// A generic error occurred and the integration was not successful.
+    REB_EXIT_ERROR = 1,
+
+    /// The integration ends early because no particles are left in the simulation.
+    REB_EXIT_NOPARTICLES = 2,
+
+    /// The integration ends early because two particles had a close encounter (see exit_min_distance)
+    REB_EXIT_ENCOUNTER = 3,
+
+    /// The integration ends early because a particle escaped (see exit_max_distance)
+    REB_EXIT_ESCAPE = 4,
+
+    /// User caused exit, simulation did not finish successfully.
+    REB_EXIT_USER = 5,
+
+    /// SIGINT received. Simulation stopped.
+    REB_EXIT_SIGINT = 6,
+
+    /// The integration ends early because two particles collided.
+    REB_EXIT_COLLISION = 7,
 };
 
 // IDs for content of a binary field. Used to read and write binary files.

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -1065,11 +1065,14 @@ void reb_output_ascii(struct reb_simulation* r, char* filename);
 void reb_output_binary_positions(struct reb_simulation* r, const char* filename);
 void reb_output_velocity_dispersion(struct reb_simulation* r, char* filename);
 
-// Compares two simulations, stores difference in buffer.
+/// Compares two simulations, stores difference in buffer.
 void reb_binary_diff(char* buf1, size_t size1, char* buf2, size_t size2, char** bufp, size_t* sizep); 
-// Same as reb_binary_diff, but with options.
-// output_option If set to 0, the differences are written to bufp. If set to 1, printed on the screen. If set to 2, then only the return value indicates any differences.
-// returns 0 is returned if the simulations do not differ (are equal). 1 is return if they differ.
+/** Same as reb_binary_diff, but with options.
+ *
+ * output_option If set to 0, the differences are written to bufp. If set to 1, printed on the screen. If set to 2, then only the return value indicates any differences.
+ *
+ * returns 0 is returned if the simulations do not differ (are equal). 1 is return if they differ.
+ */
 int reb_binary_diff_with_options(char* buf1, size_t size1, char* buf2, size_t size2, char** bufp, size_t* sizep, int output_option);
 
 // Input functions


### PR DESCRIPTION
As we discussed a bit in #705, clang-doc style documentation comments brings some benefits for automated tools, like generating bindings. This is a little mini-PR of a bit of what the changes might feel like. I tried to cover a bunch of the scenarios we'd encounter if we converted everything.

If I'm honest, I don't think these seem like improvements for the C code. Enums get _way_ bigger to document every value. Inline function comments need to be put in front, which kind of chops things up and makes symmetries less obvious. The only clear success case is probably commit 5df64af, which I think certainly makes things a little more readable.