### PR TITLE
replace unsafe sqrt7 implementation for IAS15?

### DIFF
--- a/src/integrator_ias15.c
+++ b/src/integrator_ias15.c
@@ -87,10 +87,17 @@ static const double w[8] = {0.03125, 0.18535815480297927854072897280718075447981
 // Machine independent implementation of pow(*,1./7.)
 static double sqrt7(double a){
     double x = 1.;
-    for (int k=0; k<20;k++){  // A smaller number should be ok too.
+    int iter = 0;
+    while(1){
         double x6 = x*x*x*x*x*x;
-        x += (a/x6-x)/7.;
+        double xnew = (a/x6-x)/7.;
+        if (fabs(xnew)<1.0e-14 || iter>100){
+            break;
+        }
+        x += xnew;
+        iter++;
     }
+    // printf("iter: %d\n", iter);
     return x;
 }
 


### PR DESCRIPTION
The current implementation of the sqrt7 function in the ias15 source code does the expansion for x^(1/7) for 20 iterations without checking whether the returned value has converged. Although these 20 iterations are more than good enough in almost all situations, there are pathological cases.

One example is the [Apophis propagation unit test](https://github.com/matthewholman/assist/blob/main/unit_tests/apophis/problem.c) from the [ASSIST library](https://github.com/matthewholman/assist). If we re-build the test while printing the value of x^(1/7) at every iteration in the current implementation, we see that the values are very different at each iteration for the first 20 for the first few integration steps.

Switching to a while loop that checks for convergence within a tolerance or a violation of a maximum iteration limit is the better approach proposed in this PR. This ensures convergence in all scenarios and avoids unnecessarily doing 20 iterations when they are not necessary.