### PR TITLE
Fixed documentation link issue.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,7 +49,7 @@ nav:
       - "Just getting started":
         - c_examples/simplest.md
         - c_examples/heartbeat.md
-        - c_examples/reb_simulation_add_fmt.md
+        - c_examples/reb_add_fmt.md
         - ipython_examples/Churyumov-Gerasimenko.ipynb
         - ipython_examples/WHFast.ipynb
         - c_examples/solar_system.md


### PR DESCRIPTION
There is a link in the current documentation listed as Examples -> Planetary Systems -> Just getting started -> None. As far as I can tell, this fixes the link which goes to "c_examples/reb_simulation_add_fmt.md" resulting in a 404 error but seems intended for "c_examples/reb_add_fmt/".