### PR TITLE
Link to legacy_stdio_definitions only when building with MSVC

### DIFF
--- a/src/rebound.c
+++ b/src/rebound.c
@@ -23,7 +23,9 @@
  *
  */
 #define _NO_CRT_STDIO_INLINE // WIN32 to use _vsprintf_s
+#if defined(_WIN32) && defined(_MSC_VER)
 #pragma comment(lib, "legacy_stdio_definitions.lib")
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h> // for offsetof()


### PR DESCRIPTION
Hello!

We are packaging rebound in [Conan](https://github.com/conan-io/conan-center-index/pull/24277) and we noted it failed to build using Clang on Linux. The complete failed build log can be found [here](https://c3i.jfrog.io/c3i/misc/logs/pr/24277/10-linux-clang/rebound/4.4.1//a3ce2115e2a9286e43eb62371c4b8204166ba887-build.txt)

The error occurred because the Linux environment was not capable to find the library `legacy_stdio_definitions.lib`. That library is exclusive for Visual Studio environments:

https://learn.microsoft.com/en-us/cpp/porting/overview-of-potential-upgrade-issues-visual-cpp?view=msvc-170

> To provide partial link compatibility with object files (and libraries) compiled with older versions of the Microsoft C Runtime headers, we provide a library, legacy_stdio_definitions.lib, with Visual Studio 2015 and later. This library provides compatibility symbols for most of the functions and data exports that were removed from the Universal CRT. The set of compatibility symbols provided by legacy_stdio_definitions.lib is sufficient to satisfy most dependencies, including all of the dependencies in libraries included in the Windows SDK. 

This pull request adds a condition to link that library only when building on Windows and using Visual Studio, avoiding linkage errors in Linux.

/cc @RubenRBS 