### PR TITLE
Encounter Prediction Switching Condition for TRACE

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,8 +10,8 @@ REBOUND is an N-body integrator, i.e. a software package that can integrate the 
 * No dependencies on external libraries.
 * Runs natively on Linux, MacOS, and Windows. 
 * Symplectic integrators ([WHFast](integrators/#whfast), [SEI](integrators/#sei), [LEAPFROG](integrators/#leapfrog), [EOS](integrators/#embedded-operator-splitting-method-eos))
-* Hybrid symplectic integrators for planetary dynamics with close encounters ([MERCURIUS](integrators/#mercurius))
 * Hybrid reversible integrators for planetary dynamics with arbitrary close encounters ([TRACE](integrators/#trace))
+* Hybrid symplectic integrators for planetary dynamics with close encounters ([MERCURIUS](integrators/#mercurius))
 * High order symplectic integrators for integrating planetary systems ([SABA](integrators/#saba), WH Kernel methods)
 * High accuracy non-symplectic integrator with adaptive time-stepping ([IAS15](integrators/#ias15))
 * Can integrate arbitrary user-defined ODEs that are coupled to N-body dynamics for tides, spin, etc

--- a/docs/integrators.md
+++ b/docs/integrators.md
@@ -404,7 +404,7 @@ The `reb_integrator_mercurius` structure contains the configuration and data str
 
 TRACE is a hybrid time-reversible integrator, based on the algorithm described in [Hernandez & Dehnen 2023](https://ui.adsabs.harvard.edu/abs/2023MNRAS.522.4639H/abstract). 
 It uses WHFast for long term integrations but switches time-reversibly to BS or IAS15 for all close encounters. TRACE is appropriate for systems with a dominant central mass that will occasionally have close encounters. 
-A paper describing the TRACE implementation is in preparation. 
+The TRACE implementation is described in [Lu, Hernandez & Rein](https://ui.adsabs.harvard.edu/abs/2024arXiv240503800L/abstract). 
 
 
 The following code enables TRACE and sets the critical radius to 4 Hill radii

--- a/rebound/integrators/trace.py
+++ b/rebound/integrators/trace.py
@@ -60,6 +60,8 @@ class IntegratorTRACE(ctypes.Structure):
                 ("_particles_backup", ctypes.POINTER(Particle)),
                 ("_particles_backup_kepler", ctypes.POINTER(Particle)),
                 ("_particles_backup_additional_forces", ctypes.POINTER(Particle)),
+                ("_particles_pre", ctypes.POINTER(Particle)),
+                ("_particles_post", ctypes.POINTER(Particle)),
                 ("_encounter_map", ctypes.POINTER(ctypes.c_int)),
                 ("_com_pos", Vec3dBasic),
                 ("_com_vel", Vec3dBasic),

--- a/rebound/integrators/trace.py
+++ b/rebound/integrators/trace.py
@@ -76,8 +76,6 @@ class IntegratorTRACE(ctypes.Structure):
             self._S = cast(clibrebound.reb_integrator_trace_switch_default,TRACEKF)
         elif func == "line":
             self._S = cast(clibrebound.reb_integrator_trace_switch_encounter_line, TRACEKF)
-        elif func == "cubic":
-            self._S = cast(clibrebound.reb_integrator_trace_switch_encounter_predict, TRACEKF)
         else:
             self._Sfp = TRACEKF(func)
             self._S = self._Sfp

--- a/rebound/integrators/trace.py
+++ b/rebound/integrators/trace.py
@@ -60,8 +60,6 @@ class IntegratorTRACE(ctypes.Structure):
                 ("_particles_backup", ctypes.POINTER(Particle)),
                 ("_particles_backup_kepler", ctypes.POINTER(Particle)),
                 ("_particles_backup_additional_forces", ctypes.POINTER(Particle)),
-                ("_particles_pre", ctypes.POINTER(Particle)),
-                ("_particles_post", ctypes.POINTER(Particle)),
                 ("_encounter_map", ctypes.POINTER(ctypes.c_int)),
                 ("_com_pos", Vec3dBasic),
                 ("_com_vel", Vec3dBasic),
@@ -69,7 +67,6 @@ class IntegratorTRACE(ctypes.Structure):
                 ("_current_C", ctypes.c_uint),
                 ("_force_accept", ctypes.c_uint),
                 ]
-    # To be honest I'm not sure what these do: do we need this? - Tiger
     @property
     def S(self):
         raise AttributeError("You can only set C function pointers from python.")
@@ -77,6 +74,10 @@ class IntegratorTRACE(ctypes.Structure):
     def S(self, func):
         if func == "default":
             self._S = cast(clibrebound.reb_integrator_trace_switch_default,TRACEKF)
+        elif func == "line":
+            self._S = cast(clibrebound.reb_integrator_trace_switch_encounter_line, TRACEKF)
+        elif func == "cubic":
+            self._S = cast(clibrebound.reb_integrator_trace_switch_encounter_predict, TRACEKF)
         else:
             self._Sfp = TRACEKF(func)
             self._S = self._Sfp

--- a/rebound/integrators/trace.py
+++ b/rebound/integrators/trace.py
@@ -74,8 +74,6 @@ class IntegratorTRACE(ctypes.Structure):
     def S(self, func):
         if func == "default":
             self._S = cast(clibrebound.reb_integrator_trace_switch_default,TRACEKF)
-        elif func == "line":
-            self._S = cast(clibrebound.reb_integrator_trace_switch_encounter_line, TRACEKF)
         else:
             self._Sfp = TRACEKF(func)
             self._S = self._Sfp

--- a/rebound/tests/test_trace_basic.py
+++ b/rebound/tests/test_trace_basic.py
@@ -40,11 +40,10 @@ class TestIntegratorTraceBasic(unittest.TestCase):
         sim = rebound.Simulation()
         sim.add(m=1)
         sim.add(m=9.55e-4,x=5.2)
-        sim.add(x=5.3,y=0.36,vy=-7.2) # Normal switching condition misses this
+        sim.add(x=5.3,y=0.36,vy=-7.2) # Non-encounter prediction misses this
         sim.integrator = "TRACE"
         sim.dt = 0.01
         sim.ri_trace.r_crit_hill = 1
-        sim.S = "line"
         sim.step()
         
         self.assertEqual(sim.ri_trace._encounter_N,3)

--- a/rebound/tests/test_trace_basic.py
+++ b/rebound/tests/test_trace_basic.py
@@ -36,6 +36,20 @@ class TestIntegratorTraceBasic(unittest.TestCase):
                 for j in range(i+1,sim.N):
                     self.assertEqual(sim.ri_trace._current_Ks[i*sim.N+j],0)
 
+    def test_trace_encounter_prediction(self):
+        sim = rebound.Simulation()
+        sim.add(m=1)
+        sim.add(m=9.55e-4,x=5.2)
+        sim.add(x=5.3,y=0.36,vy=-7.2) # Normal switching condition misses this
+        sim.integrator = "TRACE"
+        sim.dt = 0.01
+        sim.ri_trace.r_crit_hill = 1
+        sim.S = "line"
+        sim.step()
+        
+        self.assertEqual(sim.ri_trace._encounter_N,3)
+
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -152,11 +152,11 @@ int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r
         dcritj6 = dj2*dj2*dj2*mr*mr;
     }
 
-    const double dx = r->particles[i].x - r->particles[j].x;
-    const double dy = r->particles[i].y - r->particles[j].y;
-    const double dz = r->particles[i].z - r->particles[j].z;
+//    const double dx = r->particles[i].x - r->particles[j].x;
+//    const double dy = r->particles[i].y - r->particles[j].y;
+//    const double dz = r->particles[i].z - r->particles[j].z;
     //const double d2 = dx*dx + dy*dy + dz*dz;
-    rmin = dx * dx + dy * dy + dz * dz;
+//    rmin = dx * dx + dy * dy + dz * dz;
 
     double r_crit_hill2 = ri_trace->r_crit_hill*ri_trace->r_crit_hill;
     double dcritmax6 = r_crit_hill2 * r_crit_hill2 * r_crit_hill2 * MAX(dcriti6,dcritj6);
@@ -279,17 +279,17 @@ int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, c
     // TLUEPP
 
     struct reb_particle pi_pre = {0};
-    pi_pre.x = r->particles[j].x - h2 * r->particles[j].vx;
-    pi_pre.y = r->particles[j].y - h2 * r->particles[j].vy;
-    pi_pre.z = r->particles[j].z - h2 * r->particles[j].vz;
+    pi_pre.x = r->particles[j].x - h2 * r->particles[j].vx - 0.5 * h2 * h2 * ddx;
+    pi_pre.y = r->particles[j].y - h2 * r->particles[j].vy - 0.5 * h2 * h2 * ddy;
+    pi_pre.z = r->particles[j].z - h2 * r->particles[j].vz - 0.5 * h2 * h2 * ddz;
     pi_pre.vx = r->particles[j].vx - h2 * ddx;
     pi_pre.vy = r->particles[j].vy - h2 * ddy;
     pi_pre.vz = r->particles[j].vz - h2 * ddz;
 
     struct reb_particle pi_post = {0};
-    pi_post.x = r->particles[j].x + h2 * r->particles[j].vx;
-    pi_post.y = r->particles[j].y + h2 * r->particles[j].vy;
-    pi_post.z = r->particles[j].z + h2 * r->particles[j].vz;
+    pi_post.x = r->particles[j].x + h2 * r->particles[j].vx + 0.5 * h2 * h2 * ddx;
+    pi_post.y = r->particles[j].y + h2 * r->particles[j].vy + 0.5 * h2 * h2 * ddy;
+    pi_post.z = r->particles[j].z + h2 * r->particles[j].vz + 0.5 * h2 * h2 * ddz;
     pi_post.vx = r->particles[j].vx + h2 * ddx;
     pi_post.vy = r->particles[j].vy + h2 * ddy;
     pi_post.vz = r->particles[j].vz + h2 * ddz;

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -278,7 +278,7 @@ int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, c
 
     // TLUEPP
 
-    struct reb_particle pi_pre = {};
+    struct reb_particle pi_pre = {0};
     pi_pre.x = r->particles[j].x - h2 * r->particles[j].vx;
     pi_pre.y = r->particles[j].y - h2 * r->particles[j].vy;
     pi_pre.z = r->particles[j].z - h2 * r->particles[j].vz;
@@ -286,7 +286,7 @@ int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, c
     pi_pre.vy = r->particles[j].vy - h2 * ddy;
     pi_pre.vz = r->particles[j].vz - h2 * ddz;
 
-    struct reb_particle pi_post = {};
+    struct reb_particle pi_post = {0};
     pi_post.x = r->particles[j].x + h2 * r->particles[j].vx;
     pi_post.y = r->particles[j].y + h2 * r->particles[j].vy;
     pi_post.z = r->particles[j].z + h2 * r->particles[j].vz;

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -98,13 +98,13 @@ int reb_integrator_trace_switch_default(struct reb_simulation* const r, const un
     }
 
     double dmin2;
-    double tmin = -d*qv/(2.*v2);
+    double tmin = -d*qv/v2;
     if (tmin < h2){
 	// minimum is in the window
-	dmin2 = rp - qv/(4.*v2);
+	dmin2 = rp - qv*qv/v2;
     }
     else{
-	dmin2 = rp + d*qv*h2 + v2*h2*h2/4.;
+	dmin2 = rp + 2*d*qv*h2 + v2*h2*h2;
     }
 
     return dmin2*dmin2*dmin2 < dcritmax6;

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -152,11 +152,11 @@ int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r
         dcritj6 = dj2*dj2*dj2*mr*mr;
     }
 
-    //const double dx = r->particles[i].x - r->particles[j].x;
-    //const double dy = r->particles[i].y - r->particles[j].y;
-    //const double dz = r->particles[i].z - r->particles[j].z;
+    const double dx = r->particles[i].x - r->particles[j].x;
+    const double dy = r->particles[i].y - r->particles[j].y;
+    const double dz = r->particles[i].z - r->particles[j].z;
     //const double d2 = dx*dx + dy*dy + dz*dz;
-    //rmin = dx * dx + dy * dy + dz * dz;
+    rmin = dx * dx + dy * dy + dz * dz;
 
     double r_crit_hill2 = ri_trace->r_crit_hill*ri_trace->r_crit_hill;
     double dcritmax6 = r_crit_hill2 * r_crit_hill2 * r_crit_hill2 * MAX(dcriti6,dcritj6);

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -145,25 +145,25 @@ int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, c
 
     if (qp < 0){
 	// positive solution
-        tmin = -1.*qp / p2; 
+        tmin = -1.*qp/p2; 
 	if (tmin < h2 && tmin > 0.){
-	    const double rmin2 = rp + tmin;
+	    const double rmin2 = rp - qp*qp/p2;
 	    rmin = MIN(rmin2, rmin);
 	}
 	else if (tmin > h2){
-            const double rmin2 = rp + 2.*r->dt*qp + p2 + r->dt*r->dt;
+            const double rmin2 = rp + 2.*r->dt*qp + p2*r->dt*r->dt;
 	    rmin = MIN(rmin2, rmin);
 	}
     }
     else{
         // negative solution
-	tmin = qp / (dpx*dpx + dpy*dpy + dpz*dpz);
+	tmin = qp/p2;
 	if (tmin > -1.*h2 && tmin < 0.){
-	    const double rmin2 = rp + tmin;
+	    const double rmin2 = rp - qp*qp/p2;
 	    rmin = MIN(rmin2, rmin);
 	}
 	else if (tmin < -1.*h2){
-            const double rmin2 = rp - 2.*r->dt*qp + p2 + r->dt*r->dt;
+            const double rmin2 = rp - 2.*r->dt*qp + p2*r->dt*r->dt;
 	    rmin = MIN(rmin2, rmin);
 	}
     }

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -99,7 +99,7 @@ int reb_integrator_trace_switch_default(struct reb_simulation* const r, const un
 
     double dmin2;
     double tmin = -d*qv/(2.*v2);
-    if (fabs(tmin) < h2){
+    if (tmin < h2){
 	// minimum is in the window
 	dmin2 = rp - qv/(4.*v2);
     }

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -853,8 +853,9 @@ DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
-DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
+//DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
+DLLEXPORT int reb_integrator_trace_switch_encounter_line_peri(struct reb_simulation* const r, const unsigned int j); // debugging only
 
 
 // Built in collision resolve functions

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -857,6 +857,7 @@ DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const
 DLLEXPORT int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, const unsigned int j); // This is a placeholder
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
+DLLEXPORT int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 
 
 // Built in collision resolve functions

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -853,7 +853,6 @@ DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
-//DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_line_peri(struct reb_simulation* const r, const unsigned int j); // debugging only
 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -291,8 +291,6 @@ struct reb_integrator_trace {
     struct reb_particle* REB_RESTRICT particles_backup; //  Contains coordinates before the entire step
     struct reb_particle* REB_RESTRICT particles_backup_kepler; //  Contains coordinates before kepler step
     struct reb_particle* REB_RESTRICT particles_backup_additional_forces; // For additional forces
-    struct reb_particle* REB_RESTRICT particles_pre; //  Pre-Timestep coordinates
-    struct reb_particle* REB_RESTRICT particles_post; // Post-Timestep coordinates
 
     int* encounter_map;             // Map to represent which particles are integrated with BS
     struct reb_vec3d com_pos;       // Used to keep track of the centre of mass during the timestep
@@ -854,7 +852,6 @@ DLLEXPORT double reb_integrator_mercurius_L_C5(const struct reb_simulation* cons
 DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
-DLLEXPORT int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, const unsigned int j); // This is a placeholder
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, const unsigned int i, const unsigned int j);

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -853,7 +853,6 @@ DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
-DLLEXPORT int reb_integrator_trace_switch_encounter_line(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_encounter_line_peri(struct reb_simulation* const r, const unsigned int j); // debugging only
 
 

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -849,11 +849,11 @@ DLLEXPORT double reb_integrator_mercurius_L_C5(const struct reb_simulation* cons
 
 // Built in trace switching functions
 
+DLLEXPORT int reb_integrator_trace_switch_peri_default(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
-DLLEXPORT int reb_integrator_trace_switch_encounter_line_peri(struct reb_simulation* const r, const unsigned int j); // debugging only
 
 
 // Built in collision resolve functions

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -291,6 +291,8 @@ struct reb_integrator_trace {
     struct reb_particle* REB_RESTRICT particles_backup; //  Contains coordinates before the entire step
     struct reb_particle* REB_RESTRICT particles_backup_kepler; //  Contains coordinates before kepler step
     struct reb_particle* REB_RESTRICT particles_backup_additional_forces; // For additional forces
+    struct reb_particle* REB_RESTRICT particles_pre; //  Pre-Timestep coordinates
+    struct reb_particle* REB_RESTRICT particles_post; // Post-Timestep coordinates
 
     int* encounter_map;             // Map to represent which particles are integrated with BS
     struct reb_vec3d com_pos;       // Used to keep track of the centre of mass during the timestep
@@ -849,11 +851,12 @@ DLLEXPORT double reb_integrator_mercurius_L_C5(const struct reb_simulation* cons
 
 // Built in trace switching functions
 
-DLLEXPORT int reb_integrator_trace_switch_peri_default(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_fdot(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_distance(struct reb_simulation* const r, const unsigned int j);
 DLLEXPORT int reb_integrator_trace_switch_peri_none(struct reb_simulation* const r, const unsigned int j);
+DLLEXPORT int reb_integrator_trace_switch_peri_ep_accels(struct reb_simulation* const r, const unsigned int j); // This is a placeholder
 DLLEXPORT int reb_integrator_trace_switch_default(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
+DLLEXPORT int reb_integrator_trace_switch_encounter_predict(struct reb_simulation* const r, const unsigned int i, const unsigned int j);
 
 
 // Built in collision resolve functions


### PR DESCRIPTION
@hannorein @dmhernan

This is in response to a few comments/suggestions we've gotten - my first try at implementing a switching condition that accounts for close encounters mid-timestep. In brief, we crudely calculate positions and velocities at dt/2 behind and ahead of the check and use the interpolation scheme from MERCURIUS encounter_predict. From preliminary testing it catches many more close encounters in large N problems, where relative velocities may be quite high compared to rcrit.

At the moment this is quite a bit slower than the default condition without a huge accuracy boost, so I don't think it's worth making the default, but having it as an option may be useful. There's also certainly room for optimization, let me know if you have immediate thoughts.

Also not quite sure why the checks are not passing... everything is fine on my machine (python and C) for what it's worth.