### PR TITLE
Force accept fix

### DIFF
--- a/rebound/simulation.py
+++ b/rebound/simulation.py
@@ -1543,6 +1543,7 @@ Simulation._fields_ = [
                 ("collision_resolve_keep_sorted", c_int),
                 ("collisions", c_void_p),
                 ("N_allocated_collisions", c_int),
+                ("collisions_N", c_uint),
                 ("minimum_collision_velocity", c_double),
                 ("collisions_plog", c_double),
                 ("max_radius", c_double*2),

--- a/rebound/tests/test_trace.py
+++ b/rebound/tests/test_trace.py
@@ -251,6 +251,7 @@ class TestIntegratorTrace(unittest.TestCase):
         dE = abs((sim.energy() - E0)/E0)
         self.assertLess(dE,3e-9)
         self.assertEqual(N0-1,sim.N)
+        self.assertEqual(0,sim.ri_trace._force_accept) # check force_accept bug
     
     def test_collision_add_particles(self):
         sim = rebound.Simulation()

--- a/src/collision.c
+++ b/src/collision.c
@@ -81,6 +81,7 @@ void reb_collision_search(struct reb_simulation* const r){
                 break;
         }
     }
+    r->collisions_N = 0;
     int collisions_N = 0;
     const struct reb_particle* const particles = r->particles;
     switch (r->collision){

--- a/src/collision.c
+++ b/src/collision.c
@@ -364,6 +364,8 @@ void reb_collision_search(struct reb_simulation* const r){
             reb_exit("Collision routine not implemented.");
     }
 
+    r->collisions_N += collisions_N;
+
     // randomize
     for (int i=0;i<collisions_N;i++){
         int new = rand_r(&(r->rand_seed))%collisions_N;

--- a/src/integrator.c
+++ b/src/integrator.c
@@ -46,7 +46,6 @@
 #define MIN(a, b) ((a) > (b) ? (b) : (a))   ///< Returns the minimum of a and b
 
 void reb_integrator_part1(struct reb_simulation* r){
-	r->collisions_N = 0; // Maybe a better place to put this? Just need to reset before every timestep
 	switch(r->integrator){
 		case REB_INTEGRATOR_IAS15:
 			reb_integrator_ias15_part1(r);

--- a/src/integrator.c
+++ b/src/integrator.c
@@ -46,6 +46,7 @@
 #define MIN(a, b) ((a) > (b) ? (b) : (a))   ///< Returns the minimum of a and b
 
 void reb_integrator_part1(struct reb_simulation* r){
+	r->collisions_N = 0; // Maybe a better place to put this? Just need to reset before every timestep
 	switch(r->integrator){
 		case REB_INTEGRATOR_IAS15:
 			reb_integrator_ias15_part1(r);

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -415,7 +415,6 @@ void reb_integrator_trace_bs_step(struct reb_simulation* const r, double dt){
         nbody_ode->needs_nbody = 0;
 
         // TODO: Support backwards integrations
-	unsigned int collisions_N = 0;
         while(r->t < t_needed && fabs(dt/old_dt)>1e-14 ){
             double* y = nbody_ode->y;
 
@@ -491,7 +490,6 @@ void reb_integrator_trace_bs_step(struct reb_simulation* const r, double dt){
         }
 
         // Restore odes
-	
         reb_ode_free(nbody_ode);
         free(r->odes);
         r->odes = odes_backup;
@@ -749,7 +747,6 @@ static void reb_integrator_trace_step(struct reb_simulation* const r){
                     struct reb_ode* nbody_ode = NULL;
 
                     double* y;
-		    unsigned int collisions_N = 0;
                     while(r->t < t_needed && fabs(r->dt/old_dt)>1e-14 ){
                         if (!nbody_ode || nbody_ode->length != 6*r->N){
                             if (nbody_ode){
@@ -781,7 +778,6 @@ static void reb_integrator_trace_step(struct reb_simulation* const r){
                         reb_integrator_bs_update_particles(r, nbody_ode->y);
 
                         reb_collision_search(r);
-			collisions_N += r->collisions_N;
                     }
                     reb_ode_free(nbody_ode);
                     // Resetting BS here reduces binary file size

--- a/src/integrator_trace.c
+++ b/src/integrator_trace.c
@@ -451,6 +451,7 @@ void reb_integrator_trace_bs_step(struct reb_simulation* const r, double dt){
             r->particles[0].vz = star.vz;
             
 	    reb_collision_search(r);
+	    if (r->collisions_N) r->ri_trace.force_accept = 1;
 
             if (nbody_ode->length != ri_trace->encounter_N*3*2){
 		// Just re-create the ODE
@@ -736,6 +737,7 @@ static void reb_integrator_trace_step(struct reb_simulation* const r){
                         r->dt = t_needed-r->t;
                     }
                     reb_collision_search(r);
+	            if (r->collisions_N) r->ri_trace.force_accept = 1;
                 }
                 // Resetting IAS15 here reduces binary file size.
                 reb_integrator_ias15_reset(r);
@@ -778,6 +780,7 @@ static void reb_integrator_trace_step(struct reb_simulation* const r){
                         reb_integrator_bs_update_particles(r, nbody_ode->y);
 
                         reb_collision_search(r);
+	                if (r->collisions_N) r->ri_trace.force_accept = 1;
                     }
                     reb_ode_free(nbody_ode);
                     // Resetting BS here reduces binary file size
@@ -812,8 +815,6 @@ void reb_integrator_trace_part2(struct reb_simulation* const r){
     
     // Attempt one step. 
     reb_integrator_trace_step(r);
-
-    if (r->collisions_N) ri_trace->force_accept = 1;
 
     // We alaways accept the step if a collision occured as it is impossible to undo the collision.
     if (!ri_trace->force_accept){

--- a/src/output.c
+++ b/src/output.c
@@ -176,6 +176,7 @@ const struct reb_binary_field_descriptor reb_binary_field_descriptor_list[]= {
     { 165, REB_DOUBLE,      "ri_trace.r_crit_hill",         offsetof(struct reb_simulation, ri_trace.r_crit_hill), 0, 0},
     // TRACE Pericenter conditions used to have ids 166 - 168. Do not reuse.
     { 169, REB_DOUBLE,      "ri_trace.peri_crit_eta",       offsetof(struct reb_simulation, ri_trace.peri_crit_eta), 0, 0},
+    { 170, REB_INT, "ri_trace.peri_mode", offsetof(struct reb_simulation, ri_trace.peri_mode), 0, 0},
 //    { 163, REB_INT,         "var_rescale_warning", offsetof(struct reb_simulation, var_rescale_warning), 0, 0},
     // TES Variables used to have ids 300 - 388. Do not reuse. 
     { 390, REB_UINT,        "ri_whfast512.keep_unsynchronized", offsetof(struct reb_simulation, ri_whfast512.keep_unsynchronized), 0, 0},

--- a/src/rebound.c
+++ b/src/rebound.c
@@ -534,6 +534,7 @@ void reb_simulation_init(struct reb_simulation* r){
     r->minimum_collision_velocity = 0;
     r->collisions_plog  = 0;
     r->collisions_log_n  = 0;    
+    r->collisions_N  = 0;    
     r->collision_resolve_keep_sorted   = 0;    
     
     r->simulationarchive_version       = 3;

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -571,6 +571,7 @@ struct reb_simulation {
     int collision_resolve_keep_sorted;      // 0 (default): may reorder particles during collisions, 1: keep particles sorted.
     struct reb_collision* collisions;       // Array of current collisions. Do not change manually
     int N_allocated_collisions;
+    unsigned int collisions_N;
     double minimum_collision_velocity;      // Ensure relative velocity during collisions is at least this much (to avoid particles sinking into each other)
     double collisions_plog;                 // Keeping track of momentum transfer in collisions (for ring simulations)
     double max_radius0;                     // The largest particle radius, set automatically, needed for collision search.


### PR DESCRIPTION
Fixes #829 and doesn't appear to be breaking anything.

Just checking -- `collisions_N` only tracks collisions over one timestep, so there's no need to include it in `output.c` correct?