### PR TITLE
check for convergence on M_to_E

### DIFF
--- a/src/tools.c
+++ b/src/tools.c
@@ -568,16 +568,24 @@ double reb_mod2pi(double f){
 
 double reb_M_to_E(double e, double M){
     double E;
-    int converged = 0;
-    if(e < 1.){
-        M = reb_mod2pi(M); // avoid numerical artefacts for negative numbers
-        E = e < 0.8 ? M : M_PI;
-        double F = E - e*sin(E) - M;
+    double F;
 
+    int converged = 0;
+    if (e < 1.){
+        M = reb_mod2pi(M); // avoid numerical artefacts for negative numbers
+
+        // E = e < 0.8 ? M : M_PI;
+
+        // Guess from Danby & Burkadt 1983 and Napier 2024
+        double sigma = 1.;
+        if (M > M_PI) sigma = -1;
+        E = M + sigma * 0.71 * e;
+
+        F = E - e*sin(E) - M;
         for(int i=0; i<100; i++){
             E = E - F/(1.-e*cos(E));
             F = E - e*sin(E) - M;
-            if(fabs(F) < 1.e-16){
+            if(fabs(F) < 1.e-15){
                 converged = 1;
                 break;
             }
@@ -587,16 +595,15 @@ double reb_M_to_E(double e, double M){
     else{
         E = M/fabs(M)*log(2.*fabs(M)/e + 1.8);
 
-        double F = E - e*sinh(E) + M;
+        F = E - e*sinh(E) + M;
         for(int i=0; i<100; i++){
             E = E - F/(1.0 - e*cosh(E));
             F = E - e*sinh(E) + M;
-            if(fabs(F) < 1.e-16){
+            if(fabs(F) < 1.e-15){
                 converged = 1;
                 break;
             }
         }
-        
     }
     if (converged == 0){
         printf("reb_M_to_E failed to converge. M = %g, e = %g, E = %g\n", M, e, E);

--- a/src/tools.c
+++ b/src/tools.c
@@ -569,11 +569,10 @@ double reb_mod2pi(double f){
 double reb_M_to_E(double e, double M){
     double E;
     double F;
-
-    int converged = 0;
     if (e < 1.){
         M = reb_mod2pi(M); // avoid numerical artefacts for negative numbers
 
+        // Previous REBOUND initial guess
         // E = e < 0.8 ? M : M_PI;
 
         // Guess from Danby & Burkadt 1983 and Napier 2024
@@ -586,7 +585,6 @@ double reb_M_to_E(double e, double M){
             E = E - F/(1.-e*cos(E));
             F = E - e*sin(E) - M;
             if(fabs(F) < 1.e-15){
-                converged = 1;
                 break;
             }
         }
@@ -600,13 +598,9 @@ double reb_M_to_E(double e, double M){
             E = E - F/(1.0 - e*cosh(E));
             F = E - e*sinh(E) + M;
             if(fabs(F) < 1.e-15){
-                converged = 1;
                 break;
             }
         }
-    }
-    if (converged == 0){
-        printf("reb_M_to_E failed to converge. M = %g, e = %g, E = %g\n", M, e, E);
     }
     return E;
 }

--- a/src/tools.c
+++ b/src/tools.c
@@ -568,19 +568,21 @@ double reb_mod2pi(double f){
 
 double reb_M_to_E(double e, double M){
     double E;
+    int converged = 0;
     if(e < 1.){
         M = reb_mod2pi(M); // avoid numerical artefacts for negative numbers
         E = e < 0.8 ? M : M_PI;
         double F = E - e*sin(E) - M;
+
         for(int i=0; i<100; i++){
             E = E - F/(1.-e*cos(E));
             F = E - e*sin(E) - M;
             if(fabs(F) < 1.e-16){
+                converged = 1;
                 break;
             }
         }
         E = reb_mod2pi(E);
-        return E;
     }
     else{
         E = M/fabs(M)*log(2.*fabs(M)/e + 1.8);
@@ -590,11 +592,16 @@ double reb_M_to_E(double e, double M){
             E = E - F/(1.0 - e*cosh(E));
             F = E - e*sinh(E) + M;
             if(fabs(F) < 1.e-16){
+                converged = 1;
                 break;
             }
         }
-        return E;
+        
     }
+    if (converged == 0){
+        printf("reb_M_to_E failed to converge. M = %g, e = %g, E = %g\n", M, e, E);
+    }
+    return E;
 }
 
 double reb_E_to_f(double e, double E){
@@ -1669,4 +1676,4 @@ void reb_tools_xyz_to_spherical(const struct reb_vec3d xyz, double* magnitude, d
     *magnitude = sqrt(xyz.x*xyz.x + xyz.y*xyz.y + xyz.z*xyz.z);
     *theta = acos2(xyz.z, *magnitude, 1.);    // theta always in [0,pi] so pass dummy disambiguator=1
     *phi = atan2(xyz.y, xyz.x);
-}  
+}


### PR DESCRIPTION
The following setup fails to converge when executing the function `reb_M_to_E` in the `src/tools.c` file. I implemented a simple check to throw a warning message when convergence is not reached after 100 iterations. Perhaps a better implementation is to perform a different method to solve Kepler's equations when Newton's method fails.

```
#include "rebound.h"

int main(int argc, char **argv) {
    double e = 0.1;
    double M = 0.991;
    double E = reb_M_to_E(e, M);

    return 0;
}
```