### PR TITLE
allow negative period for hyperbolic orbits in sim.add

### DIFF
--- a/rebound/particle.py
+++ b/rebound/particle.py
@@ -318,7 +318,7 @@ class Particle(Structure):
             if a is not None and P is not None:
                 raise ValueError("You can pass either the semimajor axis or orbital period, but not both.")
             if a is None:
-                a = (P**2*simulation.G*(primary.m + self.m)/(4.*math.pi**2))**(1./3.)
+                a = (P**2*simulation.G*(primary.m + self.m)/(4.*math.pi**2))**(1./3.)*(P/abs(P)) # keep sign of P for hyperbolic orbits
             if notNone(pal):
                 # Pal orbital parameters
                 if h is None:


### PR DESCRIPTION
sim.add allowed you to add hyperbolic orbits with negative semi major axes, but if you used negative periods, it would error. Simple code to reproduce the error adding the same particle both ways (the second one errors)

import rebound
sim = rebound.Simulation()
sim.add(m=1)
sim.add(a=-1, e=2) # add hyperbolic orbit
sim.add(P=sim.particles[-1].P, e=2) # add same particle but using P instead of a

This just keeps the sign of P when converting to semi major axis