### PR TITLE
using Yoshida Solution A for LF6. Previous coefficients were truncated.

### DIFF
--- a/rebound/tests/test_leapfrog.py
+++ b/rebound/tests/test_leapfrog.py
@@ -42,7 +42,7 @@ class TestIntegrator(unittest.TestCase):
         self.sim.integrate(1e3)
         self.sim.step()
         e1 = self.sim.energy()
-        self.assertLess(math.fabs((e0-e1)/e1),1e-9)
+        self.assertLess(math.fabs((e0-e1)/e1),2e-9)
     
     def test_leapfrog_order_8(self):
         self.sim.integrator = "leapfrog"

--- a/src/integrator_eos.c
+++ b/src/integrator_eos.c
@@ -396,10 +396,6 @@ static void reb_integrator_eos_drift_shell0(struct reb_simulation* const r, doub
                 reb_integrator_eos_interaction_shell1(r, dt*reb_integrator_leapfrog_lf6_a[2], 0.);
                 reb_integrator_eos_drift_shell1(r, dt*(reb_integrator_leapfrog_lf6_a[2]+reb_integrator_leapfrog_lf6_a[3])*0.5);
                 reb_integrator_eos_interaction_shell1(r, dt*reb_integrator_leapfrog_lf6_a[3], 0.);
-                reb_integrator_eos_drift_shell1(r, dt*(reb_integrator_leapfrog_lf6_a[3]+reb_integrator_leapfrog_lf6_a[4])*0.5);
-                reb_integrator_eos_interaction_shell1(r, dt*reb_integrator_leapfrog_lf6_a[4], 0.);
-                reb_integrator_eos_drift_shell1(r, dt*(reb_integrator_leapfrog_lf6_a[3]+reb_integrator_leapfrog_lf6_a[4])*0.5);
-                reb_integrator_eos_interaction_shell1(r, dt*reb_integrator_leapfrog_lf6_a[3], 0.);
                 reb_integrator_eos_drift_shell1(r, dt*(reb_integrator_leapfrog_lf6_a[2]+reb_integrator_leapfrog_lf6_a[3])*0.5);
                 reb_integrator_eos_interaction_shell1(r, dt*reb_integrator_leapfrog_lf6_a[2], 0.);
                 reb_integrator_eos_drift_shell1(r, dt*(reb_integrator_leapfrog_lf6_a[1]+reb_integrator_leapfrog_lf6_a[2])*0.5);

--- a/src/integrator_leapfrog.c
+++ b/src/integrator_leapfrog.c
@@ -33,7 +33,7 @@
 #include "integrator_leapfrog.h"
 
 const double reb_integrator_leapfrog_lf4_a = 0.675603595979828817023843904485;
-const double reb_integrator_leapfrog_lf6_a[5] = {0.1867, 0.5554970237124784, 0.1294669489134754, -0.843265623387734, 0.9432033015235604};
+const double reb_integrator_leapfrog_lf6_a[5] = {0.78451361047756, 0.23557321335936, -1.1776799841789, 1.3151863206846204};
 const double reb_integrator_leapfrog_lf8_a[9] = {0.128865979381443, 0.581514087105251, -0.410175371469850, 0.1851469357165877, -0.4095523434208514, 0.1444059410800120, 0.2783355003936797, 0.3149566839162949, -0.6269948254051343979}; 
 
 static void drift(struct reb_simulation* r, double dt){
@@ -109,12 +109,6 @@ void reb_integrator_leapfrog_part2(struct reb_simulation* r){
             reb_simulation_update_acceleration(r);
             kick(r, dt*reb_integrator_leapfrog_lf6_a[2]);
             drift(r, dt*(reb_integrator_leapfrog_lf6_a[2]+reb_integrator_leapfrog_lf6_a[3])*0.5);
-            reb_simulation_update_acceleration(r);
-            kick(r, dt*reb_integrator_leapfrog_lf6_a[3]);
-            drift(r, dt*(reb_integrator_leapfrog_lf6_a[3]+reb_integrator_leapfrog_lf6_a[4])*0.5);
-            reb_simulation_update_acceleration(r);
-            kick(r, dt*reb_integrator_leapfrog_lf6_a[4]);
-            drift(r, dt*(reb_integrator_leapfrog_lf6_a[3]+reb_integrator_leapfrog_lf6_a[4])*0.5);
             reb_simulation_update_acceleration(r);
             kick(r, dt*reb_integrator_leapfrog_lf6_a[3]);
             drift(r, dt*(reb_integrator_leapfrog_lf6_a[2]+reb_integrator_leapfrog_lf6_a[3])*0.5);


### PR DESCRIPTION
LF6 coefficient was truncated. New ones use fewer function evaluations (but bigger negative step sizes). 