### PR TITLE
Feat: Add try_create API to prevent Segfault on memory allocation failure

### DIFF
--- a/src/rebound.c
+++ b/src/rebound.c
@@ -380,11 +380,17 @@ int reb_simulation_reset_function_pointers(struct reb_simulation* const r){
 }
 
 struct reb_simulation* reb_simulation_create(){
-    struct reb_simulation* r = calloc(1,sizeof(struct reb_simulation));
-    reb_simulation_init(r);
+    struct reb_simulation* r = reb_simulation_try_create();
+    if (r == NULL) reb_exit("Memory allocation failed.");
     return r;
 }
 
+struct reb_simulation* reb_simulation_try_create(){
+    struct reb_simulation* r = calloc(1,sizeof(struct reb_simulation));
+    if (r == NULL) return NULL;
+    reb_simulation_init(r);
+    return r;
+}
 
 void reb_simulation_copy_with_messages(struct reb_simulation* r_copy,  struct reb_simulation* r, enum reb_simulation_binary_error_codes* warnings){
     char* bufp;

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -701,8 +701,10 @@ struct reb_simulation {
 
 // Simulation life cycle
 
-// Allocates memory for reb_simulation and initializes it.
+// Allocates memory for reb_simulation and initializes it. Fatal on allocation failure.
 DLLEXPORT struct reb_simulation* reb_simulation_create(void);
+// Attempts to allocate memory for reb_simulation and initializes it. Returns NULL on allocation failure.
+DLLEXPORT struct reb_simulation* reb_simulation_try_create(void);
 // Create a simulation object from a file. Set snapshot=-1 to load last snapshot.
 DLLEXPORT struct reb_simulation* reb_simulation_create_from_file(char* filename, int64_t snapshot);
 // Create a simulation object from a simulationarchive. Set snapshot=-1 to load last snapshot.


### PR DESCRIPTION
Hi! I'm currently working on a Rust wrapper for REBOUND. During development, I noticed that `reb_simulation_create` calls `memset` immediately after `calloc` without checking for a `NULL` return value. If the memory allocation fails, this triggers an immediate Segmentation Fault.

For high-level language wrappers (like Rust, Python, etc.), it's crucial to catch these Out-Of-Memory (OOM) errors gracefully rather than having the entire process hard-crash.

## Changes

To fix this without breaking backward compatibility, I implemented the following:
- Add `reb_simulation_try_create()`, which returns `NULL` on allocation failure
- make `reb_simulation_create()` call `reb_simulation_try_create()` and fail explicitly on allocation failure

## Notes

While reviewing the code, I noticed there are many other `malloc` and `calloc` calls throughout the codebase that also lack `NULL` checks. To keep this PR focused and easy to review, I only addressed the primary simulation initialization. However, it might be worth adding similar checks to other memory allocations in the future to further harden the library.

Thanks for the great library!