### PR TITLE
Niave CUDA implementation of REB_GRAVITY_BASIC

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -3,21 +3,30 @@ include Makefile.defs
 SOURCES=rebound.c tree.c particle.c gravity.c integrator.c integrator_whfast.c integrator_whfast512.c integrator_saba.c integrator_ias15.c integrator_sei.c integrator_bs.c integrator_leapfrog.c integrator_mercurius.c integrator_trace.c integrator_eos.c boundary.c input.c binarydiff.c output.c collision.c communication_mpi.c display.c tools.c rotations.c derivatives.c simulationarchive.c glad.c integrator_janus.c transformations.c fmemopen.c server.c frequency_analysis.c
 OBJECTS=$(SOURCES:.c=.$(OBJFILEEXT))
 HEADERS=$(SOURCES:.c=.h)
+ifeq ($(CUDA), 1)
+SOURCES += gravity_opt.cu
+OBJECTS += gravity_opt.o
+HEADERS += gravity_opt.h
+endif
 
 all: $(SOURCES) $(LIBREBOUND)
 
-ifneq ($(OS),Windows_NT) 
+ifneq ($(OS),Windows_NT)
 # Linux, MacOS
 %.$(OBJFILEEXT): %.c $(HEADERS)
 	@echo "Compiling source file $< ..."
 	$(CC) -c $(OPT) $(PREDEF) -o $@ $<
 
+%.$(OBJFILEEXT): %.cu $(HEADERS)
+	@echo "Compiling source file $< ..."
+	$(CC) -c $(OPT) $(PREDEF) -o $@ $<
+
 $(LIBREBOUND): $(OBJECTS)
-	@echo ""        
+	@echo ""
 	@echo "Linking shared library $@ ..."
-	$(CC) $(OPT) -shared $(OBJECTS) $(LIB) -o $@ 
-	
-	@echo ""        
+	$(CC) $(OPT) -shared $(OBJECTS) $(LIB) -o $@
+
+	@echo ""
 	@echo "The shared library $< has been created successfully."
 else
 # Windows
@@ -26,15 +35,15 @@ else
 	$(CC) -c $(OPT) $(PREDEF) /Fo: $@ $<
 
 $(LIBREBOUND): $(OBJECTS)
-	@echo ""        
+	@echo ""
 	@echo "Linking shared library $@ ..."
-	$(CC) /D_USRDLL /D_WINDLL $(OBJECTS) /link /DLL /OUT:$@ 
-	
-	@echo ""        
+	$(CC) /D_USRDLL /D_WINDLL $(OBJECTS) /link /DLL /OUT:$@
+
+	@echo ""
 	@echo "The shared library $< has been created successfully."
 endif
-	
-	
+
+
 clean:
 	@echo "Removing object files *.$(OBJFILEEXT) ..."
 	@-$(RM) *.$(OBJFILEEXT)
@@ -43,4 +52,4 @@ clean:
 	@echo "Removing coverage files ..."
 	@-$(RM) *.gcda
 	@-$(RM) *.gcno
-	
+

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -2,14 +2,23 @@ ifndef OS
 	OS=$(shell uname)
 endif
 ifneq ($(OS), Windows_NT)
-	OPT+= -std=c99 -Wpointer-arith -D_GNU_SOURCE -fPIC
+	ifeq ($(CUDA), 1)
+		CC=nvcc
+		OPT+= -Xcompiler -std=c99 -Xcompiler -Wpointer-arith -D_GNU_SOURCE -Xcompiler -fPIC
+	else
+		OPT+= -std=c99 -Wpointer-arith -D_GNU_SOURCE -fPIC
+	endif
 	OBJFILEEXT=o
 	LIBREBOUND=librebound.so
 	EXEREBOUND=rebound
 	RM=rm -f
 	LINKORCOPYLIBREBOUND=ln -s -f ../../src/$(LIBREBOUND) .
 	LINKORCOPYLIBREBOUNDMAIN=ln -s -f src/$(LIBREBOUND) .
-	CCPROBLEM=$(CC) -I../../src/ -Wl,-rpath,./ $(OPT) $(PREDEF) $< -L. -lrebound $(LIB) -o $(EXEREBOUND)
+	ifeq ($(CUDA), 1)
+		CCPROBLEM=$(CC) -I../../src/ -Xlinker -rpath,./ $(OPT) $(PREDEF) $< -L. -lrebound $(LIB) -o $(EXEREBOUND)
+	else
+		CCPROBLEM=$(CC) -I../../src/ -Wl,-rpath,./ $(OPT) $(PREDEF) $< -L. -lrebound $(LIB) -o $(EXEREBOUND)
+	endif
 else
 ifeq ($(OPENGL), 1)
 $(warning OpenGL not supported on Windows. Setting OPENGL=0)
@@ -24,7 +33,7 @@ endif
 ifeq ($(AVX512), 1)
 $(error AVX512 currently not supported on Windows. Please set AVX512=0)
 endif
-	OPT+= /D_GNU_SOURCE /Ox /fp:precise 
+	OPT+= /D_GNU_SOURCE /Ox /fp:precise
 	OBJFILEEXT=obj
 	LIBREBOUND=librebound.dll
 	EXEREBOUND=rebound.exe
@@ -40,7 +49,11 @@ endif
 endif
 # Removed -march=native for now
 ifeq ($(OS), Linux)
-	OPT+= -Wall -g 
+	ifeq ($(CUDA), 1)
+		OPT+= -Xcompiler -Wall -g
+	else
+		OPT+= -Wall -g
+	endif
 	LIB+= -lm -lrt
 endif
 ifeq ($(OS), Darwin)
@@ -57,7 +70,7 @@ ifeq ($(MPI), 1)
 	endif
 	PREDEF+= -DMPI
 else
-	ifeq ($(OS),Windows_NT) 
+	ifeq ($(OS),Windows_NT)
 		ifeq ($(origin CC),default)
 			CC:=cl
 		endif
@@ -114,7 +127,11 @@ ifeq ($(OPENMPCLANG), 1)
 	LIB+= -lomp
 else
 	ifneq ($(OS), Windows_NT)
-		OPT+= -Wno-unknown-pragmas
+		ifeq ($(CUDA), 1)
+			OPT+= -Xcompiler -Wno-unknown-pragmas
+		else
+			OPT+= -Wno-unknown-pragmas
+		endif
 	endif
 endif
 endif

--- a/src/gravity.c
+++ b/src/gravity.c
@@ -4,12 +4,12 @@
  * @author     Hanno Rein <hanno@hanno-rein.de>
  *
  * @details     This is the crudest implementation of an N-body code
- * which sums up every pair of particles. It is only useful very small 
+ * which sums up every pair of particles. It is only useful very small
  * particle numbers (N<~100) as it scales as O(N^2). Note that the MPI
  * implementation is not well tested and only works for very specific
- * problems. This should be resolved in the future. 
+ * problems. This should be resolved in the future.
  *
- * 
+ *
  * @section LICENSE
  * Copyright (c) 2011 Hanno Rein, Shangfei Liu
  *
@@ -43,12 +43,15 @@
 #ifdef MPI
 #include "communication_mpi.h"
 #endif
+#ifdef CUDA
+#include "gravity_opt.h"
+#endif
 
 /**
  * @brief The function loops over all trees to call calculate_forces_for_particle_from_cell() tree to calculate forces for each particle.
  * @param r REBOUND simulation to consider
  * @param pt Index of the particle the force is calculated for.
- * @param gb Ghostbox plus position of the particle (precalculated). 
+ * @param gb Ghostbox plus position of the particle (precalculated).
  */
 static void reb_calculate_acceleration_for_particle(const struct reb_simulation* const r, const int pt, const struct reb_vec6d gb);
 
@@ -71,10 +74,10 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
     switch (r->gravity){
         case REB_GRAVITY_NONE: // Do nothing.
             for (int j=0; j<N; j++){
-                particles[j].ax = 0;  
-                particles[j].ay = 0;  
-                particles[j].az = 0;  
-            }  
+                particles[j].ax = 0;
+                particles[j].ay = 0;
+                particles[j].az = 0;
+            }
             break;
         case REB_GRAVITY_JACOBI:
             {
@@ -86,19 +89,19 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                 double Rjz = 0.;
                 double Mj = 0.;
                 for (int j=0; j<N; j++){
-                    particles[j].ax = 0; 
-                    particles[j].ay = 0; 
-                    particles[j].az = 0; 
+                    particles[j].ax = 0;
+                    particles[j].ay = 0;
+                    particles[j].az = 0;
                     for (int i=0; i<j+1; i++){
                         if (j>1){
                             ////////////////
                             // Jacobi Term
                             // Note: ignoring j==1 term here and below as they cancel
-                            const double Qjx = particles[j].x - Rjx/Mj; 
+                            const double Qjx = particles[j].x - Rjx/Mj;
                             const double Qjy = particles[j].y - Rjy/Mj;
                             const double Qjz = particles[j].z - Rjz/Mj;
                             const double dr = sqrt(Qjx*Qjx + Qjy*Qjy + Qjz*Qjz);
-                            double dQjdri = Mj; 
+                            double dQjdri = Mj;
                             if (i<j){
                                 dQjdri = -particles[j].m; //rearranged such that m==0 does not diverge
                             }
@@ -110,7 +113,7 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                         if (i!=j && (i!=0 || j!=1)){
                             ////////////////
                             // Direct Term
-                            // Note: ignoring i==0 && j==1 term here and above as they cancel 
+                            // Note: ignoring i==0 && j==1 term here and above as they cancel
                             const double dx = particles[i].x - particles[j].x;
                             const double dy = particles[i].y - particles[j].y;
                             const double dz = particles[i].z - particles[j].z;
@@ -143,11 +146,11 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                 const int starti = (_gravity_ignore_terms==0)?1:2;
                 const int startj = (_gravity_ignore_terms==2)?1:0;
 #endif // OPENMP
-#pragma omp parallel for 
+#pragma omp parallel for
                 for (int i=0; i<N; i++){
-                    particles[i].ax = 0; 
-                    particles[i].ay = 0; 
-                    particles[i].az = 0; 
+                    particles[i].ax = 0;
+                    particles[i].ay = 0;
+                    particles[i].az = 0;
                 }
                 // Summing over all Ghost Boxes
                 for (int gbx=-N_ghost_x; gbx<=N_ghost_x; gbx++){
@@ -155,7 +158,12 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                         for (int gbz=-N_ghost_z; gbz<=N_ghost_z; gbz++){
                             struct reb_vec6d gb = reb_boundary_get_ghostbox(r, gbx,gby,gbz);
                             // All active particle pairs
-#ifndef OPENMP // OPENMP off, do O(1/2*N^2)
+#ifndef OPENMP
+#ifdef CUDA
+                            // Launch CUDA kernel
+                            launch_gravity_basic_naive(_N_real, _N_active, G, softening2, _gravity_ignore_terms, gb, particles);
+#endif //CUDA
+// OPENMP off, do O(1/2*N^2)
                             for (int i=starti; i<_N_active; i++){
                                 if (reb_sigint > 1) return;
                                 for (int j=startj; j<i; j++){
@@ -252,9 +260,9 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                 struct reb_vec3d* restrict const cs = r->gravity_cs;
 #pragma omp parallel for schedule(guided)
                 for (int i=0; i<_N_real; i++){
-                    particles[i].ax = 0.; 
-                    particles[i].ay = 0.; 
-                    particles[i].az = 0.; 
+                    particles[i].ax = 0.;
+                    particles[i].ay = 0.;
+                    particles[i].az = 0.;
                     cs[i].x = 0.;
                     cs[i].y = 0.;
                     cs[i].z = 0.;
@@ -488,9 +496,9 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
             {
 #pragma omp parallel for schedule(guided)
                 for (int i=0; i<N; i++){
-                    particles[i].ax = 0; 
-                    particles[i].ay = 0; 
-                    particles[i].az = 0; 
+                    particles[i].ax = 0;
+                    particles[i].ay = 0;
+                    particles[i].az = 0;
                 }
                 // Summing over all Ghost Boxes
                 for (int gbx=-r->N_ghost_x; gbx<=r->N_ghost_x; gbx++){
@@ -523,9 +531,9 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                             const double* const dcrit = r->ri_mercurius.dcrit;
 #ifndef OPENMP
                             for (int i=0; i<_N_real; i++){
-                                particles[i].ax = 0; 
-                                particles[i].ay = 0; 
-                                particles[i].az = 0; 
+                                particles[i].ax = 0;
+                                particles[i].ay = 0;
+                                particles[i].az = 0;
                             }
                             for (int i=2; i<_N_active; i++){
                                 if (reb_sigint > 1) return;
@@ -571,14 +579,14 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                                 }
                             }
 #else // OPENMP
-                            particles[0].ax = 0; 
-                            particles[0].ay = 0; 
-                            particles[0].az = 0; 
+                            particles[0].ax = 0;
+                            particles[0].ay = 0;
+                            particles[0].az = 0;
 #pragma omp parallel for schedule(guided)
                             for (int i=1; i<_N_real; i++){
-                                particles[i].ax = 0; 
-                                particles[i].ay = 0; 
-                                particles[i].az = 0; 
+                                particles[i].ax = 0;
+                                particles[i].ay = 0;
+                                particles[i].az = 0;
                                 for (int j=1; j<_N_active; j++){
                                     if (i==j) continue;
                                     const double dx = particles[i].x - particles[j].x;
@@ -620,9 +628,9 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                             const int encounter_N_active = r->ri_mercurius.encounter_N_active;
                             int* map = r->ri_mercurius.encounter_map;
 #ifndef OPENMP
-                            particles[0].ax = 0; // map[0] is always 0 
-                            particles[0].ay = 0; 
-                            particles[0].az = 0; 
+                            particles[0].ax = 0; // map[0] is always 0
+                            particles[0].ay = 0;
+                            particles[0].az = 0;
                             // Acceleration due to star
                             for (int i=1; i<encounter_N; i++){
                                 int mi = map[i];
@@ -685,17 +693,17 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
                                 }
                             }
 #else // OPENMP
-                            particles[0].ax = 0; // map[0] is always 0 
-                            particles[0].ay = 0; 
-                            particles[0].az = 0; 
+                            particles[0].ax = 0; // map[0] is always 0
+                            particles[0].ay = 0;
+                            particles[0].az = 0;
                             // We're in a heliocentric coordinate system.
                             // The star feels no acceleration
 #pragma omp parallel for schedule(guided)
                             for (int i=1; i<encounter_N; i++){
                                 int mi = map[i];
-                                particles[mi].ax = 0; 
-                                particles[mi].ay = 0; 
-                                particles[mi].az = 0; 
+                                particles[mi].ax = 0;
+                                particles[mi].ay = 0;
+                                particles[mi].az = 0;
                                 // Acceleration due to star
                                 const double x = particles[mi].x;
                                 const double y = particles[mi].y;
@@ -978,7 +986,7 @@ void reb_simulation_update_acceleration_gravity(struct reb_simulation* r){
 #endif // OPENMP
                     }
                     break;
-                case REB_TRACE_MODE_NONE: // In-between steps. Do not calculate anything. 
+                case REB_TRACE_MODE_NONE: // In-between steps. Do not calculate anything.
                     break;
                 default:
                     reb_simulation_error(r, "TRACE mode not supported in gravity.c");
@@ -1027,9 +1035,9 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                     struct reb_particle* const particles_var1 = particles + vc.index;
                     if (vc.testparticle<0){
                         for (int i=0; i<_N_real; i++){
-                            particles_var1[i].ax = 0.; 
-                            particles_var1[i].ay = 0.; 
-                            particles_var1[i].az = 0.; 
+                            particles_var1[i].ax = 0.;
+                            particles_var1[i].ay = 0.;
+                            particles_var1[i].az = 0.;
                         }
                         for (int i=starti; i<_N_active; i++){
                             for (int j=startj; j<i; j++){
@@ -1067,7 +1075,7 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
 
                                 particles_var1[j].ax -= Gmi * dax - dGmi*r3inv*dx;
                                 particles_var1[j].ay -= Gmi * day - dGmi*r3inv*dy;
-                                particles_var1[j].az -= Gmi * daz - dGmi*r3inv*dz; 
+                                particles_var1[j].az -= Gmi * daz - dGmi*r3inv*dz;
                             }
                         }
                         for (int i=_N_active; i<_N_real; i++){
@@ -1107,15 +1115,15 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                                     // Warning! This does not make sense when the mass is varied!
                                     particles_var1[j].ax -= Gmi * dax - dGmi*r3inv*dx;
                                     particles_var1[j].ay -= Gmi * day - dGmi*r3inv*dy;
-                                    particles_var1[j].az -= Gmi * daz - dGmi*r3inv*dz; 
+                                    particles_var1[j].az -= Gmi * daz - dGmi*r3inv*dz;
                                 }
                             }
                         }
                     }else{ //testparticle
                         int i = vc.testparticle;
-                        particles_var1[0].ax = 0.; 
-                        particles_var1[0].ay = 0.; 
-                        particles_var1[0].az = 0.; 
+                        particles_var1[0].ax = 0.;
+                        particles_var1[0].ay = 0.;
+                        particles_var1[0].az = 0.;
                         for (int j=0; j<_N_real; j++){
                             if (i==j) continue;
                             if (_gravity_ignore_terms==1 && ((j==1 && i==0) || (i==1 && j==0))) continue;
@@ -1163,9 +1171,9 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                     struct reb_particle* const particles_var1b = particles + vc.index_1st_order_b;
                     if (vc.testparticle<0){
                         for (int i=0; i<_N_real; i++){
-                            particles_var2[i].ax = 0.; 
-                            particles_var2[i].ay = 0.; 
-                            particles_var2[i].az = 0.; 
+                            particles_var2[i].ax = 0.;
+                            particles_var2[i].ay = 0.;
+                            particles_var2[i].az = 0.;
                         }
                         for (int i=0; i<_N_real; i++){
                             for (int j=i+1; j<_N_real; j++){
@@ -1213,15 +1221,15 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                                 const double dk1dk2 =  dk1dx*dk2dx + dk1dy*dk2dy + dk1dz*dk2dz;
                                 dax     +=        3.* r5inv * dk2dx * rdk1
                                     + 3.* r5inv * dk1dx * rdk2
-                                    + 3.* r5inv    * dx * dk1dk2  
+                                    + 3.* r5inv    * dx * dk1dk2
                                     - 15.      * dx * r7inv * rdk1 * rdk2;
                                 day     +=        3.* r5inv * dk2dy * rdk1
                                     + 3.* r5inv * dk1dy * rdk2
-                                    + 3.* r5inv    * dy * dk1dk2  
+                                    + 3.* r5inv    * dy * dk1dk2
                                     - 15.      * dy * r7inv * rdk1 * rdk2;
                                 daz     +=        3.* r5inv * dk2dz * rdk1
                                     + 3.* r5inv * dk1dz * rdk2
-                                    + 3.* r5inv    * dz * dk1dk2  
+                                    + 3.* r5inv    * dz * dk1dk2
                                     - 15.      * dz * r7inv * rdk1 * rdk2;
 
                                 const double dk1Gmi = G * particles_var1a[i].m;
@@ -1229,28 +1237,28 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                                 const double dk2Gmi = G * particles_var1b[i].m;
                                 const double dk2Gmj = G * particles_var1b[j].m;
 
-                                particles_var2[i].ax += Gmj * dax 
-                                    - ddGmj*r3inv*dx 
+                                particles_var2[i].ax += Gmj * dax
+                                    - ddGmj*r3inv*dx
                                     - dk2Gmj*r3inv*dk1dx + 3.*dk2Gmj*r5inv*dx*rdk1
                                     - dk1Gmj*r3inv*dk2dx + 3.*dk1Gmj*r5inv*dx*rdk2;
-                                particles_var2[i].ay += Gmj * day 
+                                particles_var2[i].ay += Gmj * day
                                     - ddGmj*r3inv*dy
                                     - dk2Gmj*r3inv*dk1dy + 3.*dk2Gmj*r5inv*dy*rdk1
                                     - dk1Gmj*r3inv*dk2dy + 3.*dk1Gmj*r5inv*dy*rdk2;
-                                particles_var2[i].az += Gmj * daz 
+                                particles_var2[i].az += Gmj * daz
                                     - ddGmj*r3inv*dz
                                     - dk2Gmj*r3inv*dk1dz + 3.*dk2Gmj*r5inv*dz*rdk1
                                     - dk1Gmj*r3inv*dk2dz + 3.*dk1Gmj*r5inv*dz*rdk2;
 
-                                particles_var2[j].ax -= Gmi * dax 
+                                particles_var2[j].ax -= Gmi * dax
                                     - ddGmi*r3inv*dx
                                     - dk2Gmi*r3inv*dk1dx + 3.*dk2Gmi*r5inv*dx*rdk1
                                     - dk1Gmi*r3inv*dk2dx + 3.*dk1Gmi*r5inv*dx*rdk2;
-                                particles_var2[j].ay -= Gmi * day 
+                                particles_var2[j].ay -= Gmi * day
                                     - ddGmi*r3inv*dy
                                     - dk2Gmi*r3inv*dk1dy + 3.*dk2Gmi*r5inv*dy*rdk1
                                     - dk1Gmi*r3inv*dk2dy + 3.*dk1Gmi*r5inv*dy*rdk2;
-                                particles_var2[j].az -= Gmi * daz 
+                                particles_var2[j].az -= Gmi * daz
                                     - ddGmi*r3inv*dz
                                     - dk2Gmi*r3inv*dk1dz + 3.*dk2Gmi*r5inv*dz*rdk1
                                     - dk1Gmi*r3inv*dk2dz + 3.*dk1Gmi*r5inv*dz*rdk2;
@@ -1258,9 +1266,9 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                         }
                     }else{ //testparticle
                         int i = vc.testparticle;
-                        particles_var2[0].ax = 0.; 
-                        particles_var2[0].ay = 0.; 
-                        particles_var2[0].az = 0.; 
+                        particles_var2[0].ax = 0.;
+                        particles_var2[0].ay = 0.;
+                        particles_var2[0].az = 0.;
                         for (int j=0; j<_N_real; j++){
                             if (i==j) continue;
                             // TODO: Need to implement WH skipping
@@ -1304,20 +1312,20 @@ void reb_simulation_update_acceleration_gravity_var(struct reb_simulation* r){
                             const double dk1dk2 =  dk1dx*dk2dx + dk1dy*dk2dy + dk1dz*dk2dz;
                             dax     +=        3.* r5inv * dk2dx * rdk1
                                 + 3.* r5inv * dk1dx * rdk2
-                                + 3.* r5inv    * dx * dk1dk2  
+                                + 3.* r5inv    * dx * dk1dk2
                                 - 15.      * dx * r7inv * rdk1 * rdk2;
                             day     +=        3.* r5inv * dk2dy * rdk1
                                 + 3.* r5inv * dk1dy * rdk2
-                                + 3.* r5inv    * dy * dk1dk2  
+                                + 3.* r5inv    * dy * dk1dk2
                                 - 15.      * dy * r7inv * rdk1 * rdk2;
                             daz     +=        3.* r5inv * dk2dz * rdk1
                                 + 3.* r5inv * dk1dz * rdk2
-                                + 3.* r5inv    * dz * dk1dk2  
+                                + 3.* r5inv    * dz * dk1dk2
                                 - 15.      * dz * r7inv * rdk1 * rdk2;
 
                             // No variational mass contributions for test particles!
 
-                            particles_var2[0].ax += Gmj * dax; 
+                            particles_var2[0].ax += Gmj * dax;
                             particles_var2[0].ay += Gmj * day;
                             particles_var2[0].az += Gmj * daz;
                         }
@@ -1354,13 +1362,13 @@ void reb_calculate_and_apply_jerk(struct reb_simulation* r, const double v){
                 if (reb_sigint > 1) return;
 #endif // OPENMP
                 for (int j=startj; j<i; j++){
-                    const double dx = particles[i].x - particles[j].x; 
-                    const double dy = particles[i].y - particles[j].y; 
-                    const double dz = particles[i].z - particles[j].z; 
+                    const double dx = particles[i].x - particles[j].x;
+                    const double dy = particles[i].y - particles[j].y;
+                    const double dz = particles[i].z - particles[j].z;
 
-                    const double dax = particles[i].ax - particles[j].ax; 
-                    const double day = particles[i].ay - particles[j].ay; 
-                    const double daz = particles[i].az - particles[j].az; 
+                    const double dax = particles[i].ax - particles[j].ax;
+                    const double day = particles[i].ay - particles[j].ay;
+                    const double daz = particles[i].az - particles[j].az;
 
                     const double dr = sqrt(dx*dx + dy*dy + dz*dz);
                     const double alphasum = dax*dx+day*dy+daz*dz;
@@ -1385,13 +1393,13 @@ void reb_calculate_and_apply_jerk(struct reb_simulation* r, const double v){
                 if (reb_sigint > 1) return;
 #endif // OPENMP
                 for (int j=startj; j<i; j++){
-                    const double dx = particles[i].x - particles[j].x; 
-                    const double dy = particles[i].y - particles[j].y; 
-                    const double dz = particles[i].z - particles[j].z; 
+                    const double dx = particles[i].x - particles[j].x;
+                    const double dy = particles[i].y - particles[j].y;
+                    const double dz = particles[i].z - particles[j].z;
 
-                    const double dax = particles[i].ax - particles[j].ax; 
-                    const double day = particles[i].ay - particles[j].ay; 
-                    const double daz = particles[i].az - particles[j].az; 
+                    const double dax = particles[i].ax - particles[j].ax;
+                    const double day = particles[i].ay - particles[j].ay;
+                    const double daz = particles[i].az - particles[j].az;
 
                     const double dr = sqrt(dx*dx + dy*dy + dz*dz);
                     const double alphasum = dax*dx+day*dy+daz*dz;
@@ -1429,7 +1437,7 @@ void reb_calculate_and_apply_jerk(struct reb_simulation* r, const double v){
  * @param r REBOUND simulation to consider
  * @param pt Index of the particle the force is calculated for.
  * @param node Pointer to the cell the force is calculated from.
- * @param gb Ghostbox plus position of the particle (precalculated). 
+ * @param gb Ghostbox plus position of the particle (precalculated).
  */
 static void reb_calculate_acceleration_for_particle_from_cell(const struct reb_simulation* const r, const int pt, const struct reb_treecell *node, const struct reb_vec6d gb);
 
@@ -1462,28 +1470,28 @@ static void reb_calculate_acceleration_for_particle_from_cell(const struct reb_s
             double prefact = -G/(_r*_r*_r)*node->m;
 #ifdef QUADRUPOLE
             double qprefact = G/(_r*_r*_r*_r*_r);
-            particles[pt].ax += qprefact*(dx*node->mxx + dy*node->mxy + dz*node->mxz); 
-            particles[pt].ay += qprefact*(dx*node->mxy + dy*node->myy + dz*node->myz); 
-            particles[pt].az += qprefact*(dx*node->mxz + dy*node->myz + dz*node->mzz); 
+            particles[pt].ax += qprefact*(dx*node->mxx + dy*node->mxy + dz*node->mxz);
+            particles[pt].ay += qprefact*(dx*node->mxy + dy*node->myy + dz*node->myz);
+            particles[pt].az += qprefact*(dx*node->mxz + dy*node->myz + dz*node->mzz);
             double mrr     = dx*dx*node->mxx     + dy*dy*node->myy     + dz*dz*node->mzz
-                + 2.*dx*dy*node->mxy     + 2.*dx*dz*node->mxz     + 2.*dy*dz*node->myz; 
+                + 2.*dx*dy*node->mxy     + 2.*dx*dz*node->mxz     + 2.*dy*dz*node->myz;
             qprefact *= -5.0/(2.0*_r*_r)*mrr;
-            particles[pt].ax += (qprefact + prefact) * dx; 
-            particles[pt].ay += (qprefact + prefact) * dy; 
-            particles[pt].az += (qprefact + prefact) * dz; 
+            particles[pt].ax += (qprefact + prefact) * dx;
+            particles[pt].ay += (qprefact + prefact) * dy;
+            particles[pt].az += (qprefact + prefact) * dz;
 #else
-            particles[pt].ax += prefact*dx; 
-            particles[pt].ay += prefact*dy; 
-            particles[pt].az += prefact*dz; 
+            particles[pt].ax += prefact*dx;
+            particles[pt].ay += prefact*dy;
+            particles[pt].az += prefact*dz;
 #endif
         }
     } else { // It's a leaf node
         if (node->remote == 0 && node->pt == pt) return;
         double _r = sqrt(r2 + softening2);
         double prefact = -G/(_r*_r*_r)*node->m;
-        particles[pt].ax += prefact*dx; 
-        particles[pt].ay += prefact*dy; 
-        particles[pt].az += prefact*dz; 
+        particles[pt].ax += prefact*dx;
+        particles[pt].ay += prefact*dy;
+        particles[pt].az += prefact*dz;
     }
 }
 

--- a/src/gravity_opt.cu
+++ b/src/gravity_opt.cu
@@ -1,0 +1,179 @@
+#include "gravity_opt.h"
+
+// Naive kernel - basically a direct port of host code to run on GPU
+__global__ void gravity_basic_naive(int N_real, int N_active, double G, double softening2, unsigned int gravity_ignore_terms,
+                                    double gbx, double gby, double gbz,
+                                    double *x, double *y, double *z, const double *m,
+                                    double *ax, double *ay, double *az){
+    // N_real, N_active are loop bounds
+    // G, softening2, and gravity_ignore_terms are constants (could be moved to const memory?)
+    // gbx, gby, gbz arrays store the ghost box x, y, and z
+    // x, y, and z arrays store the particle x, y, and z
+    // m array stores the particle mass
+    // ax, ay, az are the output vraiables for acceleration computed for the particle
+    // Note: particle 0 corresponds to x[0], y[0] , z[0], m[0], ax[0], ay[0], az[0]
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < N_real){
+        // Set x,y,z postiton relative to ghost box
+        double xi = x[i] + gbx;
+        double yi = y[i] + gby;
+        double zi = z[i] + gbz;
+        // Initialize registers to be used in the calculation
+        double dx, dy, dz, _r, prefact;
+        double _ax = 0.0, _ay = 0.0, _az = 0.0;
+        for (int j = 0; j < N_active; j++){
+            if (gravity_ignore_terms==1 && ((j==1 && i==0) || (i==1 && j==0) )) continue;
+            if (gravity_ignore_terms==2 && ((j==0 || i==0) )) continue;
+            if (i==j) continue;
+            dx = xi - x[j];
+            dy = yi - y[j];
+            dz = zi - z[j];
+            _r = sqrt(dx*dx + dy*dy + dz*dz + softening2);
+            prefact = -G/(_r*_r*_r)*m[j];
+
+            _ax    += prefact*dx;
+            _ay    += prefact*dy;
+            _az    += prefact*dz;
+        }
+        ax[i] = _ax;
+        ay[i] = _ay;
+        az[i] = _az;
+    }
+}
+
+// Need a wrapper to launch the kernel from C code
+extern "C" void launch_gravity_basic_naive(int N_real, int N_active, double G, double softening2, unsigned int gravity_ignore_terms,
+                                    reb_vec6d *gb, reb_particle *particles) {
+    // Host arrays
+    double *host_x;
+    double *host_y;
+    double *host_z;
+    double *host_m;
+    double *host_ax;
+    double *host_ay;
+    double *host_az;
+    // Device arrays
+    double *device_x;
+    double *device_y;
+    double *device_z;
+    double *device_m;
+    double *device_ax;
+    double *device_ay;
+    double *device_az;
+
+    int max_N = (N_real > N_active) ? N_real : N_active;
+
+    // Allocate host memory
+    host_x = (double*)malloc(sizeof(double)*max_N);
+    host_y = (double*)malloc(sizeof(double)*max_N);
+    host_z = (double*)malloc(sizeof(double)*max_N);
+    host_m = (double*)malloc(sizeof(double)*max_N);
+    host_ax = (double*)malloc(sizeof(double)*N_real);
+    host_ay = (double*)malloc(sizeof(double)*N_real);
+    host_az = (double*)malloc(sizeof(double)*N_real);
+
+    // Initialize host arrays from particles
+    for (int i=0;i<max_N;i++){
+        host_x[i] = particles[i].x;
+        host_y[i] = particles[i].y;
+        host_z[i] = particles[i].z;
+        host_m[i] = particles[i].m;
+    }
+
+    // Allocate device memory
+
+    if (cudaMalloc((void **) &device_x, sizeof(double)*max_N) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        return;
+    }
+    if (cudaMalloc((void **) &device_y, sizeof(double)*max_N) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        return;
+    }
+    if (cudaMalloc((void **) &device_z, sizeof(double)*max_N) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        cudaFree(device_y);
+        return;
+    }
+    if (cudaMalloc((void **) &device_m, sizeof(double)*max_N) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        cudaFree(device_y);
+        cudaFree(device_z);
+        return;
+    }
+    if (cudaMalloc((void **) &device_ax, sizeof(double)*N_real) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        cudaFree(device_y);
+        cudaFree(device_z);
+        cudaFree(device_m);
+        return;
+    }
+    if (cudaMalloc((void **) &device_ay, sizeof(double)*N_real) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        cudaFree(device_y);
+        cudaFree(device_z);
+        cudaFree(device_m);
+        cudaFree(device_ax);
+        return;
+    }
+    if (cudaMalloc((void **) &device_az, sizeof(double)*N_real) != cudaSuccess) {
+        printf("CUDA device malloc error\n");
+        cudaFree(device_x);
+        cudaFree(device_y);
+        cudaFree(device_z);
+        cudaFree(device_m);
+        cudaFree(device_ax);
+        cudaFree(device_ay);
+        return;
+    }
+
+    // Transfer host arrays to device
+    cudaMemcpy(device_x, host_x, sizeof(double)*max_N, cudaMemcpyHostToDevice); // TODO error check
+    cudaMemcpy(device_y, host_y, sizeof(double)*max_N, cudaMemcpyHostToDevice);
+    cudaMemcpy(device_z, host_z, sizeof(double)*max_N, cudaMemcpyHostToDevice);
+    cudaMemcpy(device_m, host_m, sizeof(double)*max_N, cudaMemcpyHostToDevice);
+
+    int threads = 128;
+    int blocks = (N_real + threads - 1) / threads;
+
+    //Launch kernel
+    gravity_basic_naive<<<blocks,threads>>>(N_real, N_active, G, softening2, gravity_ignore_terms,
+                                gb->x, gb->y, gb->z,
+                                device_x, device_y, device_z, device_m,
+                                device_ax, device_ay, device_az);
+    cudaDeviceSynchronize();
+
+    // Transfer device arrays to host
+    cudaMemcpy(host_ax, device_ax, sizeof(double)*N_real, cudaMemcpyDeviceToHost); // TODO error check
+    cudaMemcpy(host_ay, device_ay, sizeof(double)*N_real, cudaMemcpyDeviceToHost);
+    cudaMemcpy(host_az, device_az, sizeof(double)*N_real, cudaMemcpyDeviceToHost);
+
+    // Set particle result accelerations
+    for (int i=0;i<N_real;i++){
+        particles[i].ax = host_ax[i];
+        particles[i].ay = host_ay[i];
+        particles[i].az = host_az[i];
+    }
+
+    // Free host and device memory
+    free(host_x);
+    free(host_y);
+    free(host_z);
+    free(host_m);
+    free(host_ax);
+    free(host_ay);
+    free(host_az);
+    cudaFree(device_x);
+    cudaFree(device_y);
+    cudaFree(device_z);
+    cudaFree(device_m);
+    cudaFree(device_ax);
+    cudaFree(device_ay);
+    cudaFree(device_az);
+
+}

--- a/src/gravity_opt.h
+++ b/src/gravity_opt.h
@@ -1,0 +1,9 @@
+#ifndef REBOUND_SRC_GRAVITY_OPT_H
+#define REBOUND_SRC_GRAVITY_OPT_H
+
+#include "rebound.h"
+
+void launch_gravity_basic_naive(int N_real, int N_active, double G, double softening2, unsigned int gravity_ignore_terms,
+                                    reb_vec6d *gb, reb_particle *particles)
+
+#endif // REBOUND_SRC_GRAVITY_OPT_H

--- a/src/gravity_opt.h
+++ b/src/gravity_opt.h
@@ -4,6 +4,6 @@
 #include "rebound.h"
 
 void launch_gravity_basic_naive(int N_real, int N_active, double G, double softening2, unsigned int gravity_ignore_terms,
-                                    reb_vec6d *gb, reb_particle *particles)
+                                    reb_vec6d *gb, reb_particle *particles);
 
 #endif // REBOUND_SRC_GRAVITY_OPT_H


### PR DESCRIPTION
Naive implementation of CUDA kernel for REB_GRAVITY_BASIC force calculation. This is essentially a direct port of the source code into a kernel with no optimizations. This will replace the existing implementation when compiled with the `CUDA=1` make flag