### PR TITLE
TRACE WB paper Documentation

### DIFF
--- a/docs/integrators.md
+++ b/docs/integrators.md
@@ -428,7 +428,7 @@ The `reb_integrator_trace` structure contains the configuration and data structu
 
 `unsigned int coordinates`
 :   TRACE supports different coordinate systems. 
-    Default are democratic heliocentric coordinates, but wide binary coordinates ([Chambers et al 2002](https://ui.adsabs.harvard.edu/abs/2002AJ....123.2884C/abstract)) may also be used.
+    Default are democratic heliocentric coordinates, but wide binary coordinates ([Chambers et al 2002](https://ui.adsabs.harvard.edu/abs/2002AJ....123.2884C/abstract), [Lu & Brown 2026](https://ui.adsabs.harvard.edu/abs/2026arXiv260501005L/abstract)) may also be used.
     The syntax to use them is 
     
     === "C"

--- a/rebound/citations.py
+++ b/rebound/citations.py
@@ -182,6 +182,24 @@ archivePrefix = {arXiv},
        adsurl = {https://ui.adsabs.harvard.edu/abs/2024MNRAS.533.3708L},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+"""
+        if sim.ri_trace.coordinates == "widebinary":
+            txt += """Wide binary coordinates were used in the TRACE integrator \\citep{reboundtracewb}. """
+            bib += """@ARTICLE{reboundtracewb,
+      author = {{Lu}, Tiger and {Brown}, Garett},
+      title = "{A Coordinate System for Dynamical Instabilities in Hierarchical Systems in REBOUND}",
+journal = {arXiv e-prints},
+keywords = {Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Instrumentation and Methods for Astrophysics},
+      year = 2026,
+      month = may,
+      eid = {arXiv:2605.01005},
+      pages = {arXiv:2605.01005},
+      doi = {10.48550/arXiv.2605.01005},
+archivePrefix = {arXiv},
+      eprint = {2605.01005},
+primaryClass = {astro-ph.EP},
+      adsurl = {https://ui.adsabs.harvard.edu/abs/2026arXiv260501005L},
+adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 """
 


### PR DESCRIPTION
Added the TRACE WB paper to citation bot & documentation.

The documentation updates show up fine on github but not the live website for me, any idea why?