### PR TITLE
Fix: Zero-initialize particle in orbital_elements example to prevent undefined behavior

### DIFF
--- a/examples/orbital_elements/problem.c
+++ b/examples/orbital_elements/problem.c
@@ -15,7 +15,7 @@
 int main(int argc, char* argv[]){
     struct reb_simulation* r = reb_simulation_create();
     
-    struct reb_particle p; 
+    struct reb_particle p = {0}; 
     p.m      = 1.;    
     reb_simulation_add(r, p); 
 


### PR DESCRIPTION
In `examples/orbital_elements/problem.c`, `struct reb_particle p` is declared without initialization. 

While this happens to work on some systems due to zero-filled memory pages, on some machines (such as my MacBook M4) it leaves garbage values in stack memory, leading to incorrect relative orbit calculations. 

Added `= {0}` to properly zero-initialize the struct, preventing undefined behavior and matching the safe pattern used in other examples in this repository.