### PR TITLE
[Website Vulnerability] Remove polyfill.io dependency from documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -195,7 +195,6 @@ markdown_extensions:
   - wikilinks
 extra_javascript:
   - javascripts/config.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js      
 extra_css:
   - stylesheets/extra.css  


### PR DESCRIPTION
polyfill.io is a library that helps support new-browser functionality in old browsers. At least, it did, until it was bought out two years ago and is now a security vulnerability!

Line 198 in mkdocs.yml, https://polyfill.io/v3/polyfill.min.js?features=es6, was committed five years ago, before polyfill was bought out. Since then, polyfill has become obsolete for two main reasons:

1.) Modern browsers no longer need this back-compatibility plugin, and more importantly,
2.) It can now be used to inject malicious code!

Specifically, polyfill can re-direct users to malicious sites. I removed the polyfill include, built all the docs locally, went through the pages, and there was nothing broken that I could find (I am using Firefox on an Ubuntu 24.04 laptop). The original creator of polyfill strongly suggests that any and all references to it in website code be removed: https://blog.qualys.com/vulnerabilities-threat-research/2024/06/28/polyfill-io-supply-chain-attack

Unfortunately, I don't know if there are further steps that need to be taken on the maintainer end, but this at least removes the vulnerability on the site itself, with no performance impacts that I can find.