### PR TITLE
change build to use avx when available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 # All project metadata lives in pyproject.toml.
 
 from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext
 from glob import glob
 import os
 import sys
@@ -38,8 +39,23 @@ else:
 if os.environ.get("FFP_CONTRACT_OFF"):
     extra_compile_args.append("-ffp-contract=off")
 
-if os.environ.get("AVX512"):
-    extra_compile_args += ["-march=native", "-DAVX512"]
+AVX512_FILES = {"integrator_asm512.c", "integrator_whfast512.c"}
+AVX512_FLAGS = ["-DAVX512", "-mavx512f", "-mavx512dq", "-mavx512cd", "-mavx512bw", "-mavx512vl"]
+
+class build_ext_avx512(build_ext):
+    def build_extensions(self):
+        base = self.compiler._compile
+        def _compile(obj, src, ext, cc_args, postargs, pp_opts):
+            if os.path.basename(src) in AVX512_FILES:
+                postargs = postargs + AVX512_FLAGS
+            return base(obj, src, ext, cc_args, postargs, pp_opts)
+        self.compiler._compile = _compile
+        os.makedirs(self.build_temp, exist_ok=True)
+        asm = os.path.join(self.build_temp, "integrator_asm512.o")
+        self.compiler.spawn(["as", "-g", "-o", asm, "src/integrator_asm512.s"])
+        for ext in self.extensions:
+            ext.extra_objects = (ext.extra_objects or []) + [asm]
+        super().build_extensions()
 
 ##### C Extension
 libreboundmodule = Extension(
@@ -50,4 +66,4 @@ libreboundmodule = Extension(
     extra_compile_args=extra_compile_args,
 )
 
-setup(ext_modules=[libreboundmodule])
+setup(ext_modules=[libreboundmodule], cmdclass={"build_ext": build_ext_avx512})

--- a/setup.py
+++ b/setup.py
@@ -39,17 +39,8 @@ else:
 if os.environ.get("FFP_CONTRACT_OFF"):
     extra_compile_args.append("-ffp-contract=off")
 
-AVX512_FILES = {"integrator_asm512.c", "integrator_whfast512.c"}
-AVX512_FLAGS = ["-DAVX512", "-mavx512f", "-mavx512dq", "-mavx512cd", "-mavx512bw", "-mavx512vl"]
-
 class build_ext_avx512(build_ext):
     def build_extensions(self):
-        base = self.compiler._compile
-        def _compile(obj, src, ext, cc_args, postargs, pp_opts):
-            if os.path.basename(src) in AVX512_FILES:
-                postargs = postargs + AVX512_FLAGS
-            return base(obj, src, ext, cc_args, postargs, pp_opts)
-        self.compiler._compile = _compile
         os.makedirs(self.build_temp, exist_ok=True)
         asm = os.path.join(self.build_temp, "integrator_asm512.o")
         self.compiler.spawn(["as", "-g", "-o", asm, "src/integrator_asm512.s"])

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,13 +12,6 @@ ifneq ($(OS),Windows_NT)
 	@echo "Compiling source file $< ..."
 	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) -o $@ $<
 
-# build AVX512 files with AVX512 instructions
-AVX512FLAGS = -DAVX512 -mavx512f -mavx512dq -mavx512cd -mavx512bw -mavx512vl
-integrator_asm512.$(OBJFILEEXT): integrator_asm512.c $(HEADERS)
-	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) $(AVX512FLAGS) -o $@ $<
-integrator_whfast512.$(OBJFILEEXT): integrator_whfast512.c $(HEADERS)
-	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) $(AVX512FLAGS) -o $@ $<
-
 integrator_asm512.asm_o: integrator_asm512.s
 	@echo "Assembling source file integrator_asm512.s ..."
 	as -g -o $@ $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -6,11 +6,18 @@ HEADERS=$(SOURCES:.c=.h) rebound_internal.h
 
 all: $(SOURCES) $(LIBREBOUND)
 
-ifneq ($(OS),Windows_NT) 
+ifneq ($(OS),Windows_NT)
 # Linux, MacOS
 %.$(OBJFILEEXT): %.c $(HEADERS)
 	@echo "Compiling source file $< ..."
 	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) -o $@ $<
+
+# build AVX512 files with AVX512 instructions
+AVX512FLAGS = -DAVX512 -mavx512f -mavx512dq -mavx512cd -mavx512bw -mavx512vl
+integrator_asm512.$(OBJFILEEXT): integrator_asm512.c $(HEADERS)
+	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) $(AVX512FLAGS) -o $@ $<
+integrator_whfast512.$(OBJFILEEXT): integrator_whfast512.c $(HEADERS)
+	$(CC) -c $(OPT) $(OPTLIB) $(PREDEF) $(AVX512FLAGS) -o $@ $<
 
 integrator_asm512.asm_o: integrator_asm512.s
 	@echo "Assembling source file integrator_asm512.s ..."

--- a/src/Makefile.defs
+++ b/src/Makefile.defs
@@ -83,9 +83,6 @@ else
 endif
 endif
 
-ifeq ($(AVX512), 1)
-	PREDEF+= -DAVX512
-endif
 
 ifeq ($(QUADRUPOLE), 1)
 	PREDEF+= -DQUADRUPOLE

--- a/src/integrator_asm512.c
+++ b/src/integrator_asm512.c
@@ -20,10 +20,6 @@
  *
  */
 
-#ifndef AVX512
-#define AVX512
-#endif
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -31,6 +27,7 @@
 #include <string.h>
 #include <linux/perf_event.h>
 #include <asm/unistd.h>
+#include <immintrin.h>
 #include "rebound.h"
 #include "particle.h"
 #include "tools.h"
@@ -155,7 +152,6 @@ static inline void printmat8(double* a) {
     }
 }
 
-#ifdef AVX512
 // 8x8 matrix multiplication using avx512
 static inline __m512d mat8_mul_avx512(const double* matrix, const __m512d vector) {
     __m512d v_i = _mm512_set1_pd(vector[0]);
@@ -224,13 +220,11 @@ static void load_from_m512d(struct reb_simulation* r, size_t offset, const doubl
     _mm512_store_pd(tmp, tmp512);
     for (int s=0; s<N_systems; s++){
         for (unsigned int i=1; i<N_per_system; i++){
-            *(double*)((char*)(&particles[s*N_per_system+i])+offset) = tmp[s*p_per_system+i-1]; 
+            *(double*)((char*)(&particles[s*N_per_system+i])+offset) = tmp[s*p_per_system+i-1];
         }
     }
 }
-#endif
 
-                
 // Convert jacobi coordinates to inertial coordinates
 // Also performs com step (assume original particles are unmodified)
 // Note: Speed is not a concern here 
@@ -240,7 +234,6 @@ static void jacobi_to_inertial_posvel_and_com(struct reb_simulation* r, struct s
     for (unsigned s=0;s<N_systems;s++){
         com[s] = reb_simulation_com_range(r,s*N_per_system, (s+1)*N_per_system); // original com
     }
-#ifdef AVX512
     struct reb_particle* particles = r->particles;
     load_from_m512d(r, offsetof(struct reb_particle, x), data->mat8_jacobi_to_inertial, N_systems, data->x);
     load_from_m512d(r, offsetof(struct reb_particle, y), data->mat8_jacobi_to_inertial, N_systems, data->y);
@@ -272,9 +265,6 @@ static void jacobi_to_inertial_posvel_and_com(struct reb_simulation* r, struct s
             particles[s*N_per_system+i].vz += com[s].vz;
         }
     }
-#else  // AVX512
-    reb_simulation_error(r, "Fallback for Jacobi transformations in asm512 not yet implemented.");
-#endif // AVX512
 }
 
 

--- a/src/integrator_asm512.c
+++ b/src/integrator_asm512.c
@@ -20,6 +20,10 @@
  *
  */
 
+#ifndef AVX512
+#define AVX512
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stddef.h>
@@ -34,6 +38,8 @@
 #include "boundary.h"
 #include "integrator_whfast.h"
 #include "integrator_asm512.h"
+
+#pragma GCC target("avx512f,avx512dq,avx512bw,avx512cd,avx512vl")
 
 
 void reb_integrator_asm512_free(void* state);		

--- a/src/integrator_asm512.h
+++ b/src/integrator_asm512.h
@@ -24,19 +24,6 @@
 
 #include "rebound.h"
 
-#ifdef AVX512
-#include <immintrin.h>
-
-#if defined(__GNUC__) || defined(__clang__)
-#define REB_ALIGNED_64 __attribute__((aligned(64)))
-#elif defined(_MSC_VER)
-#define REB_ALIGNED_64 __declspec(align(64))
-#else
-#define REB_ALIGNED_64
-#warning "Alignment not supported on this compiler"
-#endif
-#endif // AVX512
-
 extern const struct reb_integrator reb_integrator_asm512;
 
 struct reb_integrator_asm512_state {

--- a/src/integrator_whfast512.c
+++ b/src/integrator_whfast512.c
@@ -26,6 +26,10 @@
  *
  */
 
+#ifndef AVX512
+#define AVX512
+#endif
+
 #include <string.h>
 #include "rebound.h"
 #include <math.h>
@@ -37,6 +41,8 @@
 #include "integrator_whfast.h"
 #include "integrator_whfast512.h"
 #include "binarydata.h"
+
+#pragma GCC target("avx512f,avx512dq,avx512bw,avx512cd,avx512vl")
 
 void reb_integrator_whfast512_free(void* state);		
 void* reb_integrator_whfast512_create();		

--- a/src/rebound.h
+++ b/src/rebound.h
@@ -443,6 +443,8 @@ REB_API void reb_simulation_stop_server(struct reb_simulation* r);
 
 // This function sets the integrator of the simulation to the one with the matching name. 
 REB_API void* reb_simulation_set_integrator(struct reb_simulation* r, const char* name);
+// Return 1 if the CPU supports the AVX512.
+REB_API int reb_simulation_avx512_available(void);
 // This function registers a user provided integrator with a unique name. A user provided integrator must be called before the integrator is set.
 REB_API void reb_integrator_register(const struct reb_integrator integrator, const char* name);
 

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -25,6 +25,7 @@
 #include "rebound.h"
 #include "rebound_internal.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <math.h>
 #include <string.h>
 #ifdef MPI
@@ -214,9 +215,25 @@ static void* set_integrator(struct reb_simulation* r, const char* name, struct r
 }
 
 
+// Returns 1 if this CPU can run the AVX512 asm512 integrator
+int reb_simulation_avx512_available(void){
+    if (getenv("NO_AVX512")) return 0;
+#if defined(__x86_64__) && (defined(__GNUC__) || defined(__clang__))
+    __builtin_cpu_init();
+    return __builtin_cpu_supports("avx512f") && __builtin_cpu_supports("avx512dq");
+#else
+    return 0;
+#endif
+}
+
 void* reb_simulation_set_integrator(struct reb_simulation* r, const char* name){
     if (r->integrator.name && !r->is_synchronized){
         reb_simulation_warning(r, "Changing integrators while simulation is not synchronized results in undefined behaviour.");
+    }
+    // asm512 needs AVX512
+    if (strcmp(name, "asm512")==0 && !reb_simulation_avx512_available()){
+        reb_simulation_warning(r, "asm512 requires AVX512, which this CPU does not support.");
+        return set_integrator(r, "whfast", reb_integrator_whfast);
     }
     // All built-in integrators
 #define X(iname) if (strcmp(name, #iname)==0) { return set_integrator(r, #iname, reb_integrator_##iname); }


### PR DESCRIPTION
for the build system i have pretty much tried to do a similar approach as: https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/x86/cpu.c and https://github.com/FFmpeg/FFmpeg/blob/master/libavutil/x86/float_dsp_init.c. for the python i have largely tried to take a lot from what numpy did: https://numpy.org/devdocs/building/cpu_simd.html.