### PR TITLE
add missing python code block opening tag in timestepping.md

### DIFF
--- a/docs/simulation/timestepping.md
+++ b/docs/simulation/timestepping.md
@@ -49,6 +49,7 @@ If you want to stop a current integration after the current timestep, for exampl
     reb_simulation_stop(r); 
     ```
 === "Python"
+    ```
     sim.stop()
     ```
 


### PR DESCRIPTION
I was going through the docs and noticed the `sim.stop()` code block on the timestepping page was missing its opening tag, so I fixed it while I was at it.