### PR TITLE
Wrap Omega and pomega to [0, 2pi) and include angle ranges in docs

### DIFF
--- a/docs/particles/orbitalelements.md
+++ b/docs/particles/orbitalelements.md
@@ -21,15 +21,15 @@ Variable name   | Description
 `n`             | mean motion    (negative if hyperbolic)
 `a`             | semi-major axis
 `e`             | eccentricity
-`inc`           | inclination
-`Omega`         | longitude of ascending node
-`omega`         | argument of pericenter
-`pomega`        | longitude of pericenter
-`f`             | true anomaly
-`M`             | mean anomaly
-`E`             | Eccentric anomaly. Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
-`l`             | mean longitude = Omega + omega + M
-`theta`         | true longitude = Omega + omega + f
+`inc`           | inclination, in $[0,\pi]$
+`Omega`         | longitude of ascending node, in $[0,2\pi)$
+`omega`         | argument of pericenter, in $[0,2\pi)$
+`pomega`        | longitude of pericenter, in $[0,2\pi)$
+`f`             | true anomaly, in $[0,2\pi)$
+`M`             | mean anomaly, in $[0,2\pi)$
+`E`             | Eccentric anomaly, in $[0,2\pi)$. Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
+`l`             | mean longitude = Omega + omega + M, in $[0,2\pi)$
+`theta`         | true longitude = Omega + omega + f, in $[0,2\pi)$
 `T`             | time of pericenter passage
 `rhill`         | Hill radius, $r_{\rm hill} =a\sqrt[3]{\frac{m}{3M}}$
 `pal_h`         | Cartesian component of the eccentricity, $h = e\cdot \sin(pomega)$

--- a/docs/particles/orbitalelements.md
+++ b/docs/particles/orbitalelements.md
@@ -27,7 +27,7 @@ Variable name   | Description
 `pomega`        | longitude of pericenter, in $[0,2\pi)$
 `f`             | true anomaly, in $[0,2\pi)$
 `M`             | mean anomaly, in $[0,2\pi)$
-`E`             | Eccentric anomaly, in $[0,2\pi)$. Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
+`E`             | Eccentric anomaly (elliptic; for $e<1$ in $[0,2\pi)$; for $e>1$ `reb_M_to_E` returns the hyperbolic anomaly, unbounded). Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
 `l`             | mean longitude = Omega + omega + M, in $[0,2\pi)$
 `theta`         | true longitude = Omega + omega + f, in $[0,2\pi)$
 `T`             | time of pericenter passage

--- a/examples/orbital_elements_ranges/Makefile
+++ b/examples/orbital_elements_ranges/Makefile
@@ -1,0 +1,18 @@
+export OPENGL=0
+export SERVER=0
+include ../../src/Makefile.defs
+
+.PHONY: all librebound clean
+
+all: problem.c librebound
+	$(CCPROBLEM)
+
+librebound:
+	$(MAKE) -C ../../src/
+	@-$(RM) $(LIBREBOUND)
+	@$(LINKORCOPYLIBREBOUND)
+
+clean:
+	$(MAKE) -C ../../src/ clean
+	@-$(RM) $(LIBREBOUND)
+	@-$(RM) $(EXEREBOUND)

--- a/examples/orbital_elements_ranges/problem.c
+++ b/examples/orbital_elements_ranges/problem.c
@@ -109,9 +109,9 @@ int main(void){
     // Assert expected ranges
     printf("\nAsserting expected ranges for orbital elements...\n");
     assert(ranges[INC].min >= 0. && ranges[INC].max <= pi);
-    assert(ranges[OMEGA].min > -pi && ranges[OMEGA].max <= pi);
+    assert(ranges[OMEGA].min >= 0. && ranges[OMEGA].max < pi2);
     assert(ranges[ARG_PERI].min >= 0. && ranges[ARG_PERI].max < pi2);
-    assert(ranges[POMEGA].min > -pi2 && ranges[POMEGA].max <= pi2);
+    assert(ranges[POMEGA].min >= 0. && ranges[POMEGA].max < pi2);
     assert(ranges[THETA].min >= 0. && ranges[THETA].max < pi2);
     assert(ranges[TRUE_ANOM].min >= 0. && ranges[TRUE_ANOM].max < pi2);
     assert(ranges[MEAN_ANOM].min >= 0. && ranges[MEAN_ANOM].max < pi2);

--- a/examples/orbital_elements_ranges/problem.c
+++ b/examples/orbital_elements_ranges/problem.c
@@ -1,0 +1,124 @@
+/**
+ * Check the definition ranges of the angular orbital elements.
+ */
+#include "rebound.h"
+#include <assert.h>
+#include <stdio.h>
+#include <math.h>
+
+struct angle_range {
+    double min;
+    double max;
+};
+
+enum angle_index {
+    INC,
+    OMEGA,
+    ARG_PERI,
+    POMEGA,
+    THETA,
+    TRUE_ANOM,
+    MEAN_ANOM,
+    ECC_ANOM,
+    MEAN_LONG,
+    ANGLE_COUNT
+};
+
+static void update_range(struct angle_range* range, double value){
+    if (value < range->min) range->min = value;
+    if (value > range->max) range->max = value;
+}
+
+static void update_orbit_ranges(struct angle_range* ranges, struct reb_orbit orbit){
+    update_range(&ranges[INC], orbit.inc);
+    update_range(&ranges[OMEGA], orbit.Omega);
+    update_range(&ranges[ARG_PERI], orbit.omega);
+    update_range(&ranges[POMEGA], orbit.pomega);
+    update_range(&ranges[THETA], orbit.theta);
+    update_range(&ranges[TRUE_ANOM], orbit.f);
+    update_range(&ranges[MEAN_ANOM], orbit.M);
+    update_range(&ranges[ECC_ANOM], reb_M_to_E(orbit.e, orbit.M));
+    update_range(&ranges[MEAN_LONG], orbit.l);
+}
+
+int main(void){
+    // Init range for each angle
+    struct angle_range ranges[ANGLE_COUNT];
+    for (unsigned int i = 0; i < ANGLE_COUNT; i++){
+        ranges[i].min = INFINITY;
+        ranges[i].max = -INFINITY;
+    }
+
+    // Init simulation with primary
+    struct reb_particle primary = {0};
+    primary.m = 1.;
+    struct reb_simulation* simulation = reb_simulation_create();
+    simulation->rand_seed = 0;
+
+    // Define hand-picked test cases
+    const double pi = M_PI;
+    const double pi2 = 2.*M_PI;
+    const double tol = 1.e-6;
+    const double hand_picked[][4] = {
+        {0., 0., 0., 0.},
+        {pi, pi, 0., 0.},
+        {pi/4., pi, pi, 0.},
+        {pi/4., pi - tol, pi, 0.},
+        {3.*pi/4., pi + tol, pi, 0.},
+        {pi/2., pi + tol, 0., 0.},
+        {pi/2., -pi2 + tol, -pi2 + tol, -pi2 + tol},
+        {pi/2., pi2 - tol, pi2 - tol, pi2 - tol}
+    };
+
+    // Update ranges for hand-picked test cases
+    for (unsigned int i = 0; i < sizeof(hand_picked)/sizeof(hand_picked[0]); i++){
+        struct reb_particle particle = reb_particle_from_orbit(
+            1., primary, 0., 1., 0.5,
+            hand_picked[i][0], hand_picked[i][1],
+            hand_picked[i][2], hand_picked[i][3]);
+        update_orbit_ranges(ranges, reb_orbit_from_particle(1., particle, primary));
+    }
+
+    // Update ranges for random test cases
+    const unsigned int N = 10000;
+    const double angle_min = -10.*M_PI;
+    const double angle_max = 10.*M_PI;
+    for (unsigned int i = 0; i < N; i++){
+        const double e = reb_random_uniform(simulation, 0., 0.9);
+        const double inc = reb_random_uniform(simulation, angle_min, angle_max);
+        const double Omega = reb_random_uniform(simulation, angle_min, angle_max);
+        const double omega = reb_random_uniform(simulation, angle_min, angle_max);
+        const double f = reb_random_uniform(simulation, angle_min, angle_max);
+        struct reb_particle particle = reb_particle_from_orbit(
+            1., primary, 0., 1., e, inc, Omega, omega, f);
+        update_orbit_ranges(ranges, reb_orbit_from_particle(1., particle, primary));
+    }
+
+    // Print results
+    printf("Orbital elements ranges after test cases:\n");
+    printf("inc      min=%.17g  max=%.17g\n", ranges[INC].min, ranges[INC].max);
+    printf("Omega    min=%.17g  max=%.17g\n", ranges[OMEGA].min, ranges[OMEGA].max);
+    printf("omega    min=%.17g  max=%.17g\n", ranges[ARG_PERI].min, ranges[ARG_PERI].max);
+    printf("pomega   min=%.17g  max=%.17g\n", ranges[POMEGA].min, ranges[POMEGA].max);
+    printf("theta    min=%.17g  max=%.17g\n", ranges[THETA].min, ranges[THETA].max);
+    printf("f        min=%.17g  max=%.17g\n", ranges[TRUE_ANOM].min, ranges[TRUE_ANOM].max);
+    printf("M        min=%.17g  max=%.17g\n", ranges[MEAN_ANOM].min, ranges[MEAN_ANOM].max);
+    printf("E        min=%.17g  max=%.17g\n", ranges[ECC_ANOM].min, ranges[ECC_ANOM].max);
+    printf("l        min=%.17g  max=%.17g\n", ranges[MEAN_LONG].min, ranges[MEAN_LONG].max);
+
+    // Assert expected ranges
+    printf("\nAsserting expected ranges for orbital elements...\n");
+    assert(ranges[INC].min >= 0. && ranges[INC].max <= pi);
+    assert(ranges[OMEGA].min > -pi && ranges[OMEGA].max <= pi);
+    assert(ranges[ARG_PERI].min >= 0. && ranges[ARG_PERI].max < pi2);
+    assert(ranges[POMEGA].min > -pi2 && ranges[POMEGA].max <= pi2);
+    assert(ranges[THETA].min >= 0. && ranges[THETA].max < pi2);
+    assert(ranges[TRUE_ANOM].min >= 0. && ranges[TRUE_ANOM].max < pi2);
+    assert(ranges[MEAN_ANOM].min >= 0. && ranges[MEAN_ANOM].max < pi2);
+    assert(ranges[ECC_ANOM].min >= 0. && ranges[ECC_ANOM].max < pi2);
+    assert(ranges[MEAN_LONG].min >= 0. && ranges[MEAN_LONG].max < pi2);
+
+    // End of test
+    printf("All orbital elements are within the expected ranges.\n");
+    reb_simulation_free(simulation);
+}

--- a/ipython_examples/OrbitalElements.ipynb
+++ b/ipython_examples/OrbitalElements.ipynb
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All simulations are performed in Cartesian elements, so to avoid the overhead, REBOUND does not update particles' orbital elements as the simulation progresses.  However, you can always access any orbital element through, e.g., `sim.particles[1].inc` (see the diagram, and table of orbital elements under the Orbit structure at https://rebound.hanno-rein.de/orbitalelements/).  This will calculate that orbital element individually--you can calculate all the particles' orbital elements at once with `sim.orbits()`.  REBOUND will always output angles in the range $[-\\pi,\\pi]$, except the inclination which is always in $[0,\\pi]$."
+    "All simulations are performed in Cartesian elements, so to avoid the overhead, REBOUND does not update particles' orbital elements as the simulation progresses.  However, you can always access any orbital element through, e.g., `sim.particles[1].inc` (see the diagram, and table of orbital elements under the Orbit structure at https://rebound.hanno-rein.de/orbitalelements/).  This will calculate that orbital element individually--you can calculate all the particles' orbital elements at once with `sim.orbits()`.  REBOUND will always output angles in the range $[0, 2\\pi)$, except the inclination which is always in $[0,\\pi]$."
    ]
   },
   {

--- a/src/tools.c
+++ b/src/tools.c
@@ -1188,6 +1188,8 @@ struct reb_orbit reb_orbit_from_particle_err(double G, struct reb_particle p, st
     o.T = t0 - o.M/fabs(o.n);               // time of pericenter passage (M = n(t-T).  Works for hyperbolic orbits using fabs and n as defined above).
 
     // move some of the angles into [0,2pi) range
+    o.Omega = reb_mod2pi(o.Omega);
+    o.pomega = reb_mod2pi(o.pomega);
     o.f = reb_mod2pi(o.f);
     o.l = reb_mod2pi(o.l);
     o.M = reb_mod2pi(o.M);


### PR DESCRIPTION
This pull request adjusts the definition ranges for angles for consistency. So far, the ranges were:
- $[0, \pi]$ for the inclination,
- $(-\pi, \pi]$ for the longitude of ascending node (Omega),
- $(-2\pi, 2\pi)$ for the longitude of pericenter (pomega), and
- $[0, 2\pi)$ for all other angles.

Changes made:
- Wrap Omega and pomega to $[0, 2\pi)$ in [`reb_orbit_from_particle_err`](https://github.com/hannorein/rebound/blob/main/src/tools.c#L1190) using `reb_mod2pi`.
- Update docs to explicitly state angle ranges.
- Add `examples/orbital_elements_ranges` to test for the expected ranges.

The updated ranges are now
- $[0, \pi]$ for the inclination and
- $[0, 2\pi)$ for all other angles.

The example script outputs:
```
Orbital elements ranges after test cases:
inc      min=0  max=3.1415926535897931
Omega    min=0  max=6.2831843072461604
omega    min=0  max=6.2831843072461604
pomega   min=0  max=6.2831843071351372
theta    min=0  max=6.2831843071906466
f        min=0  max=6.2831843071906466
M        min=0  max=6.2831850184275311
E        min=0  max=6.2831847296754759
l        min=0  max=6.2831850184275311

Asserting expected ranges for orbital elements...
All orbital elements are within the expected ranges.
```

See [this issue](https://github.com/hannorein/rebound/issues/927).