### PR TITLE
Move Omega and pomega to [0, 2pi) range and update docs

### DIFF
--- a/docs/particles/orbitalelements.md
+++ b/docs/particles/orbitalelements.md
@@ -21,15 +21,15 @@ Variable name   | Description
 `n`             | mean motion    (negative if hyperbolic)
 `a`             | semi-major axis
 `e`             | eccentricity
-`inc`           | inclination
-`Omega`         | longitude of ascending node
-`omega`         | argument of pericenter
-`pomega`        | longitude of pericenter
-`f`             | true anomaly
-`M`             | mean anomaly
-`E`             | Eccentric anomaly. Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
-`l`             | mean longitude = Omega + omega + M
-`theta`         | true longitude = Omega + omega + f
+`inc`           | inclination, in $[0,\pi]$
+`Omega`         | longitude of ascending node, in $[0,2\pi)$
+`omega`         | argument of pericenter, in $[0,2\pi)$
+`pomega`        | longitude of pericenter, in $[0,2\pi)$
+`f`             | true anomaly, in $[0,2\pi)$
+`M`             | mean anomaly, in $[0,2\pi)$
+`E`             | Eccentric anomaly (in $[0,2\pi)$ for $e<1$; unbounded for $e>1$). Because this requires solving Kepler's equation it is only calculated when needed in python and never calculated in C. To get the eccentric anomaly in C, use the function `double reb_M_to_E(double e, double M)`
+`l`             | mean longitude = Omega + omega + M, in $[0,2\pi)$
+`theta`         | true longitude = Omega + omega + f, in $[0,2\pi)$
 `T`             | time of pericenter passage
 `rhill`         | Hill radius, $r_{\rm hill} =a\sqrt[3]{\frac{m}{3M}}$
 `pal_h`         | Cartesian component of the eccentricity, $h = e\cdot \sin(pomega)$

--- a/ipython_examples/OrbitalElements.ipynb
+++ b/ipython_examples/OrbitalElements.ipynb
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All simulations are performed in Cartesian elements, so to avoid the overhead, REBOUND does not update particles' orbital elements as the simulation progresses.  However, you can always access any orbital element through, e.g., `sim.particles[1].inc` (see the diagram, and table of orbital elements under the Orbit structure at https://rebound.hanno-rein.de/orbitalelements/).  This will calculate that orbital element individually--you can calculate all the particles' orbital elements at once with `sim.orbits()`.  REBOUND will always output angles in the range $[-\\pi,\\pi]$, except the inclination which is always in $[0,\\pi]$."
+    "All simulations are performed in Cartesian elements, so to avoid the overhead, REBOUND does not update particles' orbital elements as the simulation progresses.  However, you can always access any orbital element through, e.g., `sim.particles[1].inc` (see the diagram, and table of orbital elements under the Orbit structure at https://rebound.hanno-rein.de/orbitalelements/).  This will calculate that orbital element individually--you can calculate all the particles' orbital elements at once with `sim.orbits()`.  REBOUND will always output angles in the range $[0, 2\\pi)$, except the inclination which is always in $[0,\\pi]$."
    ]
   },
   {

--- a/src/tools.c
+++ b/src/tools.c
@@ -1188,6 +1188,8 @@ struct reb_orbit reb_orbit_from_particle_err(double G, struct reb_particle p, st
     o.T = t0 - o.M/fabs(o.n);               // time of pericenter passage (M = n(t-T).  Works for hyperbolic orbits using fabs and n as defined above).
 
     // move some of the angles into [0,2pi) range
+    o.Omega = reb_mod2pi(o.Omega);
+    o.pomega = reb_mod2pi(o.pomega);
     o.f = reb_mod2pi(o.f);
     o.l = reb_mod2pi(o.l);
     o.M = reb_mod2pi(o.M);


### PR DESCRIPTION
This pull request adjusts the definition ranges for angles for consistency. 

Changes made:
- Wrap Omega and pomega to $[0, 2\pi)$ in [`reb_orbit_from_particle_err`](https://github.com/hannorein/rebound/blob/main/src/tools.c#L1190) using `reb_mod2pi`.
- Update docs to explicitly state angle ranges.

The updated ranges are now
- $[0, \pi]$ for the inclination and
- $[0, 2\pi)$ for all other angles.

See [this issue](https://github.com/hannorein/rebound/issues/927).