### PR TITLE
Add boundary box rgb

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -766,7 +766,24 @@ void reb_render_frame(void* p){
                     if (data->r_copy->boundary == REB_BOUNDARY_NONE){
                         glDrawArrays(GL_LINES, 0, 6);
                     }else{
-                        glDrawArrays(GL_LINES, 0, 24);
+                        // x-direction box edges
+                        glDrawArrays(GL_LINES, 0, 2);
+                        glDrawArrays(GL_LINES, 4, 2);
+                        glDrawArrays(GL_LINES, 8, 2);
+                        glDrawArrays(GL_LINES, 12, 2);
+
+                        // y-direction box edges
+                        glUniform4f(data->shader_box.color_location, 0.,1.,0.,1.);
+                        glDrawArrays(GL_LINES, 2, 2);
+                        glDrawArrays(GL_LINES, 6, 2);
+                        glDrawArrays(GL_LINES, 10, 2);
+                        glDrawArrays(GL_LINES, 14, 2);
+
+                        // z-direction box edges
+                        glUniform4f(data->shader_box.color_location, 0.,0.,1.,1.);
+                        glDrawArrays(GL_LINES, 16, 8);
+
+                        glUniform4f(data->shader_box.color_location, 1.,0.,0.,1.); // back to red
                     }
                     glBindVertexArray(0);
                 }

--- a/src/display.c
+++ b/src/display.c
@@ -764,7 +764,12 @@ void reb_render_frame(void* p){
                     glUniformMatrix4fv(data->shader_box.mvp_location, 1, GL_TRUE, (GLfloat*) mvp.m);
                     glUniform4f(data->shader_box.color_location, 1.,0.,0.,1.);
                     if (data->r_copy->boundary == REB_BOUNDARY_NONE){
-                        glDrawArrays(GL_LINES, 0, 6);
+                        glDrawArrays(GL_LINES, 0, 2); // x-direction
+                        glUniform4f(data->shader_box.color_location, 0.,1.,0.,1.);
+                        glDrawArrays(GL_LINES, 2, 2); // y-direction
+                        glUniform4f(data->shader_box.color_location, 0.,0.,1.,1.);
+                        glDrawArrays(GL_LINES, 4, 2); // z-direction
+                        glUniform4f(data->shader_box.color_location, 1.,0.,0.,1.);
                     }else{
                         // x-direction box edges
                         glDrawArrays(GL_LINES, 0, 2);


### PR DESCRIPTION
Changes made:
- Color boundary box: red for x, green for y, blue for z
(case of no boundary: center cross color remains red)

Testing:
- Built with OPENGL=1

closes #880 